### PR TITLE
feat(web): prompt templates — save/search/reuse

### DIFF
--- a/web/src/lib/components/ChatView.svelte
+++ b/web/src/lib/components/ChatView.svelte
@@ -163,8 +163,8 @@
     onOpenTemplates={handleOpenTemplates}
     onOpenSaveTemplate={handleOpenSaveTemplate}
   />
-  <TemplateDrawer bind:open={templateDrawerOpen} onclose={handleTemplateDrawerClose} />
-  <TemplateSaveDialog bind:open={templateSaveOpen} onclose={handleTemplateSaveClose} initialContent={saveDialogContent} />
+  <TemplateDrawer bind:open={templateDrawerOpen} onClose={handleTemplateDrawerClose} />
+  <TemplateSaveDialog bind:open={templateSaveOpen} onClose={handleTemplateSaveClose} initialContent={saveDialogContent} />
 </div>
 
 <style>

--- a/web/src/lib/components/CommandPalette.svelte
+++ b/web/src/lib/components/CommandPalette.svelte
@@ -3,6 +3,7 @@
   import { templates } from '../stores/templates.svelte';
 
   interface Command {
+    key: string;
     name: string;
     description: string;
     action: () => void;
@@ -26,6 +27,7 @@
 
   const commands: Command[] = [
     {
+      key: '/new',
       name: '/new',
       description: 'Start a fresh session',
       action: () => {
@@ -34,6 +36,7 @@
       },
     },
     {
+      key: '/clear',
       name: '/clear',
       description: 'Clear chat display (keep session)',
       action: () => {
@@ -42,6 +45,7 @@
       },
     },
     {
+      key: '/plan',
       name: '/plan',
       description: 'Enter plan mode',
       action: () => {
@@ -50,6 +54,7 @@
       },
     },
     {
+      key: '/compact',
       name: '/compact',
       description: 'Compact context window',
       action: () => {
@@ -58,6 +63,7 @@
       },
     },
     {
+      key: '/model sonnet',
       name: '/model sonnet',
       description: 'Switch to Sonnet',
       action: () => {
@@ -66,6 +72,7 @@
       },
     },
     {
+      key: '/model opus',
       name: '/model opus',
       description: 'Switch to Opus',
       action: () => {
@@ -74,6 +81,7 @@
       },
     },
     {
+      key: '/model haiku',
       name: '/model haiku',
       description: 'Switch to Haiku',
       action: () => {
@@ -82,6 +90,7 @@
       },
     },
     {
+      key: '/btw',
       name: '/btw',
       description: 'Quick side-question (won\'t derail Claude)',
       action: () => {
@@ -91,6 +100,7 @@
       },
     },
     {
+      key: '/save',
       name: '/save',
       description: 'Save current input as a template',
       action: () => {
@@ -99,6 +109,7 @@
       },
     },
     {
+      key: '/templates',
       name: '/templates',
       description: 'Browse saved prompt templates',
       action: () => {
@@ -134,6 +145,7 @@
       const matchingTemplates = templates.search(query).slice(0, 5);
       for (const tpl of matchingTemplates) {
         sorted.push({
+          key: `tpl-${tpl.id}`,
           name: `# ${tpl.name}`,
           description: tpl.content.length > 50 ? tpl.content.slice(0, 50) + '...' : tpl.content,
           action: () => {
@@ -225,7 +237,7 @@
         />
       </div>
       <div class="palette-list">
-        {#each filteredCommands as cmd, i (cmd.name)}
+        {#each filteredCommands as cmd, i (cmd.key)}
           <button
             class="palette-item"
             class:selected={i === selectedIndex}

--- a/web/src/lib/components/TemplateDrawer.svelte
+++ b/web/src/lib/components/TemplateDrawer.svelte
@@ -5,10 +5,10 @@
 
   let {
     open = $bindable(false),
-    onclose,
+    onClose,
   }: {
     open: boolean;
-    onclose: () => void;
+    onClose: () => void;
   } = $props();
 
   let searchQuery = $state('');
@@ -50,7 +50,7 @@
 
   function close() {
     open = false;
-    onclose();
+    onClose();
   }
 
   function handleKeydown(e: KeyboardEvent) {

--- a/web/src/lib/components/TemplateSaveDialog.svelte
+++ b/web/src/lib/components/TemplateSaveDialog.svelte
@@ -4,11 +4,11 @@
 
   let {
     open = $bindable(false),
-    onclose,
+    onClose,
     initialContent = '',
   }: {
     open: boolean;
-    onclose: () => void;
+    onClose: () => void;
     initialContent: string;
   } = $props();
 
@@ -56,7 +56,7 @@
 
   function close() {
     open = false;
-    onclose();
+    onClose();
   }
 
   function handleKeydown(e: KeyboardEvent) {

--- a/web/src/lib/stores/templates.svelte.ts
+++ b/web/src/lib/stores/templates.svelte.ts
@@ -61,15 +61,21 @@ class TemplateStore {
                 typeof (entry as Record<string, unknown>).name === 'string' &&
                 typeof (entry as Record<string, unknown>).content === 'string'
             )
-            .map((entry) => ({
-              id: typeof entry.id === 'string' ? entry.id : uid(),
-              name: entry.name as string,
-              content: entry.content as string,
-              category: typeof entry.category === 'string' ? entry.category : undefined,
-              usageCount: typeof entry.usageCount === 'number' ? entry.usageCount : 0,
-              createdAt: typeof entry.createdAt === 'string' ? entry.createdAt : now,
-              updatedAt: typeof entry.updatedAt === 'string' ? entry.updatedAt : now,
-            }))
+            .map((entry) => {
+              const id = typeof entry.id === 'string' && entry.id ? entry.id : uid();
+              const cat = typeof entry.category === 'string' ? entry.category.trim() : '';
+              const rawCount = typeof entry.usageCount === 'number' ? entry.usageCount : 0;
+              const usageCount = Number.isFinite(rawCount) && rawCount >= 0 ? rawCount : 0;
+              return {
+                id,
+                name: entry.name as string,
+                content: entry.content as string,
+                category: cat || undefined,
+                usageCount,
+                createdAt: typeof entry.createdAt === 'string' ? entry.createdAt : now,
+                updatedAt: typeof entry.updatedAt === 'string' ? entry.updatedAt : now,
+              };
+            })
             .slice(0, MAX_TEMPLATES);
         }
       }


### PR DESCRIPTION
## Summary
- New `templates.svelte.ts` store — CRUD, search, usage tracking, localStorage persistence (`mt-prompt-templates`)
- New `TemplateDrawer.svelte` — bottom slide-up drawer with search, category badges, tap-to-insert
- New `TemplateSaveDialog.svelte` — modal to save current input as named template with category
- Command palette: `/save` and `/templates` commands, dynamic template matching in search
- Template button (star icon) in input bar

## Phase 5 — Track A: Prompt Power-Ups (A2)

Max 100 templates, sorted by usage count. No protocol changes.

## Test plan
- [ ] Type prompt, use `/save` or star button to save as template
- [ ] Open `/templates` drawer, verify template appears with category badge
- [ ] Tap template to insert into input, verify content fills textarea
- [ ] Search templates by name/content in drawer
- [ ] Type in command palette, verify matching templates appear
- [ ] Delete a template via two-tap confirmation
- [ ] Refresh page, verify templates persist from localStorage

🤖 Generated with [Claude Code](https://claude.com/claude-code)