### PR TITLE
chore: Rename to Major Tom + GitHub infrastructure

### DIFF
--- a/.claude/STATE.md
+++ b/.claude/STATE.md
@@ -1,0 +1,38 @@
+# Major Tom — Project State
+
+> Auto-injected at session start via UserPromptSubmit hook.
+> Update after each phase milestone.
+
+---
+
+## Current Phase
+
+**Pre-Implementation** — Planning complete, infrastructure being set up
+
+## Repo Status
+
+- Architecture & planning: Done (PLANNING.md)
+- Agent roles: Done (6 specialists in `.agents/agents/`)
+- Skills: Partial (iOS/SwiftUI/VSCode installed, more needed)
+- GitHub CI/PR workflow: Done
+- Source code: None yet
+
+## What's Next
+
+Phase 1: "Hello Claude" — Foundation + CLI Chat (v1.0)
+- Relay server scaffold (WebSocket + adapter interface)
+- CLI adapter (PTY spawn, stdin/stdout, session management)
+- Hook system (pre-tool-use, approval flow)
+- iOS app scaffold (SwiftUI shell, WebSocket client)
+- Chat UI + Approval UI
+
+## Skills Needed Before Phase 1
+
+- [ ] WebSocket server patterns (ws library)
+- [ ] node-pty usage patterns
+- [ ] Claude Code hooks reference
+- [ ] SpriteKit game dev (for Phase 3, not urgent)
+
+---
+
+_Last updated: 2026-03-15_

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,133 @@
+## Overview
+
+<!-- Brief description of what this PR accomplishes -->
+
+| Property  | Value |
+| --------- | ----- |
+| **Phase** | Phase N: "Theme Name" |
+| **Scope** | What this PR delivers |
+
+---
+
+## Labels Applied
+
+<!-- Agent: Apply these labels when creating the PR -->
+
+**Component Labels** (based on files changed):
+
+- [ ] Relay — Changes to `relay/`
+- [ ] iOS — Changes to `ios/`
+- [ ] Extension — Changes to `vscode-extension/`
+- [ ] Docs — Documentation changes
+
+**Type Labels**:
+
+- [ ] Bug Fix — For `fix/` branches
+- [ ] Breaking Change — Breaking protocol or API changes
+
+**Status Labels**:
+
+- [x] Needs Review — Agent applies on PR creation
+- [ ] Accepted — Human applies when ready to merge
+
+**Auto-Applied Labels** (by GitHub Actions CI):
+
+- Lint Failure / Type Error / Test Failure / Build Failure / CI Pass
+
+---
+
+## Changes
+
+### Added
+
+-
+
+### Changed
+
+-
+
+### Removed
+
+-
+
+---
+
+## Related Links
+
+| Resource    | Link |
+| ----------- | ---- |
+| Planning Doc | [PLANNING.md](docs/PLANNING.md) |
+| Related PRs | #XX |
+
+---
+
+## Tests
+
+| Test File | Description |
+| --------- | ----------- |
+| `path/to/test.ts` | What's tested |
+
+### Testing Instructions
+
+**Automated:**
+
+```bash
+# Relay server
+cd relay && npm test
+
+# VSCode extension
+cd vscode-extension && npm test
+```
+
+**Manual (if UI changes):**
+
+```
+1. Navigate to...
+2. Expected result:...
+```
+
+---
+
+## Screenshots
+
+<!-- If UI changes, add before/after screenshots -->
+
+| Before | After |
+| ------ | ----- |
+| N/A    | N/A   |
+
+---
+
+## Deployment Notes
+
+- [ ] No new environment variables
+- [ ] No breaking protocol changes
+- [ ] No new dependencies requiring native builds
+
+---
+
+## Checklist
+
+### Code Quality
+
+- [ ] Code follows project conventions (see CLAUDE.md)
+- [ ] No `any` types (relay/extension)
+- [ ] No force unwraps (iOS)
+- [ ] No hardcoded secrets
+- [ ] Proper error handling
+
+### Pre-merge
+
+- [ ] Branch is up to date with `main`
+- [ ] All CI checks pass
+- [ ] Self-reviewed the diff
+
+---
+
+## Notes for Reviewers
+
+<!-- Anything specific reviewers should focus on -->
+
+---
+
+<sub>Created using [PR Template](.github/PULL_REQUEST_TEMPLATE.md)</sub>

--- a/.github/instructions/ci.instructions.md
+++ b/.github/instructions/ci.instructions.md
@@ -1,0 +1,70 @@
+---
+applyTo: "**/*"
+---
+
+# CI / Pre-Push Quality Gates
+
+**MANDATORY**: Before EVERY `git commit` or `git push`, run the full CI pipeline locally and confirm all steps pass. No exceptions.
+
+## The CI Pipeline
+
+The CI pipeline mirrors `.github/workflows/ci.yml`:
+
+### Relay Server (`relay/`)
+
+```bash
+cd relay && npm run lint && npm run typecheck && npm test && npm run build
+```
+
+### VSCode Extension (`vscode-extension/`)
+
+```bash
+cd vscode-extension && npm run lint && npm run typecheck && npm run build
+```
+
+### iOS App (`ios/`)
+
+```bash
+# Build via Xcode (when project exists)
+xcodebuild build \
+  -project ios/MajorTom.xcodeproj \
+  -scheme MajorTom \
+  -destination 'platform=iOS Simulator,name=iPhone 15' \
+  -configuration Debug \
+  CODE_SIGNING_ALLOWED=NO
+```
+
+## Rules
+
+1. **Run ALL steps** before every commit and push — not just the component you changed.
+2. **Fix failures immediately** — do NOT commit or push code that fails any step.
+3. **Re-run after fixes** — a lint fix can break typecheck or tests. Always re-run from the top.
+4. **Never skip steps** — even if you think nothing changed.
+5. **Check output** — read the output. Non-zero exit = failed.
+
+## Common Pitfalls
+
+### TypeScript (Relay + Extension)
+
+- **`async` without `await`**: If a handler doesn't use `await`, don't mark it `async`.
+- **`||` vs `??`**: Use `??` for nullish coalescing.
+- **`any` types**: Never. Use `unknown` and narrow.
+- **Type-only imports**: Use `import type { Foo }` when only used as a type.
+
+### Swift (iOS)
+
+- **Force unwraps (`!`)**: Never. Use `guard let` or `if let`.
+- **`@ObservableObject`**: Never. Use `@Observable` (iOS 17+).
+- **Combine**: Never. Use async/await.
+- **UIKit**: Never (unless absolutely unavoidable). SwiftUI only.
+
+## Workflow
+
+```
+1. Make code changes
+2. Run CI for affected components
+3. ALL pass? -> git add, commit, push
+4. ANY fail? -> fix, go back to step 2
+```
+
+**NEVER push code that hasn't passed CI locally.**

--- a/.github/instructions/github.instructions.md
+++ b/.github/instructions/github.instructions.md
@@ -1,0 +1,142 @@
+---
+applyTo: "**/*"
+---
+
+# GitHub Integration
+
+## Repository Details
+
+| Property           | Value |
+| ------------------ | ----- |
+| **Owner**          | `seantokuzo` |
+| **Repo**           | `major-tom` |
+| **URL**            | https://github.com/seantokuzo/major-tom |
+| **PRs**            | https://github.com/seantokuzo/major-tom/pulls |
+| **Git Remote**     | `https://github.com/seantokuzo/major-tom.git` |
+| **Default Branch** | `main` |
+| **Username**       | `seantokuzo` |
+
+## Branch Strategy
+
+Branches follow the **phase-based** pattern from PLANNING.md:
+
+| Scope | Branch Pattern | Example |
+| ----- | -------------- | ------- |
+| **Phase work** | `phase-N/feature-name` | `phase-1/relay-scaffold` |
+| **Bug fix** | `fix/description` | `fix/websocket-reconnect` |
+| **Docs** | `docs/description` | `docs/protocol-spec` |
+
+### Commit Convention
+
+```
+type(scope): description
+```
+
+**Types**: `feat`, `fix`, `refactor`, `docs`, `test`, `chore`
+**Scopes**: `ios`, `relay`, `extension`, `docs`, `agents`
+
+Examples:
+
+```bash
+git commit -m "feat(relay): add CLI adapter PTY spawn"
+git commit -m "fix(ios): handle WebSocket disconnect gracefully"
+git commit -m "test(relay): add approval flow integration tests"
+```
+
+### PR Naming
+
+```
+Phase N: description
+```
+
+Examples:
+
+```
+Phase 1: Relay server scaffold + CLI adapter
+Phase 1: iOS app shell + WebSocket client
+```
+
+For bug fixes or non-phase work:
+
+```
+fix: WebSocket reconnect on cellular handoff
+```
+
+## PR Setup (ALL MANDATORY)
+
+When creating a PR:
+
+1. **Create PR** (not draft)
+2. **Assign `@seantokuzo`**
+3. **Apply labels**: component + type + `Needs Review`
+4. **Request Copilot review**
+5. **STOP** — wait for user response
+
+## PR Labels
+
+### Component Labels (based on files changed)
+
+| Label | When to Apply |
+| ----- | ------------- |
+| **Relay** | Changes to `relay/` |
+| **iOS** | Changes to `ios/` |
+| **Extension** | Changes to `vscode-extension/` |
+| **Docs** | Documentation changes |
+
+### Type Labels
+
+| Label | When to Apply |
+| ----- | ------------- |
+| **Bug Fix** | Fixing a bug |
+| **Breaking Change** | Breaking protocol or API changes |
+
+### Status Labels
+
+| Label | When to Apply |
+| ----- | ------------- |
+| **Needs Review** | PR ready for review (agent applies) |
+| **Accepted** | Human approved, ready to merge |
+
+### CI Labels (auto-applied by GitHub Actions)
+
+| Label | Trigger |
+| ----- | ------- |
+| **Lint Failure** | Lint job fails |
+| **Type Error** | Typecheck job fails |
+| **Test Failure** | Test job fails |
+| **Build Failure** | Build job fails |
+| **CI Pass** | All jobs pass |
+
+## PR Template
+
+**ALWAYS** use the PR template at `.github/PULL_REQUEST_TEMPLATE.md`. Fill in ALL sections.
+
+## Protected Branches
+
+- `main` — Requires PR, passing CI, 1 approval
+- Direct pushes disabled
+
+## MCP Tools for GitHub
+
+### Creating PRs
+
+```
+mcp__github__create_pull_request
+- owner: "seantokuzo"
+- repo: "major-tom"
+- title: "Phase 1: Relay server scaffold"
+- body: "## Summary\n..."
+- head: "phase-1/relay-scaffold"
+- base: "main"
+```
+
+### Reading PR Comments
+
+```bash
+# Get all review comments on a PR
+gh api repos/seantokuzo/major-tom/pulls/{number}/comments
+
+# Reply to a specific comment
+gh api repos/seantokuzo/major-tom/pulls/{number}/comments/{comment_id}/replies \
+  -f body="Fixed in abc123"
+```

--- a/.github/instructions/pr-review.instructions.md
+++ b/.github/instructions/pr-review.instructions.md
@@ -1,0 +1,110 @@
+---
+applyTo: "**/*"
+---
+
+# PR Review — Addressing Copilot Comments
+
+## Comment Categorization
+
+When Copilot reviews a PR, categorize each comment:
+
+| Category | Action | When to Use |
+| -------- | ------ | ----------- |
+| **fix-now** | Fix in current PR | Real bugs, type errors, security issues |
+| **respond** | Reply explaining why no change | Intentional design, false positives, not applicable |
+| **defer** | Acknowledge, note for later | Valid but out of scope for this PR |
+
+## Skeptical Review (CRITICAL)
+
+**You have MORE context than Copilot.** Before accepting a suggestion, ask:
+
+1. **Does this apply to our setup?** (e.g., SSR concerns in a SwiftUI app)
+2. **Is this already handled elsewhere?** (e.g., guards upstream)
+3. **Is this a real problem or theoretical?** (e.g., edge cases that can't happen)
+4. **Does the fix add complexity for marginal benefit?**
+5. **Would a human reviewer make this same comment with full project context?**
+
+### Default Posture
+
+| Suggestion Type | Default | Reasoning |
+| --------------- | ------- | --------- |
+| Actual bugs | **Fix** | Real runtime errors |
+| Security vulnerabilities | **Fix** | XSS, injection, auth bypass |
+| Type errors | **Fix** | Will break CI |
+| Memory leaks | **Fix** | Will degrade performance |
+| Platform-specific concerns | **Evaluate** | May or may not apply |
+| Over-engineering suggestions | **Respond** | Adds complexity without value |
+| Future feature requests | **Respond** | Out of scope |
+| Architecture opinions | **Respond** | Design decisions already made |
+| Valid but out of scope | **Defer** | Note for future work |
+
+## Workflow
+
+### 1. Fetch Comments
+
+```bash
+gh api repos/seantokuzo/major-tom/pulls/{number}/comments
+```
+
+### 2. Categorize
+
+Sort every comment into fix-now / respond / defer.
+
+### 3. Fix
+
+Address all fix-now items. Run CI after fixes. Commit with descriptive message.
+
+### 4. Reply to EVERY Comment
+
+Reply individually to each comment explaining what was done:
+
+```bash
+# Fixed
+gh api repos/seantokuzo/major-tom/pulls/{number}/comments/{id}/replies \
+  -f body="Fixed in commit abc1234."
+
+# Not applicable
+gh api repos/seantokuzo/major-tom/pulls/{number}/comments/{id}/replies \
+  -f body="Not applicable — this is a native iOS app using URLSessionWebSocketTask, not a browser WebSocket."
+
+# Deferred
+gh api repos/seantokuzo/major-tom/pulls/{number}/comments/{id}/replies \
+  -f body="Valid point. Noted for Phase 2 when we add retry logic."
+```
+
+### 5. Summary Comment
+
+After addressing all comments, leave a summary on the PR:
+
+```bash
+gh pr comment {number} --body "Addressed Copilot review:
+- Fixed: [list]
+- Responded: [list]
+- Deferred: [list]
+
+All CI passing."
+```
+
+## Response Templates
+
+```markdown
+# Fixed
+Fixed in commit abc1234.
+
+# Not applicable
+Not applicable — [specific reason why this doesn't apply to our architecture].
+
+# Intentional
+Intentional design decision — [reason]. See PLANNING.md [section].
+
+# Deferred
+Valid improvement. Noted for Phase N work.
+```
+
+## Key Principles
+
+- **Don't blindly fix everything** — Copilot lacks project context
+- **Always reply** — Close the loop on every comment
+- **Include commit links** — When fixing, reference the specific commit
+- **Batch fixes** — Fix all issues, run CI once, then reply to all
+- **Be specific** — "Not applicable because X" not just "Not applicable"

--- a/.github/instructions/workflow.instructions.md
+++ b/.github/instructions/workflow.instructions.md
@@ -1,0 +1,147 @@
+---
+applyTo: "**/*"
+---
+
+# Agent Workflow — GSD-Inspired
+
+Major Tom uses a **phase-based, GSD-inspired workflow**. No Jira, no sprints, no ceremonies. Phases deliver observable user capabilities.
+
+---
+
+## The Loop
+
+```
+1. PLAN PHASE (Agent) -> 2. EXECUTE PHASE (Agent) -> 3. VERIFY (Agent)
+       ^                                                      |
+6. UPDATE ROADMAP  <-  5. ADDRESS COMMENTS  <-  4. PR REVIEW
+```
+
+---
+
+## Phase-Triggered Role Loading
+
+| Trigger | Role to Load |
+| ------- | ------------ |
+| "Plan phase N", "What's next?" | `mt-orchestrator.md` + `mt-researcher.md` |
+| "Build it", "DESTROY IT!", "Execute" | `mt-orchestrator.md` → spawns specialists |
+| "Has comments", "Address feedback" | Read pr-review.instructions.md |
+| "Merged!", "Phase done" | Update PLANNING.md progress, STATE.md |
+
+---
+
+## Phase Execution (GSD Pattern)
+
+### 1. Research Phase
+
+Before implementing, the orchestrator spawns `mt-researcher.md` to:
+- Investigate APIs, libraries, capabilities
+- Verify assumptions from PLANNING.md
+- Mark confidence: HIGH (Context7), MEDIUM (official docs), LOW (web search)
+- Output prescriptive recommendations ("Use X because Y")
+
+### 2. Plan Phase
+
+The orchestrator decomposes work into **atomic tasks**:
+- Each task = one commit
+- Tasks grouped into **dependency waves**
+- Wave 1 = independent tasks (run in parallel)
+- Wave 2+ = tasks depending on Wave 1 outputs
+
+### 3. Execute Phase
+
+For each wave:
+1. **Spawn specialists** — `mt-ios-engineer.md`, `mt-relay-engineer.md`, etc.
+2. **Each specialist gets fresh context** — paths only, not content
+3. **Verify after each wave** — does it compile? does it integrate?
+4. **Commit after each task** — atomic commits
+
+### 4. Internal Review (BLOCKING)
+
+Before ANY push:
+1. Review all changed files
+2. Check protocol compliance (messages match PLANNING.md spec)
+3. Check convention compliance (CLAUDE.md rules)
+4. Fix issues, commit fixes
+5. Run CI locally
+
+### 5. PR + Copilot Review
+
+1. Push branch
+2. Create PR (not draft) with template
+3. Apply labels, assign @seantokuzo
+4. Request Copilot review
+5. **STOP — wait for user**
+
+### 6. Address Comments
+
+See `.github/instructions/pr-review.instructions.md` for the full comment-handling workflow.
+
+---
+
+## Context Management (GSD Pattern)
+
+### Thin Orchestrator
+
+The orchestrator stays LEAN:
+- Discovers work, decomposes, spawns specialists
+- Never executes heavy implementation itself
+- Stays under 50% context capacity
+- Passes **paths** to subagents, not file contents
+
+### Context Exhaustion Signals
+
+- Forgetting recent decisions
+- Repeating similar searches
+- Response quality degrading
+
+**When signals appear:** Finish current task, commit, tell user: _"Context is heavy — suggest fresh session."_
+
+### Anti-Patterns
+
+- **Analysis paralysis**: If agent reads files 5+ times without writing code → stop and report blocker
+- **Context bloat**: Never paste file contents into agent prompts
+- **Deep nesting**: Subagents never spawn sub-subagents
+
+---
+
+## Implementer Selection
+
+Before implementing ANY task, select the right specialist:
+
+| Domain | Specialist | Skills to Load |
+| ------ | ---------- | -------------- |
+| iOS / SwiftUI | `mt-ios-engineer.md` | ios-swiftui-patterns, Context7 (SwiftUI, SpriteKit) |
+| Relay / Node.js | `mt-relay-engineer.md` | Context7 (ws, node-pty, pino) |
+| VSCode Extension | `mt-extension-engineer.md` | vscode-extension-builder, Context7 (VSCode API) |
+| Sprites / SpriteKit | `mt-sprite-artist.md` | Context7 (SpriteKit) |
+| Research | `mt-researcher.md` | Context7 (any library) |
+
+---
+
+## Context7 (MANDATORY for Library Work)
+
+**NEVER trust training data for library APIs.** Always fetch current docs:
+
+```
+1. mcp__context7__resolve-library-id -> libraryName: "swiftui" | "ws" | etc.
+2. mcp__context7__query-docs -> id from step 1, topic, tokens: 10000
+```
+
+| Domain | Libraries to Fetch |
+| ------ | ------------------ |
+| iOS | SwiftUI, SpriteKit, URLSession |
+| Relay | ws, node-pty, pino |
+| Extension | vscode (extension API) |
+| Protocol | ws (shared between relay + extension) |
+
+---
+
+## Quality Gates
+
+Before marking any task complete:
+
+1. **Code compiles** — no type errors, no build failures
+2. **No regressions** — existing functionality still works
+3. **Protocol compliance** — messages match PLANNING.md spec
+4. **Convention compliance** — follows CLAUDE.md rules
+5. **Security** — no secrets in code, no sensitive data in logs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,338 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  # =============================================================================
+  # Relay Server — Lint
+  # =============================================================================
+  lint-relay:
+    name: Lint (Relay)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: relay
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: "npm"
+          cache-dependency-path: relay/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+  # =============================================================================
+  # Relay Server — Typecheck
+  # =============================================================================
+  typecheck-relay:
+    name: Typecheck (Relay)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: relay
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: "npm"
+          cache-dependency-path: relay/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Typecheck
+        run: npm run typecheck
+
+  # =============================================================================
+  # Relay Server — Tests
+  # =============================================================================
+  test-relay:
+    name: Test (Relay)
+    runs-on: ubuntu-latest
+    needs: [lint-relay, typecheck-relay]
+    defaults:
+      run:
+        working-directory: relay
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: "npm"
+          cache-dependency-path: relay/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run Tests
+        run: npm test
+        env:
+          NODE_ENV: test
+
+  # =============================================================================
+  # Relay Server — Build
+  # =============================================================================
+  build-relay:
+    name: Build (Relay)
+    runs-on: ubuntu-latest
+    needs: [lint-relay, typecheck-relay]
+    defaults:
+      run:
+        working-directory: relay
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: "npm"
+          cache-dependency-path: relay/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+  # =============================================================================
+  # VSCode Extension — Lint + Typecheck + Build
+  # =============================================================================
+  build-extension:
+    name: Build (VSCode Extension)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: vscode-extension
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: "npm"
+          cache-dependency-path: vscode-extension/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Typecheck
+        run: npm run typecheck
+
+      - name: Build
+        run: npm run build
+
+  # =============================================================================
+  # iOS — Build (requires macOS runner)
+  # NOTE: Disabled until Xcode project exists. Enable when Phase 1 starts.
+  # =============================================================================
+  # build-ios:
+  #   name: Build (iOS)
+  #   runs-on: macos-14
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #
+  #     - name: Select Xcode
+  #       run: sudo xcode-select -s /Applications/Xcode_15.2.app
+  #
+  #     - name: Build
+  #       run: |
+  #         xcodebuild build \
+  #           -project ios/MajorTom.xcodeproj \
+  #           -scheme MajorTom \
+  #           -destination 'platform=iOS Simulator,name=iPhone 15' \
+  #           -configuration Debug \
+  #           CODE_SIGNING_ALLOWED=NO
+
+  # =============================================================================
+  # Auto-Label PRs on CI Results
+  # =============================================================================
+  label-pr:
+    name: Label PR
+    runs-on: ubuntu-latest
+    needs: [lint-relay, typecheck-relay, test-relay, build-relay, build-extension]
+    if: always() && github.event_name == 'pull_request'
+    steps:
+      - name: Add Lint Failure label
+        if: needs.lint-relay.result == 'failure'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              labels: ['Lint Failure']
+            });
+
+      - name: Remove Lint Failure label on success
+        if: needs.lint-relay.result == 'success'
+        uses: actions/github-script@v7
+        continue-on-error: true
+        with:
+          script: |
+            await github.rest.issues.removeLabel({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              name: 'Lint Failure'
+            });
+
+      - name: Add Type Error label
+        if: needs.typecheck-relay.result == 'failure'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              labels: ['Type Error']
+            });
+
+      - name: Remove Type Error label on success
+        if: needs.typecheck-relay.result == 'success'
+        uses: actions/github-script@v7
+        continue-on-error: true
+        with:
+          script: |
+            await github.rest.issues.removeLabel({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              name: 'Type Error'
+            });
+
+      - name: Add Test Failure label
+        if: needs.test-relay.result == 'failure'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              labels: ['Test Failure']
+            });
+
+      - name: Remove Test Failure label on success
+        if: needs.test-relay.result == 'success'
+        uses: actions/github-script@v7
+        continue-on-error: true
+        with:
+          script: |
+            await github.rest.issues.removeLabel({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              name: 'Test Failure'
+            });
+
+      - name: Add Build Failure label
+        if: needs.build-relay.result == 'failure' || needs.build-extension.result == 'failure'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              labels: ['Build Failure']
+            });
+
+      - name: Remove Build Failure label on success
+        if: needs.build-relay.result == 'success' && needs.build-extension.result == 'success'
+        uses: actions/github-script@v7
+        continue-on-error: true
+        with:
+          script: |
+            await github.rest.issues.removeLabel({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              name: 'Build Failure'
+            });
+
+      - name: Add CI Pass label
+        if: |
+          needs.lint-relay.result == 'success' &&
+          needs.typecheck-relay.result == 'success' &&
+          needs.test-relay.result == 'success' &&
+          needs.build-relay.result == 'success' &&
+          needs.build-extension.result == 'success'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              labels: ['CI Pass']
+            });
+
+      - name: Remove CI Pass label on failure
+        if: |
+          needs.lint-relay.result == 'failure' ||
+          needs.typecheck-relay.result == 'failure' ||
+          needs.test-relay.result == 'failure' ||
+          needs.build-relay.result == 'failure' ||
+          needs.build-extension.result == 'failure'
+        uses: actions/github-script@v7
+        continue-on-error: true
+        with:
+          script: |
+            await github.rest.issues.removeLabel({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              name: 'CI Pass'
+            });
+
+  # =============================================================================
+  # Required Status Check (summary job for branch protection)
+  # =============================================================================
+  ci-success:
+    name: CI Success
+    runs-on: ubuntu-latest
+    needs: [lint-relay, typecheck-relay, test-relay, build-relay, build-extension]
+    if: always()
+    steps:
+      - name: Check all jobs passed
+        run: |
+          if [[ "${{ needs.lint-relay.result }}" != "success" ]] || \
+             [[ "${{ needs.typecheck-relay.result }}" != "success" ]] || \
+             [[ "${{ needs.test-relay.result }}" != "success" ]] || \
+             [[ "${{ needs.build-relay.result }}" != "success" ]] || \
+             [[ "${{ needs.build-extension.result }}" != "success" ]]; then
+            echo "One or more jobs failed"
+            exit 1
+          fi
+          echo "All CI checks passed!"

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # ============================================
-# Remote Pilot - .gitignore
+# Major Tom - .gitignore
 # iOS (Swift/SwiftUI) + Node.js Relay Server
 # ============================================
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,4 @@
-# Remote Pilot — Project Instructions
+# Major Tom — Project Instructions
 
 > Extends global `~/.claude/CLAUDE.md`. Project-specific rules live here.
 
@@ -6,7 +6,7 @@
 
 ## Project Overview
 
-Remote Pilot is a native iOS app for controlling Claude Code from your iPhone. It consists of three components:
+Major Tom is a native iOS app for controlling Claude Code from your iPhone. It consists of three components:
 
 1. **iOS App** (`ios/`) — SwiftUI + SpriteKit, iOS 17+
 2. **Relay Server** (`relay/`) — Node.js + TypeScript, WebSocket hub
@@ -28,7 +28,7 @@ See [docs/PLANNING.md](docs/PLANNING.md) for architecture, protocol spec, and ro
 
 ## Tech Stack & Conventions
 
-### iOS App (`ios/RemotePilot/`)
+### iOS App (`ios/MajorTom/`)
 
 | Concern | Convention |
 |---------|-----------|
@@ -108,12 +108,12 @@ Agent directives live in `.agents/agents/`:
 
 | Agent | Role | Scope |
 |-------|------|-------|
-| `rp-orchestrator.md` | Thin coordinator | Task decomposition, wave scheduling |
-| `rp-ios-engineer.md` | iOS specialist | SwiftUI, SpriteKit, iOS app code |
-| `rp-relay-engineer.md` | Backend specialist | Node.js relay server, adapters |
-| `rp-extension-engineer.md` | VSCode specialist | Companion extension |
-| `rp-sprite-artist.md` | Game/art specialist | SpriteKit scenes, sprites, animations |
-| `rp-researcher.md` | Research specialist | Context7, docs, API investigation |
+| `mt-orchestrator.md` | Thin coordinator | Task decomposition, wave scheduling |
+| `mt-ios-engineer.md` | iOS specialist | SwiftUI, SpriteKit, iOS app code |
+| `mt-relay-engineer.md` | Backend specialist | Node.js relay server, adapters |
+| `mt-extension-engineer.md` | VSCode specialist | Companion extension |
+| `mt-sprite-artist.md` | Game/art specialist | SpriteKit scenes, sprites, animations |
+| `mt-researcher.md` | Research specialist | Context7, docs, API investigation |
 
 ---
 
@@ -138,4 +138,3 @@ Before marking any task complete:
 - Don't guess package versions — always check with `npm view`
 - Don't nest subagents (orchestrator → workers, never workers → sub-workers)
 - Don't paste file contents into agent prompts (pass paths instead)
-- Don't create Atlassian/Copilot features (they're backlogged)

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# Remote Pilot
+# Major Tom
 
 > Control Claude Code from your iPhone. Watch your AI agents work in a pixel art office.
 
 ## What is this?
 
-Remote Pilot is a native iOS app that gives you **complete mobile control** over Claude Code sessions running on your Mac. Leave a CLI session running, head out the door, and keep steering from your phone.
+Major Tom is a native iOS app that gives you **complete mobile control** over Claude Code sessions running on your Mac. Leave a CLI session running, head out the door, and keep steering from your phone.
 
 **The killer feature:** When Claude Code asks "Allow tool call?", you approve it from the couch. Or the park. Or the grocery store.
 
@@ -68,14 +68,14 @@ See [docs/PLANNING.md](docs/PLANNING.md) for the full roadmap, architecture, and
 
 ```bash
 # Clone
-git clone https://github.com/seantokuzo/remote-pilot.git
-cd remote-pilot
+git clone https://github.com/seantokuzo/major-tom.git
+cd major-tom
 
 # Relay server
 cd relay && npm install && npm start
 
 # iOS app — open in Xcode
-open ios/RemotePilot.xcodeproj
+open ios/MajorTom.xcodeproj
 ```
 
 ## License

--- a/docs/PLANNING.md
+++ b/docs/PLANNING.md
@@ -1,4 +1,4 @@
-# Remote Pilot — Planning Document
+# Major Tom — Planning Document
 
 > Control Claude Code from your iPhone. Watch your AI agents work in a gamified Zelda-style office. Ship code from the couch.
 
@@ -6,7 +6,7 @@
 
 ## Vision
 
-Remote Pilot is a native iOS app that gives you **complete mobile control** over Claude Code sessions running on your Mac — both CLI sessions and the VSCode extension. When you leave your desk, your AI keeps working. You steer it from your phone.
+Major Tom is a native iOS app that gives you **complete mobile control** over Claude Code sessions running on your Mac — both CLI sessions and the VSCode extension. When you leave your desk, your AI keeps working. You steer it from your phone.
 
 **But we're not just building a remote control.** We're building a fucking beautiful, gamified visualization of your AI workforce. Think tiny Zelda-style pixel office where your Claude orchestrator and subagents are little characters — moving to their desks when you spawn them on tasks, hanging in the break room when idle, and tappable to see their thought streams in real-time.
 
@@ -160,7 +160,7 @@ Lightweight extension that provides the bridge between Claude Code's VSCode UI a
 ## Project Structure
 
 ```
-remote-pilot/
+major-tom/
 ├── CLAUDE.md                          # Project-level AI instructions
 ├── README.md
 ├── docs/
@@ -169,9 +169,9 @@ remote-pilot/
 │   └── PROTOCOL.md                    # WebSocket message protocol spec
 │
 ├── ios/                               # Xcode project
-│   └── RemotePilot/
+│   └── MajorTom/
 │       ├── App/
-│       │   └── RemotePilotApp.swift
+│       │   └── MajorTomApp.swift
 │       ├── Features/
 │       │   ├── Control/               # Chat, approvals, remote control
 │       │   │   ├── Views/
@@ -220,12 +220,12 @@ remote-pilot/
 └── .agents/                           # AI agent directives
     ├── skills/                        # Installed skills
     └── agents/                        # GSD-style agent files
-        ├── rp-orchestrator.md         # Thin orchestrator
-        ├── rp-ios-engineer.md         # iOS/SwiftUI specialist
-        ├── rp-relay-engineer.md       # Node.js relay specialist
-        ├── rp-extension-engineer.md   # VSCode extension specialist
-        ├── rp-sprite-artist.md        # SpriteKit/pixel art specialist
-        └── rp-researcher.md           # Research & Context7 specialist
+        ├── mt-orchestrator.md         # Thin orchestrator
+        ├── mt-ios-engineer.md         # iOS/SwiftUI specialist
+        ├── mt-relay-engineer.md       # Node.js relay specialist
+        ├── mt-extension-engineer.md   # VSCode extension specialist
+        ├── mt-sprite-artist.md        # SpriteKit/pixel art specialist
+        └── mt-researcher.md           # Research & Context7 specialist
 ```
 
 ---
@@ -285,8 +285,6 @@ remote-pilot/
 
 | ID | Feature | Notes |
 |----|---------|-------|
-| F-B1 | Jira Integration | Nice to have, not core to the Claude Code vision |
-| F-B2 | Confluence Integration | Same — can revisit if needed |
 | F-B3 | GitHub PR Status | Can use GitHub app directly |
 | F-B4 | CI/CD Pipeline View | Same |
 | F-B5 | Copilot Support | Legacy — only if you need it alongside Claude Code |
@@ -529,7 +527,7 @@ remote-pilot/
 
 ### Phase 5: "Everywhere" — Platform Expansion (v3.0)
 
-**Goal:** Remote Pilot on your wrist and home screen.
+**Goal:** Major Tom on your wrist and home screen.
 
 **Delivers:** Apple Watch app, Home Screen widgets
 
@@ -705,4 +703,3 @@ npx skills add https://github.com/anthropics/knowledge-work-plugins --skill road
 npx skills add https://github.com/borghei/claude-skills --skill product-manager-toolkit
 ```
 
-> Note: Atlassian skill retained but deprioritized. Jira/Confluence integration moved to backlog.

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -1,11 +1,6 @@
 {
   "version": 1,
   "skills": {
-    "atlassian-admin": {
-      "source": "alirezarezvani/claude-skills",
-      "sourceType": "github",
-      "computedHash": "009975ce9421546bc07a42538d4fdfe75eb553fcf1e564076f9b127b35a9e90b"
-    },
     "find-skills": {
       "source": "vercel-labs/skills",
       "sourceType": "github",


### PR DESCRIPTION
## Overview

| Property  | Value |
| --------- | ----- |
| **Phase** | Pre-Phase 1: Infrastructure |
| **Scope** | Rename + CI/PR/workflow infrastructure |

---

## Changes

### Added

- **CI pipeline** (`.github/workflows/ci.yml`) — Lint, typecheck, test, build for relay server + VSCode extension. iOS build ready but commented out until Xcode project exists. Auto-labels PRs on CI results. Summary gate job for branch protection.
- **PR template** (`.github/PULL_REQUEST_TEMPLATE.md`) — Phase-based, clean structure with component labels for relay/iOS/extension.
- **CI instructions** (`.github/instructions/ci.instructions.md`) — Pre-push quality gates for all 3 components.
- **GitHub instructions** (`.github/instructions/github.instructions.md`) — Branch strategy, commit convention, PR setup, label scheme.
- **PR review instructions** (`.github/instructions/pr-review.instructions.md`) — Full Copilot comment handling workflow — categorize, fix, reply individually with commit links, skeptical review posture.
- **Workflow instructions** (`.github/instructions/workflow.instructions.md`) — GSD-inspired phase workflow, context management, implementer selection, Context7 rules.
- **Session state** (`.claude/STATE.md`) — Auto-injected at session start for project context.

### Changed

- Renamed all "Remote Pilot" references to "Major Tom" across README, CLAUDE.md, PLANNING.md, .gitignore
- Renamed agent files from `rp-*.md` to `mt-*.md` (6 files)
- Updated all internal references to use `mt-` prefix

### Removed

- Jira Integration (F-B1) and Confluence Integration (F-B2) from backlog
- `atlassian-admin` skill from skills-lock.json and skill directory
- Atlassian OAuth reference from copilot-instructions
- "Don't create Atlassian features" constraint from CLAUDE.md

---

## Checklist

### Code Quality

- [x] No secrets or hardcoded URLs
- [x] All file references updated consistently

### Pre-merge

- [x] Self-reviewed the diff
- [x] All references consistent (no stray "Remote Pilot" or "rp-" anywhere)

---

## Notes for Reviewers

The CI workflow won't run yet since there's no `relay/` or `vscode-extension/` source code — it'll kick in once Phase 1 implementation starts. The iOS build job is commented out and ready to enable when the Xcode project exists.

---

<sub>Created using [PR Template](.github/PULL_REQUEST_TEMPLATE.md)</sub>