### PR TITLE
feat(ios): Pixel art sprites for all 9 Office characters

### DIFF
--- a/ios/MajorTom/Features/Office/Sprites/AgentSprite.swift
+++ b/ios/MajorTom/Features/Office/Sprites/AgentSprite.swift
@@ -48,15 +48,12 @@ final class AgentSprite: SKSpriteNode {
         statusDot.fillColor = .gray
         statusDot.strokeColor = .clear
 
-        // Use a clear base node — the pixel art child provides the visuals
-        let spriteSize: CGSize
-        if characterType == .dachshund {
-            spriteSize = CGSize(width: 44, height: 20)
-        } else if Self.dogTypes.contains(characterType) {
-            spriteSize = CGSize(width: 36, height: 24)
-        } else {
-            spriteSize = CGSize(width: 32, height: 32)
-        }
+        // Derive sprite size from pixel art's actual bounds
+        let artFrame = pixelArt.calculateAccumulatedFrame()
+        let spriteSize = CGSize(
+            width: max(artFrame.width + 4, 32),
+            height: max(artFrame.height + 4, 32)
+        )
 
         super.init(texture: nil, color: .clear, size: spriteSize)
 
@@ -67,11 +64,11 @@ final class AgentSprite: SKSpriteNode {
         pixelArt.zPosition = 0
         addChild(pixelArt)
 
-        // Position label above sprite
+        // Position label above sprite (derived from art frame)
         nameLabel.position = CGPoint(x: 0, y: spriteSize.height / 2 + 4)
         addChild(nameLabel)
 
-        // Position status dot below sprite
+        // Position status dot below sprite (derived from art frame)
         statusDot.position = CGPoint(x: 0, y: -(spriteSize.height / 2 + 6))
         addChild(statusDot)
     }

--- a/ios/MajorTom/Features/Office/Sprites/PixelArtBuilder.swift
+++ b/ios/MajorTom/Features/Office/Sprites/PixelArtBuilder.swift
@@ -57,7 +57,7 @@ enum PixelArtBuilder {
 
     // MARK: - Pixel Helpers
 
-    /// Place a single pixel at grid coordinates. (0,0) is center of the sprite.
+    /// Place a single pixel at local grid coordinates. The container is auto-centered by `build(for:)`.
     private static func pixel(
         x: Int,
         y: Int,


### PR DESCRIPTION
## Summary
- Replace colored rectangle placeholders with programmatic pixel art built from SpriteKit nodes
- New `PixelArtBuilder` enum with helper methods (`pixel`, `hRun`, `vRun`, `rect`) for composing sprites
- 9 distinct characters: Dev (hoodie + headphones), Office Worker (shirt + tie), PM (clipboard), Clown (rainbow hair + red nose), Frankenstein (green skin + bolts), Dachshund (elongated), Cattle Dog (heeler speckle), Black Schnauzer, Pepper Schnauzer
- ~40 color palette, all drawn at 2pt pixel scale
- Removed SwiftUI `Color.components` extension (no longer needed)

## Test plan
- [ ] Verify all 9 character sprites render correctly in OfficeScene
- [ ] Confirm sprites are visually distinct at small scale
- [ ] Verify existing animations (idle bob, work shake, celebrate) still work
- [ ] Confirm name labels and status dots position correctly for all sprite sizes

🤖 Generated with [Claude Code](https://claude.com/claude-code)