### PR TITLE
feat(web): service worker + push notification UI

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -8,7 +8,6 @@
       "name": "web",
       "version": "0.0.0",
       "dependencies": {
-        "@types/dompurify": "^3.0.5",
         "dompurify": "^3.3.3",
         "highlight.js": "^11.11.1",
         "marked": "^17.0.4"
@@ -16,6 +15,7 @@
       "devDependencies": {
         "@sveltejs/vite-plugin-svelte": "^7.0.0",
         "@tsconfig/svelte": "^5.0.8",
+        "@types/dompurify": "^3.0.5",
         "@types/node": "^24.12.0",
         "svelte": "^5.53.7",
         "svelte-check": "^4.4.5",
@@ -458,6 +458,7 @@
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/@types/dompurify/-/dompurify-3.0.5.tgz",
       "integrity": "sha512-1Wg0g3BtQF7sSb27fJQAKck1HECM6zV1EB66j8JH9i3LCjYabJa0FSdiSgsD5K/RbrsR0SiraKacLB+T8ZVYAg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/trusted-types": "*"
@@ -485,6 +486,7 @@
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/types": {

--- a/web/public/sw.js
+++ b/web/public/sw.js
@@ -1,0 +1,75 @@
+// Major Tom — Service Worker
+// Handles push notifications and notification click routing
+
+self.addEventListener('push', (event) => {
+  const fallback = { type: 'approval', title: 'Major Tom', body: 'Major Tom needs your attention', data: {} };
+  let data = fallback;
+
+  if (event.data) {
+    try {
+      const parsed = event.data.json();
+      data = {
+        type: parsed.type || fallback.type,
+        title: typeof parsed.title === 'string' ? parsed.title : fallback.title,
+        body: typeof parsed.body === 'string' ? parsed.body : fallback.body,
+        data: parsed.data && typeof parsed.data === 'object' ? parsed.data : fallback.data,
+      };
+    } catch {
+      // JSON parse failed — try plain text, fall back to default
+      try {
+        const text = event.data.text();
+        if (text) data = { ...fallback, body: text };
+      } catch {
+        // Use fallback as-is
+      }
+    }
+  }
+
+  const options = {
+    body: data.body,
+    icon: '/favicon.svg',
+    badge: '/favicon.svg',
+    tag: 'major-tom-approval',
+    renotify: true,
+    requireInteraction: true,
+    data: data.data || {},
+  };
+
+  event.waitUntil(self.registration.showNotification(data.title || 'Major Tom', options));
+});
+
+self.addEventListener('notificationclick', (event) => {
+  event.notification.close();
+
+  const rawUrl = event.notification.data?.url;
+  let url = typeof rawUrl === 'string' ? rawUrl : '/';
+
+  // Restrict to same-origin URLs for security
+  if (url.startsWith('/')) {
+    // Relative path — safe
+  } else {
+    try {
+      if (new URL(url).origin !== self.location.origin) {
+        url = '/';
+      }
+    } catch {
+      url = '/';
+    }
+  }
+
+  event.waitUntil(
+    clients.matchAll({ type: 'window', includeUncontrolled: true }).then((windowClients) => {
+      // Try to focus an existing window
+      for (const client of windowClients) {
+        if (new URL(client.url).origin === self.location.origin) {
+          if (url !== '/') {
+            return client.focus().then(() => client.navigate(url));
+          }
+          return client.focus();
+        }
+      }
+      // No existing window — open a new one
+      return clients.openWindow(url);
+    })
+  );
+});

--- a/web/src/App.svelte
+++ b/web/src/App.svelte
@@ -9,6 +9,8 @@
   import { relay } from './lib/stores/relay.svelte';
   import { toasts } from './lib/stores/toast.svelte';
   import { createOfficeState } from './lib/office/state.svelte';
+  import NotificationToggle from './lib/components/NotificationToggle.svelte';
+  import { resendPushSubscription } from './lib/push/push-manager';
 
   // ── Toast notifications for connection state ────────────────
 
@@ -22,6 +24,9 @@
     prevState = state;
 
     if (state === 'connected') {
+      // Re-send push subscription on every connect (relay may have restarted)
+      resendPushSubscription();
+
       if (wasReconnecting) {
         toasts.success('Reconnected to relay');
         wasReconnecting = false;
@@ -130,6 +135,8 @@
         {/if}
       </button>
     </nav>
+    <div class="header-spacer"></div>
+    <NotificationToggle />
   </header>
   <ConnectionBar />
   <ConnectionStatus />
@@ -214,6 +221,10 @@
   .tab.active {
     color: var(--text-primary);
     background: var(--surface-hover);
+  }
+
+  .header-spacer {
+    flex: 1;
   }
 
   .agent-count {

--- a/web/src/lib/components/NotificationToggle.svelte
+++ b/web/src/lib/components/NotificationToggle.svelte
@@ -1,0 +1,145 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import { initPushNotifications, unsubscribeFromPush } from '../push/push-manager';
+  import { toasts } from '../stores/toast.svelte';
+
+  let permission = $state<NotificationPermission | 'unsupported'>(
+    typeof Notification !== 'undefined' ? Notification.permission : 'unsupported',
+  );
+  let loading = $state(false);
+  let subscribed = $state(false);
+
+  // Check for existing subscription on mount (once only)
+  onMount(() => {
+    checkExistingSubscription();
+  });
+
+  async function checkExistingSubscription(): Promise<void> {
+    if (!('serviceWorker' in navigator) || !('PushManager' in window)) {
+      permission = 'unsupported';
+      return;
+    }
+    try {
+      const registration = await navigator.serviceWorker.getRegistration();
+      if (!registration) return;
+      const sub = await registration.pushManager.getSubscription();
+      subscribed = sub !== null;
+    } catch {
+      // Silently degrade
+    }
+  }
+
+  async function handleEnable(): Promise<void> {
+    loading = true;
+    try {
+      const status = await initPushNotifications();
+      permission = status.permission === 'unsupported' ? 'unsupported' : status.permission;
+      subscribed = status.subscribed;
+
+      if (status.permission === 'denied') {
+        toasts.warning('Notifications blocked — enable in browser settings');
+      } else if (status.subscribed) {
+        toasts.success('Notifications enabled');
+      } else if (status.error) {
+        toasts.error(status.error);
+      }
+    } catch {
+      toasts.error('Failed to enable notifications');
+    } finally {
+      loading = false;
+    }
+  }
+
+  async function handleDisable(): Promise<void> {
+    loading = true;
+    try {
+      const registration = await navigator.serviceWorker.getRegistration();
+      if (!registration) {
+        toasts.error('No service worker registered');
+        return;
+      }
+      const sub = await registration.pushManager.getSubscription();
+      if (sub) {
+        await unsubscribeFromPush(sub);
+      }
+      subscribed = false;
+      toasts.info('Notifications disabled');
+    } catch {
+      toasts.error('Failed to disable notifications');
+    } finally {
+      loading = false;
+    }
+  }
+</script>
+
+<div class="notification-toggle">
+  {#if permission === 'unsupported'}
+    <span class="status-text muted">Notifications not supported</span>
+  {:else if permission === 'denied'}
+    <span class="status-text blocked">Notifications blocked</span>
+    <span class="hint">Enable in browser settings</span>
+  {:else if permission === 'granted' && subscribed}
+    <span class="status-text enabled">Notifications on</span>
+    <button class="btn btn-disable" onclick={handleDisable} disabled={loading}>
+      {loading ? '...' : 'Disable'}
+    </button>
+  {:else}
+    <button class="btn btn-enable" onclick={handleEnable} disabled={loading}>
+      {loading ? 'Enabling...' : 'Enable Notifications'}
+    </button>
+  {/if}
+</div>
+
+<style>
+  .notification-toggle {
+    display: flex;
+    align-items: center;
+    gap: var(--sp-sm);
+  }
+
+  .status-text {
+    font-family: var(--font-mono);
+    font-size: 0.7rem;
+    font-weight: 500;
+  }
+
+  .status-text.enabled {
+    color: var(--allow);
+  }
+
+  .status-text.blocked {
+    color: var(--deny);
+  }
+
+  .status-text.muted {
+    color: var(--text-tertiary);
+  }
+
+  .hint {
+    font-size: 0.65rem;
+    color: var(--text-tertiary);
+  }
+
+  .btn {
+    padding: var(--sp-xs) var(--sp-md);
+    border: none;
+    border-radius: var(--r-sm);
+    font-size: 0.7rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition: opacity 0.15s;
+  }
+  .btn:hover { opacity: 0.85; }
+  .btn:disabled { opacity: 0.5; cursor: not-allowed; }
+
+  .btn-enable {
+    background: var(--accent);
+    color: #000;
+  }
+
+  .btn-disable {
+    background: var(--surface-hover);
+    color: var(--text-secondary);
+    border: 1px solid var(--border);
+  }
+</style>

--- a/web/src/lib/push/push-manager.ts
+++ b/web/src/lib/push/push-manager.ts
@@ -1,0 +1,179 @@
+// Push notification manager — handles SW registration, permission, and subscription lifecycle
+
+export interface PushStatus {
+  supported: boolean;
+  permission: NotificationPermission | 'unsupported';
+  subscribed: boolean;
+  error?: string;
+}
+
+/**
+ * Convert a URL-safe base64 string to a Uint8Array for applicationServerKey.
+ */
+function urlBase64ToUint8Array(base64String: string): Uint8Array<ArrayBuffer> {
+  const padding = '='.repeat((4 - (base64String.length % 4)) % 4);
+  const base64 = (base64String + padding).replace(/-/g, '+').replace(/_/g, '/');
+  const rawData = atob(base64);
+  const outputArray = new Uint8Array(rawData.length);
+  for (let i = 0; i < rawData.length; i++) {
+    outputArray[i] = rawData.charCodeAt(i);
+  }
+  return outputArray;
+}
+
+/**
+ * Register the service worker from /sw.js.
+ * Returns the registration, or null if unsupported.
+ */
+export async function registerServiceWorker(): Promise<ServiceWorkerRegistration | null> {
+  if (!('serviceWorker' in navigator)) return null;
+
+  try {
+    const registration = await navigator.serviceWorker.register('/sw.js');
+    return registration;
+  } catch (err) {
+    console.warn('[push] Service worker registration failed:', err);
+    return null;
+  }
+}
+
+/**
+ * Request notification permission from the user.
+ * Returns the resulting permission state.
+ */
+export async function requestNotificationPermission(): Promise<NotificationPermission> {
+  if (!('Notification' in window)) return 'denied';
+  return Notification.requestPermission();
+}
+
+/**
+ * Subscribe to push notifications using the VAPID public key from the relay server.
+ */
+export async function subscribeToPush(
+  registration: ServiceWorkerRegistration,
+): Promise<PushSubscription | null> {
+  try {
+    // Check for existing subscription first
+    const existing = await registration.pushManager.getSubscription();
+    if (existing) return existing;
+
+    // Fetch VAPID public key from relay
+    const response = await fetch('/push/vapid-key');
+    if (!response.ok) {
+      console.warn('[push] Failed to fetch VAPID key:', response.status);
+      return null;
+    }
+
+    const { publicKey } = (await response.json()) as { publicKey: string };
+    if (!publicKey) {
+      console.warn('[push] No VAPID public key returned from server');
+      return null;
+    }
+
+    const applicationServerKey = urlBase64ToUint8Array(publicKey);
+    const subscription = await registration.pushManager.subscribe({
+      userVisibleOnly: true,
+      applicationServerKey,
+    });
+
+    return subscription;
+  } catch (err) {
+    console.warn('[push] Push subscription failed:', err);
+    return null;
+  }
+}
+
+/**
+ * Send the push subscription to the relay server so it can send us notifications.
+ */
+export async function sendSubscriptionToServer(subscription: PushSubscription): Promise<boolean> {
+  try {
+    const response = await fetch('/push/subscribe', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(subscription.toJSON()),
+    });
+    return response.ok;
+  } catch (err) {
+    console.warn('[push] Failed to send subscription to server:', err);
+    return false;
+  }
+}
+
+/**
+ * Unsubscribe from push notifications — both locally and on the server.
+ */
+export async function unsubscribeFromPush(subscription: PushSubscription): Promise<boolean> {
+  try {
+    // Notify server
+    await fetch('/push/unsubscribe', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(subscription.toJSON()),
+    }).catch(() => {
+      // Server might be down — still unsubscribe locally
+    });
+
+    // Unsubscribe locally
+    return await subscription.unsubscribe();
+  } catch (err) {
+    console.warn('[push] Failed to unsubscribe:', err);
+    return false;
+  }
+}
+
+/**
+ * Full initialization flow: register SW → check permission → subscribe → send to server.
+ * Call this when the user explicitly enables notifications.
+ */
+export async function initPushNotifications(): Promise<PushStatus> {
+  // Check support
+  if (!('serviceWorker' in navigator) || !('PushManager' in window) || !('Notification' in window)) {
+    return { supported: false, permission: 'unsupported', subscribed: false };
+  }
+
+  // Register SW
+  const registration = await registerServiceWorker();
+  if (!registration) {
+    return { supported: true, permission: Notification.permission, subscribed: false, error: 'Service worker registration failed' };
+  }
+
+  // Request permission
+  const permission = await requestNotificationPermission();
+  if (permission !== 'granted') {
+    return { supported: true, permission, subscribed: false };
+  }
+
+  // Subscribe to push
+  const subscription = await subscribeToPush(registration);
+  if (!subscription) {
+    return { supported: true, permission, subscribed: false, error: 'Push subscription failed' };
+  }
+
+  // Send to server
+  const sent = await sendSubscriptionToServer(subscription);
+  if (!sent) {
+    return { supported: true, permission, subscribed: false, error: 'Failed to register with server' };
+  }
+
+  return { supported: true, permission, subscribed: true };
+}
+
+/**
+ * Re-send the existing push subscription to the relay server.
+ * Useful after WebSocket reconnect when the relay may have restarted.
+ */
+export async function resendPushSubscription(): Promise<void> {
+  if (!('serviceWorker' in navigator) || !('PushManager' in window)) return;
+
+  try {
+    const registration = await navigator.serviceWorker.getRegistration();
+    if (!registration) return;
+    const subscription = await registration.pushManager.getSubscription();
+    if (subscription) {
+      await sendSubscriptionToServer(subscription);
+    }
+  } catch (err) {
+    console.warn('[push] Failed to re-send push subscription:', err);
+  }
+}

--- a/web/src/main.ts
+++ b/web/src/main.ts
@@ -1,9 +1,15 @@
 import { mount } from 'svelte'
 import './lib/theme/theme.css'
 import App from './App.svelte'
+import { registerServiceWorker } from './lib/push/push-manager'
 
 const app = mount(App, {
   target: document.getElementById('app')!,
 })
+
+// Register service worker on load (doesn't request notification permission — that needs user gesture)
+if (import.meta.env.PROD) {
+  registerServiceWorker()
+}
 
 export default app


### PR DESCRIPTION
## Summary
- Service worker (`sw.js`) handles push events and notification clicks with payload validation
- Push manager module orchestrates: SW registration, permission request, push subscribe, server sync
- `NotificationToggle` component for enabling/disabling notifications in the UI
- Auto re-sends push subscription to relay on every WebSocket reconnect (handles relay restarts)

## Details
- `web/public/sw.js` — Push event handler with defensive JSON parsing, notification click with focus/navigate logic, tag-based dedup (`requireInteraction: true` for approvals)
- `web/src/lib/push/push-manager.ts` — Full push lifecycle management, VAPID key fetch, reconnect re-subscription
- `web/src/lib/components/NotificationToggle.svelte` — Three-state UI (default/granted/denied), uses `onMount` for one-time check, toast feedback
- `web/src/App.svelte` — Toggle in header, `resendPushSubscription()` on connect
- `web/src/main.ts` — SW registration on app load (no auto-permission prompt)

## Dependencies
- Requires relay push endpoints (merge relay PR first)

## Test plan
- [ ] App loads, SW registers (check DevTools, Application, Service Workers)
- [ ] Click Enable Notifications, browser permission prompt appears
- [ ] Grant permission, subscription sent to relay `/push/subscribe`
- [ ] Trigger approval request, native OS notification appears
- [ ] Click notification, app focuses and navigates to approval
- [ ] Reload app, notification state persists (shows Notifications on)
- [ ] Disconnect/reconnect WebSocket, subscription re-sent to relay
- [ ] Deny permission, shows Notifications blocked hint
- [ ] `npm run build` succeeds, `svelte-check` passes

:robot: Generated with [Claude Code](https://claude.com/claude-code)
