### PR TITLE
feat(ios): Wave 2 — Chat polish

### DIFF
--- a/ios/MajorTom.xcodeproj/project.pbxproj
+++ b/ios/MajorTom.xcodeproj/project.pbxproj
@@ -18,13 +18,17 @@
 		47EC9244ECBFED3B28C37DBA /* AgentState.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3C4E64AF88E24ABC75AB59E /* AgentState.swift */; };
 		4F564AFF2C107C396235D252 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21F681FC6A3D7B14792DDC15 /* SettingsView.swift */; };
 		50BB1C73D342CB99FCFD747C /* ConnectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2E379544E5140C04B00F724 /* ConnectionView.swift */; };
+		51B910C9CC6764F080BE47A5 /* StreamingIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B67F68CAC7F1FF23E1890F69 /* StreamingIndicator.swift */; };
 		54DF40806CDE825D4201BB6B /* ApprovalCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AC497E5E769C0087E856232 /* ApprovalCard.swift */; };
 		6842CC155924DD2F8E828C18 /* WebSocketClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = C13191C0A248C84CA6959981 /* WebSocketClient.swift */; };
 		6C1C58D6705B5201DC10755F /* ChatView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6657773292DC21D71241871E /* ChatView.swift */; };
+		6E2A37930D558EB0D0811007 /* ToolMessageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC0B8C7069C99E830703066D /* ToolMessageView.swift */; };
 		6E4EDEA7EBF6C0B069F3654C /* OfficeScene.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7643A52E74C92A59EFA82ED7 /* OfficeScene.swift */; };
 		818FA51F81C18CFE08B3C097 /* PairingViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 526DF9EAD13F47F747C7ACC3 /* PairingViewModel.swift */; };
 		8294293F9EF30CBEED38BFC6 /* HapticService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7794C5813F5964F288D432AD /* HapticService.swift */; };
+		85574E49192424FB81A91CA9 /* MarkdownText.swift in Sources */ = {isa = PBXBuildFile; fileRef = D91A9F673395FFFDE1E3A220 /* MarkdownText.swift */; };
 		8AD9CF79749CD5BE5EF22487 /* AgentInspectorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A6B155FB1E10E586EFA12AC /* AgentInspectorView.swift */; };
+		91A9EFC3F37C8C38BCA1CABE /* TurnSeparator.swift in Sources */ = {isa = PBXBuildFile; fileRef = A81796AAA2EEAB4F3C12EF5C /* TurnSeparator.swift */; };
 		924AA688A4D5BF0B708C40A4 /* ApprovalView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B99FD8B1AB490C5124F962DC /* ApprovalView.swift */; };
 		926D953D313C1AF78A9041EE /* MessageBubble.swift in Sources */ = {isa = PBXBuildFile; fileRef = E659E1885E32B1187E8C3703 /* MessageBubble.swift */; };
 		9F2F95450060416CA67BA3FB /* OfficeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD500881DC6249D63A9E0ACA /* OfficeView.swift */; };
@@ -36,6 +40,8 @@
 		C9BB54E28A623F2765BB3A95 /* SettingsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A981C64512EE7700D1A27BAB /* SettingsViewModel.swift */; };
 		C9D6EF3F81D2EB74C1C3C741 /* ConnectionViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4862EDC8F8386FEB727657BF /* ConnectionViewModel.swift */; };
 		CFCBB89895F30259222DD268 /* ChatViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FA484DB960E122B25A8773F /* ChatViewModel.swift */; };
+		D2AA323DD9F0C43560F0DA89 /* CostBadge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F00E9E962D46250F2E6B5FB /* CostBadge.swift */; };
+		D919E02E075F0907DC4F66E0 /* CodeBlockView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E95A53D48D5BEC57C156BCD9 /* CodeBlockView.swift */; };
 		DEC7A03BAD629CB026FDD77F /* DeviceManagementView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B2D2956D7BBBE520D548CED /* DeviceManagementView.swift */; };
 		E4C11D19C5CBC7B5653532FD /* Theme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 345B4AA475B96036D85853BA /* Theme.swift */; };
 		ECD4CC99C031E1B803D88C76 /* Session.swift in Sources */ = {isa = PBXBuildFile; fileRef = 591E0D4455AD31B2BBD8761C /* Session.swift */; };
@@ -46,6 +52,7 @@
 /* Begin PBXFileReference section */
 		2155A4D6123944C4CDE2BEE8 /* MajorTom.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = MajorTom.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		21F681FC6A3D7B14792DDC15 /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
+		2F00E9E962D46250F2E6B5FB /* CostBadge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CostBadge.swift; sourceTree = "<group>"; };
 		345B4AA475B96036D85853BA /* Theme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Theme.swift; sourceTree = "<group>"; };
 		3AC497E5E769C0087E856232 /* ApprovalCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApprovalCard.swift; sourceTree = "<group>"; };
 		4862EDC8F8386FEB727657BF /* ConnectionViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectionViewModel.swift; sourceTree = "<group>"; };
@@ -69,15 +76,20 @@
 		8FEBD49051DFF465363BBE2B /* Message.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Message.swift; sourceTree = "<group>"; };
 		944EEB19C6C12FD8F9F43846 /* STATUS.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = STATUS.md; sourceTree = "<group>"; };
 		A2873A7A68C25BFA4E7C9756 /* AuthService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthService.swift; sourceTree = "<group>"; };
+		A81796AAA2EEAB4F3C12EF5C /* TurnSeparator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TurnSeparator.swift; sourceTree = "<group>"; };
 		A981C64512EE7700D1A27BAB /* SettingsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsViewModel.swift; sourceTree = "<group>"; };
 		A9BD8A95DFAD6160FF41E83F /* KeychainService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainService.swift; sourceTree = "<group>"; };
 		B2A5F6ECD6AEA9681C140DA3 /* OfficeLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OfficeLayout.swift; sourceTree = "<group>"; };
+		B67F68CAC7F1FF23E1890F69 /* StreamingIndicator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StreamingIndicator.swift; sourceTree = "<group>"; };
 		B99FD8B1AB490C5124F962DC /* ApprovalView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApprovalView.swift; sourceTree = "<group>"; };
+		BC0B8C7069C99E830703066D /* ToolMessageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolMessageView.swift; sourceTree = "<group>"; };
 		BD500881DC6249D63A9E0ACA /* OfficeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OfficeView.swift; sourceTree = "<group>"; };
 		C13191C0A248C84CA6959981 /* WebSocketClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebSocketClient.swift; sourceTree = "<group>"; };
 		C3C4E64AF88E24ABC75AB59E /* AgentState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentState.swift; sourceTree = "<group>"; };
 		CC19E99FB3AAD181F192CD3B /* MessageCodec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageCodec.swift; sourceTree = "<group>"; };
+		D91A9F673395FFFDE1E3A220 /* MarkdownText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownText.swift; sourceTree = "<group>"; };
 		E659E1885E32B1187E8C3703 /* MessageBubble.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageBubble.swift; sourceTree = "<group>"; };
+		E95A53D48D5BEC57C156BCD9 /* CodeBlockView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeBlockView.swift; sourceTree = "<group>"; };
 		F2E379544E5140C04B00F724 /* ConnectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectionView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -279,7 +291,6 @@
 		B785C26F2874B8A4F530FD1D /* Settings */ = {
 			isa = PBXGroup;
 			children = (
-				F4CC29694F42E4B5FD57C761 /* Components */,
 				D28A628DB467A01A77C6F494 /* ViewModels */,
 				DE1EBD87DDB29A1DB6A9A638 /* Views */,
 			);
@@ -307,8 +318,14 @@
 			isa = PBXGroup;
 			children = (
 				3AC497E5E769C0087E856232 /* ApprovalCard.swift */,
+				E95A53D48D5BEC57C156BCD9 /* CodeBlockView.swift */,
+				2F00E9E962D46250F2E6B5FB /* CostBadge.swift */,
+				D91A9F673395FFFDE1E3A220 /* MarkdownText.swift */,
 				E659E1885E32B1187E8C3703 /* MessageBubble.swift */,
+				B67F68CAC7F1FF23E1890F69 /* StreamingIndicator.swift */,
 				73D57C1446E7A203616CCE20 /* StreamingText.swift */,
+				BC0B8C7069C99E830703066D /* ToolMessageView.swift */,
+				A81796AAA2EEAB4F3C12EF5C /* TurnSeparator.swift */,
 			);
 			path = Components;
 			sourceTree = "<group>";
@@ -346,13 +363,6 @@
 				591E0D4455AD31B2BBD8761C /* Session.swift */,
 			);
 			path = Models;
-			sourceTree = "<group>";
-		};
-		F4CC29694F42E4B5FD57C761 /* Components */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			path = Components;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -436,12 +446,15 @@
 				BD4DE18F7D89A6E7BE778875 /* CharacterConfig.swift in Sources */,
 				6C1C58D6705B5201DC10755F /* ChatView.swift in Sources */,
 				CFCBB89895F30259222DD268 /* ChatViewModel.swift in Sources */,
+				D919E02E075F0907DC4F66E0 /* CodeBlockView.swift in Sources */,
 				50BB1C73D342CB99FCFD747C /* ConnectionView.swift in Sources */,
 				C9D6EF3F81D2EB74C1C3C741 /* ConnectionViewModel.swift in Sources */,
+				D2AA323DD9F0C43560F0DA89 /* CostBadge.swift in Sources */,
 				DEC7A03BAD629CB026FDD77F /* DeviceManagementView.swift in Sources */,
 				8294293F9EF30CBEED38BFC6 /* HapticService.swift in Sources */,
 				36B33910C927C9BBAC0813A7 /* KeychainService.swift in Sources */,
 				BF6D1C0B63D35D14E62F514B /* MajorTomApp.swift in Sources */,
+				85574E49192424FB81A91CA9 /* MarkdownText.swift in Sources */,
 				AECFF1EF021E81589ADBC052 /* Message.swift in Sources */,
 				926D953D313C1AF78A9041EE /* MessageBubble.swift in Sources */,
 				43FBF1E65395F38364EDB020 /* MessageCodec.swift in Sources */,
@@ -456,8 +469,11 @@
 				ECD4CC99C031E1B803D88C76 /* Session.swift in Sources */,
 				4F564AFF2C107C396235D252 /* SettingsView.swift in Sources */,
 				C9BB54E28A623F2765BB3A95 /* SettingsViewModel.swift in Sources */,
+				51B910C9CC6764F080BE47A5 /* StreamingIndicator.swift in Sources */,
 				FFB20C4BF1BD6D83D3404F2B /* StreamingText.swift in Sources */,
 				E4C11D19C5CBC7B5653532FD /* Theme.swift in Sources */,
+				6E2A37930D558EB0D0811007 /* ToolMessageView.swift in Sources */,
+				91A9EFC3F37C8C38BCA1CABE /* TurnSeparator.swift in Sources */,
 				6842CC155924DD2F8E828C18 /* WebSocketClient.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/ios/MajorTom/Features/Control/Components/CodeBlockView.swift
+++ b/ios/MajorTom/Features/Control/Components/CodeBlockView.swift
@@ -1,0 +1,186 @@
+import SwiftUI
+import UIKit
+
+struct CodeBlockView: View {
+    let code: String
+    let language: String
+    @State private var copied = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            // Header: language label + copy button
+            header
+
+            // Code content
+            codeContent
+        }
+        .clipShape(RoundedRectangle(cornerRadius: MajorTomTheme.Radius.small))
+    }
+
+    // MARK: - Header
+
+    private var header: some View {
+        HStack {
+            Text(language.isEmpty ? "code" : language.lowercased())
+                .font(MajorTomTheme.Typography.codeFontSmall)
+                .foregroundStyle(MajorTomTheme.Colors.textTertiary)
+
+            Spacer()
+
+            Button {
+                UIPasteboard.general.string = code
+                HapticService.buttonTap()
+                copied = true
+                Task {
+                    try? await Task.sleep(for: .seconds(2))
+                    copied = false
+                }
+            } label: {
+                HStack(spacing: MajorTomTheme.Spacing.xs) {
+                    Image(systemName: copied ? "checkmark" : "doc.on.doc")
+                        .font(.caption2)
+                    Text(copied ? "Copied" : "Copy")
+                        .font(MajorTomTheme.Typography.codeFontSmall)
+                }
+                .foregroundStyle(copied ? MajorTomTheme.Colors.allow : MajorTomTheme.Colors.textTertiary)
+            }
+        }
+        .padding(.horizontal, MajorTomTheme.Spacing.md)
+        .padding(.vertical, MajorTomTheme.Spacing.sm)
+        .background(Color(white: 0.08))
+    }
+
+    // MARK: - Code Content
+
+    private var codeContent: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            Text(highlightedCode)
+                .font(MajorTomTheme.Typography.codeFont)
+                .textSelection(.enabled)
+                .padding(MajorTomTheme.Spacing.md)
+        }
+        .background(Color(white: 0.05))
+    }
+
+    // MARK: - Simple Keyword Highlighting
+
+    private var highlightedCode: AttributedString {
+        var result = AttributedString(code)
+        result.foregroundColor = UIColor(MajorTomTheme.Colors.textPrimary)
+
+        let keywords = languageKeywords
+        let stringPatterns = [
+            ("\"", "\""),
+            ("'", "'"),
+            ("`", "`"),
+        ]
+
+        // Highlight keywords
+        for keyword in keywords {
+            highlightPattern(
+                in: &result,
+                pattern: "\\b\(keyword)\\b",
+                color: UIColor(MajorTomTheme.Colors.accent)
+            )
+        }
+
+        // Highlight strings
+        for (open, close) in stringPatterns {
+            let escaped = NSRegularExpression.escapedPattern(for: open)
+            let escapedClose = NSRegularExpression.escapedPattern(for: close)
+            highlightPattern(
+                in: &result,
+                pattern: "\(escaped)[^\(escapedClose)]*\(escapedClose)",
+                color: UIColor(red: 0.55, green: 0.85, blue: 0.55, alpha: 1)
+            )
+        }
+
+        // Highlight comments (// and #)
+        highlightPattern(
+            in: &result,
+            pattern: "(?://|#).*$",
+            color: UIColor(MajorTomTheme.Colors.textTertiary),
+            multiline: true
+        )
+
+        // Highlight numbers
+        highlightPattern(
+            in: &result,
+            pattern: "\\b\\d+(?:\\.\\d+)?\\b",
+            color: UIColor(red: 0.70, green: 0.55, blue: 0.95, alpha: 1)
+        )
+
+        return result
+    }
+
+    private func highlightPattern(
+        in attributed: inout AttributedString,
+        pattern: String,
+        color: UIColor,
+        multiline: Bool = false
+    ) {
+        var options: NSRegularExpression.Options = []
+        if multiline { options.insert(.anchorsMatchLines) }
+
+        guard let regex = try? NSRegularExpression(pattern: pattern, options: options) else { return }
+        let nsString = String(attributed.characters) as NSString
+        let matches = regex.matches(in: String(attributed.characters), range: NSRange(location: 0, length: nsString.length))
+
+        for match in matches {
+            guard let range = Range(match.range, in: attributed) else { continue }
+            attributed[range].foregroundColor = color
+        }
+    }
+
+    private var languageKeywords: [String] {
+        switch language.lowercased() {
+        case "swift":
+            return ["func", "var", "let", "if", "else", "guard", "return", "import", "struct", "class", "enum", "protocol", "extension", "self", "Self", "nil", "true", "false", "async", "await", "throws", "throw", "try", "catch", "for", "while", "switch", "case", "default", "break", "continue", "where", "in", "private", "public", "internal", "static", "override", "final", "init", "deinit", "some", "any"]
+        case "typescript", "ts", "javascript", "js":
+            return ["function", "const", "let", "var", "if", "else", "return", "import", "export", "from", "class", "interface", "type", "enum", "async", "await", "throw", "try", "catch", "for", "while", "switch", "case", "default", "break", "continue", "new", "this", "super", "extends", "implements", "true", "false", "null", "undefined", "typeof", "instanceof"]
+        case "python", "py":
+            return ["def", "class", "if", "elif", "else", "return", "import", "from", "as", "for", "while", "with", "try", "except", "raise", "pass", "break", "continue", "and", "or", "not", "in", "is", "None", "True", "False", "self", "lambda", "yield", "async", "await"]
+        case "bash", "sh", "zsh":
+            return ["if", "then", "else", "elif", "fi", "for", "while", "do", "done", "case", "esac", "function", "return", "export", "local", "readonly", "echo", "exit", "cd", "ls", "grep", "sed", "awk"]
+        case "go":
+            return ["func", "var", "const", "if", "else", "return", "import", "package", "struct", "interface", "type", "for", "range", "switch", "case", "default", "break", "continue", "go", "defer", "chan", "select", "map", "nil", "true", "false", "make", "new"]
+        case "rust":
+            return ["fn", "let", "mut", "if", "else", "return", "use", "mod", "pub", "struct", "enum", "impl", "trait", "for", "while", "loop", "match", "break", "continue", "self", "Self", "true", "false", "async", "await", "move", "ref", "where", "type", "const", "static"]
+        default:
+            return ["function", "func", "def", "class", "var", "let", "const", "if", "else", "return", "import", "for", "while", "true", "false", "null", "nil"]
+        }
+    }
+}
+
+#Preview {
+    ScrollView {
+        VStack(spacing: 16) {
+            CodeBlockView(
+                code: """
+                func greet(_ name: String) -> String {
+                    let message = "Hello, \\(name)!"
+                    return message // greeting
+                }
+                """,
+                language: "swift"
+            )
+
+            CodeBlockView(
+                code: """
+                const handler = async (req, res) => {
+                    const data = await fetch("/api");
+                    return data.json();
+                };
+                """,
+                language: "typescript"
+            )
+
+            CodeBlockView(
+                code: "echo 'hello world'",
+                language: "bash"
+            )
+        }
+        .padding()
+    }
+    .background(MajorTomTheme.Colors.background)
+}

--- a/ios/MajorTom/Features/Control/Components/CostBadge.swift
+++ b/ios/MajorTom/Features/Control/Components/CostBadge.swift
@@ -1,0 +1,98 @@
+import SwiftUI
+
+struct CostBadge: View {
+    let costUsd: Double
+    let turnCount: Int
+    let inputTokens: Int
+    let outputTokens: Int
+    @State private var isExpanded = false
+
+    var body: some View {
+        Button {
+            withAnimation(.easeInOut(duration: 0.2)) {
+                isExpanded.toggle()
+            }
+            HapticService.buttonTap()
+        } label: {
+            if isExpanded {
+                expandedView
+            } else {
+                collapsedView
+            }
+        }
+        .buttonStyle(.plain)
+    }
+
+    // MARK: - Collapsed
+
+    private var collapsedView: some View {
+        HStack(spacing: MajorTomTheme.Spacing.xs) {
+            Image(systemName: "dollarsign.circle")
+                .font(.caption2)
+                .foregroundStyle(MajorTomTheme.Colors.textTertiary)
+            Text(formattedCost)
+                .font(MajorTomTheme.Typography.codeFontSmall)
+                .foregroundStyle(MajorTomTheme.Colors.textSecondary)
+        }
+        .padding(.horizontal, MajorTomTheme.Spacing.sm)
+        .padding(.vertical, MajorTomTheme.Spacing.xs)
+        .background(MajorTomTheme.Colors.surface.opacity(0.8))
+        .clipShape(Capsule())
+    }
+
+    // MARK: - Expanded
+
+    private var expandedView: some View {
+        VStack(alignment: .leading, spacing: MajorTomTheme.Spacing.xs) {
+            statRow(label: "Cost", value: formattedCost)
+            statRow(label: "Turns", value: "\(turnCount)")
+            statRow(label: "Input", value: formatTokens(inputTokens))
+            statRow(label: "Output", value: formatTokens(outputTokens))
+        }
+        .padding(MajorTomTheme.Spacing.sm)
+        .background(MajorTomTheme.Colors.surface)
+        .clipShape(RoundedRectangle(cornerRadius: MajorTomTheme.Radius.small))
+    }
+
+    private func statRow(label: String, value: String) -> some View {
+        HStack {
+            Text(label)
+                .font(MajorTomTheme.Typography.codeFontSmall)
+                .foregroundStyle(MajorTomTheme.Colors.textTertiary)
+            Spacer()
+            Text(value)
+                .font(MajorTomTheme.Typography.codeFontSmall)
+                .foregroundStyle(MajorTomTheme.Colors.textSecondary)
+        }
+    }
+
+    // MARK: - Formatting
+
+    private var formattedCost: String {
+        if costUsd < 0.01 && costUsd > 0 {
+            return String(format: "$%.4f", costUsd)
+        } else {
+            return String(format: "$%.2f", costUsd)
+        }
+    }
+
+    private func formatTokens(_ count: Int) -> String {
+        if count >= 1_000_000 {
+            return String(format: "%.1fM", Double(count) / 1_000_000)
+        } else if count >= 1_000 {
+            return String(format: "%.1fK", Double(count) / 1_000)
+        } else {
+            return "\(count)"
+        }
+    }
+}
+
+#Preview {
+    VStack(spacing: 20) {
+        CostBadge(costUsd: 0.0042, turnCount: 3, inputTokens: 1234, outputTokens: 567)
+        CostBadge(costUsd: 1.23, turnCount: 15, inputTokens: 45_200, outputTokens: 12_800)
+        CostBadge(costUsd: 0, turnCount: 0, inputTokens: 0, outputTokens: 0)
+    }
+    .padding()
+    .background(MajorTomTheme.Colors.background)
+}

--- a/ios/MajorTom/Features/Control/Components/MarkdownText.swift
+++ b/ios/MajorTom/Features/Control/Components/MarkdownText.swift
@@ -1,0 +1,32 @@
+import SwiftUI
+
+struct MarkdownText: View {
+    let text: String
+
+    var body: some View {
+        if let attributed = try? AttributedString(markdown: text, options: .init(interpretedSyntax: .inlineOnlyPreservingWhitespace)) {
+            Text(attributed)
+                .font(MajorTomTheme.Typography.body)
+                .foregroundStyle(MajorTomTheme.Colors.textPrimary)
+                .tint(MajorTomTheme.Colors.accent)
+                .textSelection(.enabled)
+        } else {
+            Text(text)
+                .font(MajorTomTheme.Typography.body)
+                .foregroundStyle(MajorTomTheme.Colors.textPrimary)
+                .textSelection(.enabled)
+        }
+    }
+}
+
+#Preview {
+    VStack(alignment: .leading, spacing: 12) {
+        MarkdownText(text: "Hello **bold** and *italic* text")
+        MarkdownText(text: "Use `inline code` for variables")
+        MarkdownText(text: "Visit [Apple](https://apple.com)")
+        MarkdownText(text: "- Item one\n- Item two\n- Item three")
+        MarkdownText(text: "Plain text fallback")
+    }
+    .padding()
+    .background(MajorTomTheme.Colors.background)
+}

--- a/ios/MajorTom/Features/Control/Components/MessageBubble.swift
+++ b/ios/MajorTom/Features/Control/Components/MessageBubble.swift
@@ -2,19 +2,19 @@ import SwiftUI
 
 struct MessageBubble: View {
     let message: ChatMessage
+    @State private var relativeTime = ""
 
     var body: some View {
         HStack {
             if message.role == .user { Spacer(minLength: 60) }
 
             VStack(alignment: message.role == .user ? .trailing : .leading, spacing: MajorTomTheme.Spacing.xs) {
-                Text(message.content)
-                    .font(message.role == .tool ? MajorTomTheme.Typography.codeFontSmall : MajorTomTheme.Typography.body)
-                    .foregroundStyle(textColor)
-                    .textSelection(.enabled)
+                // Content — markdown + code blocks for assistant, plain for user
+                contentView
 
-                Text(message.timestamp, style: .time)
-                    .font(MajorTomTheme.Typography.caption)
+                // Relative timestamp
+                Text(relativeTime)
+                    .font(.caption2)
                     .foregroundStyle(MajorTomTheme.Colors.textTertiary)
             }
             .padding(MajorTomTheme.Spacing.md)
@@ -23,7 +23,57 @@ struct MessageBubble: View {
 
             if message.role != .user { Spacer(minLength: 60) }
         }
+        .task {
+            updateRelativeTime()
+        }
+        .task(id: timerTick) {
+            updateRelativeTime()
+        }
     }
+
+    // MARK: - Content Router
+
+    @ViewBuilder
+    private var contentView: some View {
+        switch message.role {
+        case .assistant:
+            assistantContent
+        case .user:
+            Text(message.content)
+                .font(MajorTomTheme.Typography.body)
+                .foregroundStyle(MajorTomTheme.Colors.textPrimary)
+                .textSelection(.enabled)
+        case .system:
+            Text(message.content)
+                .font(MajorTomTheme.Typography.body)
+                .foregroundStyle(MajorTomTheme.Colors.deny)
+                .textSelection(.enabled)
+        case .tool:
+            // Tool messages use ToolMessageView — this shouldn't render
+            Text(message.content)
+                .font(MajorTomTheme.Typography.codeFontSmall)
+                .foregroundStyle(MajorTomTheme.Colors.textSecondary)
+                .textSelection(.enabled)
+        }
+    }
+
+    // MARK: - Assistant Content (Mixed Markdown + Code Blocks)
+
+    private var assistantContent: some View {
+        let segments = ContentParser.parse(message.content)
+        return VStack(alignment: .leading, spacing: MajorTomTheme.Spacing.sm) {
+            ForEach(Array(segments.enumerated()), id: \.offset) { _, segment in
+                switch segment {
+                case .text(let text):
+                    MarkdownText(text: text)
+                case .codeBlock(let code, let language):
+                    CodeBlockView(code: code, language: language)
+                }
+            }
+        }
+    }
+
+    // MARK: - Styling
 
     private var bubbleColor: Color {
         switch message.role {
@@ -34,22 +84,105 @@ struct MessageBubble: View {
         }
     }
 
-    private var textColor: Color {
-        switch message.role {
-        case .tool: MajorTomTheme.Colors.textSecondary
-        case .system: MajorTomTheme.Colors.deny
-        default: MajorTomTheme.Colors.textPrimary
+    // MARK: - Relative Time
+
+    private var timerTick: Int {
+        Int(Date().timeIntervalSince1970 / 30)
+    }
+
+    private func updateRelativeTime() {
+        relativeTime = RelativeTimeFormatter.format(message.timestamp)
+    }
+}
+
+// MARK: - Content Parser
+
+enum ContentSegment {
+    case text(String)
+    case codeBlock(code: String, language: String)
+}
+
+enum ContentParser {
+    static func parse(_ content: String) -> [ContentSegment] {
+        var segments: [ContentSegment] = []
+        let pattern = "```(\\w*)\\n([\\s\\S]*?)```"
+
+        guard let regex = try? NSRegularExpression(pattern: pattern, options: []) else {
+            return [.text(content)]
         }
+
+        let nsContent = content as NSString
+        var lastEnd = 0
+        let matches = regex.matches(in: content, range: NSRange(location: 0, length: nsContent.length))
+
+        for match in matches {
+            let matchStart = match.range.location
+
+            // Text before this code block
+            if matchStart > lastEnd {
+                let textRange = NSRange(location: lastEnd, length: matchStart - lastEnd)
+                let text = nsContent.substring(with: textRange).trimmingCharacters(in: .whitespacesAndNewlines)
+                if !text.isEmpty {
+                    segments.append(.text(text))
+                }
+            }
+
+            // Language
+            let langRange = match.range(at: 1)
+            let language = langRange.location != NSNotFound ? nsContent.substring(with: langRange) : ""
+
+            // Code content
+            let codeRange = match.range(at: 2)
+            let code = codeRange.location != NSNotFound ? nsContent.substring(with: codeRange).trimmingCharacters(in: .newlines) : ""
+
+            if !code.isEmpty {
+                segments.append(.codeBlock(code: code, language: language))
+            }
+
+            lastEnd = match.range.location + match.range.length
+        }
+
+        // Remaining text after last code block
+        if lastEnd < nsContent.length {
+            let text = nsContent.substring(from: lastEnd).trimmingCharacters(in: .whitespacesAndNewlines)
+            if !text.isEmpty {
+                segments.append(.text(text))
+            }
+        }
+
+        // No code blocks found — entire content is text
+        if segments.isEmpty {
+            return [.text(content)]
+        }
+
+        return segments
     }
 }
 
 #Preview {
-    VStack(spacing: 12) {
-        MessageBubble(message: ChatMessage(role: .user, content: "Fix the login bug"))
-        MessageBubble(message: ChatMessage(role: .assistant, content: "I'll look at the auth module..."))
-        MessageBubble(message: ChatMessage(role: .tool, content: "Read src/auth.ts"))
-        MessageBubble(message: ChatMessage(role: .system, content: "Error: Connection lost"))
+    ScrollView {
+        VStack(spacing: 12) {
+            MessageBubble(message: ChatMessage(role: .user, content: "Fix the login bug"))
+
+            MessageBubble(message: ChatMessage(
+                role: .assistant,
+                content: """
+                I found the issue. The **auth token** is expiring too early.
+
+                ```swift
+                func refreshToken() async throws {
+                    let newToken = try await api.refresh()
+                    KeychainService.save(newToken)
+                }
+                ```
+
+                This should fix the `401` errors you're seeing.
+                """
+            ))
+
+            MessageBubble(message: ChatMessage(role: .system, content: "Error: Connection lost"))
+        }
+        .padding()
     }
-    .padding()
     .background(MajorTomTheme.Colors.background)
 }

--- a/ios/MajorTom/Features/Control/Components/StreamingIndicator.swift
+++ b/ios/MajorTom/Features/Control/Components/StreamingIndicator.swift
@@ -1,0 +1,39 @@
+import SwiftUI
+
+struct StreamingIndicator: View {
+    @State private var animationPhase: CGFloat = 0
+
+    var body: some View {
+        HStack(spacing: MajorTomTheme.Spacing.xs) {
+            ForEach(0..<3, id: \.self) { index in
+                Circle()
+                    .fill(MajorTomTheme.Colors.textTertiary)
+                    .frame(width: 6, height: 6)
+                    .offset(y: bounceOffset(for: index))
+            }
+        }
+        .padding(.horizontal, MajorTomTheme.Spacing.md)
+        .padding(.vertical, MajorTomTheme.Spacing.sm)
+        .background(MajorTomTheme.Colors.assistantBubble)
+        .clipShape(RoundedRectangle(cornerRadius: MajorTomTheme.Radius.medium))
+        .task {
+            withAnimation(.easeInOut(duration: 0.6).repeatForever(autoreverses: true)) {
+                animationPhase = 1
+            }
+        }
+    }
+
+    private func bounceOffset(for index: Int) -> CGFloat {
+        let delay = CGFloat(index) * 0.15
+        let phase = max(0, min(1, animationPhase - delay))
+        return -4 * sin(phase * .pi)
+    }
+}
+
+#Preview {
+    VStack(spacing: 20) {
+        StreamingIndicator()
+    }
+    .padding()
+    .background(MajorTomTheme.Colors.background)
+}

--- a/ios/MajorTom/Features/Control/Components/ToolMessageView.swift
+++ b/ios/MajorTom/Features/Control/Components/ToolMessageView.swift
@@ -1,0 +1,172 @@
+import SwiftUI
+
+struct ToolMessageView: View {
+    let message: ChatMessage
+    @State private var isExpanded: Bool = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            // Collapsed header — always visible
+            toolHeader
+                .contentShape(Rectangle())
+                .onTapGesture {
+                    withAnimation(.easeInOut(duration: 0.2)) {
+                        isExpanded.toggle()
+                    }
+                    HapticService.buttonTap()
+                }
+
+            // Expanded output
+            if isExpanded, let output = message.toolOutput, !output.isEmpty {
+                toolOutput(output)
+            }
+        }
+        .background(MajorTomTheme.Colors.surface.opacity(0.6))
+        .clipShape(RoundedRectangle(cornerRadius: MajorTomTheme.Radius.small))
+    }
+
+    // MARK: - Header
+
+    private var toolHeader: some View {
+        HStack(spacing: MajorTomTheme.Spacing.sm) {
+            // Tool icon
+            Image(systemName: toolIcon)
+                .font(.caption)
+                .foregroundStyle(MajorTomTheme.Colors.textTertiary)
+                .frame(width: 20, height: 20)
+
+            // Tool name
+            Text(message.toolName ?? "tool")
+                .font(MajorTomTheme.Typography.codeFontSmall)
+                .foregroundStyle(MajorTomTheme.Colors.textSecondary)
+
+            Spacer()
+
+            // Status badge
+            statusBadge
+
+            // Expand chevron (if has output)
+            if message.toolOutput != nil, !(message.toolOutput?.isEmpty ?? true) {
+                Image(systemName: isExpanded ? "chevron.up" : "chevron.down")
+                    .font(.caption2)
+                    .foregroundStyle(MajorTomTheme.Colors.textTertiary)
+            }
+        }
+        .padding(.horizontal, MajorTomTheme.Spacing.md)
+        .padding(.vertical, MajorTomTheme.Spacing.sm)
+    }
+
+    // MARK: - Status Badge
+
+    @ViewBuilder
+    private var statusBadge: some View {
+        switch message.toolStatus {
+        case .running:
+            HStack(spacing: MajorTomTheme.Spacing.xs) {
+                ProgressView()
+                    .scaleEffect(0.6)
+                    .tint(MajorTomTheme.Colors.accent)
+                Text("running")
+                    .font(.caption2)
+                    .foregroundStyle(MajorTomTheme.Colors.accent)
+            }
+        case .success:
+            HStack(spacing: MajorTomTheme.Spacing.xs) {
+                Image(systemName: "checkmark.circle.fill")
+                    .font(.caption2)
+                    .foregroundStyle(MajorTomTheme.Colors.allow)
+                Text("done")
+                    .font(.caption2)
+                    .foregroundStyle(MajorTomTheme.Colors.allow)
+            }
+        case .failure:
+            HStack(spacing: MajorTomTheme.Spacing.xs) {
+                Image(systemName: "xmark.circle.fill")
+                    .font(.caption2)
+                    .foregroundStyle(MajorTomTheme.Colors.deny)
+                Text("failed")
+                    .font(.caption2)
+                    .foregroundStyle(MajorTomTheme.Colors.deny)
+            }
+        case .none:
+            EmptyView()
+        }
+    }
+
+    // MARK: - Output
+
+    private func toolOutput(_ output: String) -> some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            Text(output)
+                .font(MajorTomTheme.Typography.codeFontSmall)
+                .foregroundStyle(MajorTomTheme.Colors.textTertiary)
+                .textSelection(.enabled)
+                .padding(MajorTomTheme.Spacing.md)
+        }
+        .frame(maxHeight: 200)
+        .background(Color(white: 0.05))
+    }
+
+    // MARK: - Tool Icon Mapping
+
+    private var toolIcon: String {
+        guard let name = message.toolName?.lowercased() else { return "wrench" }
+
+        if name.contains("bash") || name.contains("terminal") || name.contains("exec") {
+            return "terminal"
+        } else if name.contains("read") || name.contains("cat") {
+            return "doc.text"
+        } else if name.contains("edit") || name.contains("write") || name.contains("patch") {
+            return "pencil"
+        } else if name.contains("search") || name.contains("grep") || name.contains("glob") || name.contains("find") {
+            return "magnifyingglass"
+        } else if name.contains("list") || name.contains("ls") {
+            return "list.bullet"
+        } else if name.contains("git") {
+            return "arrow.triangle.branch"
+        } else if name.contains("web") || name.contains("fetch") || name.contains("http") {
+            return "globe"
+        } else if name.contains("file") {
+            return "doc"
+        } else {
+            return "wrench"
+        }
+    }
+}
+
+#Preview {
+    VStack(spacing: 8) {
+        ToolMessageView(message: ChatMessage(
+            role: .tool,
+            content: "Using Bash...",
+            toolName: "Bash",
+            toolStatus: .running
+        ))
+
+        ToolMessageView(message: ChatMessage(
+            role: .tool,
+            content: "Read completed",
+            toolName: "Read",
+            toolStatus: .success,
+            toolOutput: "Line 1: import SwiftUI\nLine 2: \nLine 3: struct MyView: View {"
+        ))
+
+        ToolMessageView(message: ChatMessage(
+            role: .tool,
+            content: "Edit failed",
+            toolName: "Edit",
+            toolStatus: .failure,
+            toolOutput: "Error: File not found"
+        ))
+
+        ToolMessageView(message: ChatMessage(
+            role: .tool,
+            content: "Searching...",
+            toolName: "Grep",
+            toolStatus: .success,
+            toolOutput: "Found 3 matches in 2 files"
+        ))
+    }
+    .padding()
+    .background(MajorTomTheme.Colors.background)
+}

--- a/ios/MajorTom/Features/Control/Components/TurnSeparator.swift
+++ b/ios/MajorTom/Features/Control/Components/TurnSeparator.swift
@@ -1,0 +1,71 @@
+import SwiftUI
+
+struct TurnSeparator: View {
+    let timestamp: Date
+    @State private var relativeTime = ""
+
+    var body: some View {
+        HStack(spacing: MajorTomTheme.Spacing.sm) {
+            line
+            Text(relativeTime)
+                .font(.caption2)
+                .foregroundStyle(MajorTomTheme.Colors.textTertiary)
+            line
+        }
+        .padding(.vertical, MajorTomTheme.Spacing.xs)
+        .task {
+            updateRelativeTime()
+        }
+        .task(id: timerTick) {
+            updateRelativeTime()
+        }
+    }
+
+    private var line: some View {
+        Rectangle()
+            .fill(MajorTomTheme.Colors.textTertiary.opacity(0.3))
+            .frame(height: 0.5)
+    }
+
+    /// Triggers a re-render roughly every 30 seconds
+    private var timerTick: Int {
+        Int(Date().timeIntervalSince1970 / 30)
+    }
+
+    private func updateRelativeTime() {
+        relativeTime = RelativeTimeFormatter.format(timestamp)
+    }
+}
+
+// MARK: - Relative Time Formatter
+
+enum RelativeTimeFormatter {
+    static func format(_ date: Date) -> String {
+        let seconds = Int(Date().timeIntervalSince(date))
+
+        if seconds < 5 {
+            return "just now"
+        } else if seconds < 60 {
+            return "\(seconds)s ago"
+        } else if seconds < 3600 {
+            let minutes = seconds / 60
+            return "\(minutes)m ago"
+        } else if seconds < 86400 {
+            let hours = seconds / 3600
+            return "\(hours)h ago"
+        } else {
+            let days = seconds / 86400
+            return "\(days)d ago"
+        }
+    }
+}
+
+#Preview {
+    VStack(spacing: 20) {
+        TurnSeparator(timestamp: Date())
+        TurnSeparator(timestamp: Date().addingTimeInterval(-120))
+        TurnSeparator(timestamp: Date().addingTimeInterval(-3700))
+    }
+    .padding()
+    .background(MajorTomTheme.Colors.background)
+}

--- a/ios/MajorTom/Features/Control/ViewModels/ChatViewModel.swift
+++ b/ios/MajorTom/Features/Control/ViewModels/ChatViewModel.swift
@@ -6,7 +6,14 @@ final class ChatViewModel {
     var inputText = ""
     var isLoading = false
 
+    // Smart scroll state
+    var isNearBottom = true
+    var showScrollFab = false
+    var unreadCount = 0
+    var scrollToBottomTrigger = 0
+
     private let relay: RelayService
+    private let nearBottomThreshold: CGFloat = 150
 
     init(relay: RelayService) {
         self.relay = relay
@@ -27,6 +34,59 @@ final class ChatViewModel {
     var connectionState: ConnectionState {
         relay.connectionState
     }
+
+    // MARK: - Cost Passthrough
+
+    var sessionCostUsd: Double {
+        relay.sessionCostUsd
+    }
+
+    var sessionTurnCount: Int {
+        relay.sessionTurnCount
+    }
+
+    var sessionInputTokens: Int {
+        relay.sessionInputTokens
+    }
+
+    var sessionOutputTokens: Int {
+        relay.sessionOutputTokens
+    }
+
+    // MARK: - Streaming Detection
+
+    var isStreaming: Bool {
+        // Streaming if the last message is from the assistant and tools are running
+        guard let last = messages.last else { return false }
+        return last.role == .assistant && !relay.activeTools.isEmpty
+    }
+
+    // MARK: - Smart Scroll
+
+    func updateScrollPosition(contentMaxY: CGFloat) {
+        // contentMaxY is the max Y of the content relative to the scroll view's coordinate space.
+        // When near the bottom, this value is close to the scroll view's height.
+        // We consider "near bottom" if the content bottom is within threshold of visible area.
+        let wasNearBottom = isNearBottom
+        isNearBottom = contentMaxY < nearBottomThreshold
+
+        if !isNearBottom && wasNearBottom {
+            withMainActorAnimation {
+                showScrollFab = true
+            }
+        } else if isNearBottom && !wasNearBottom {
+            unreadCount = 0
+            withMainActorAnimation {
+                showScrollFab = false
+            }
+        }
+    }
+
+    private func withMainActorAnimation(_ body: () -> Void) {
+        body()
+    }
+
+    // MARK: - Actions
 
     func sendPrompt() async {
         let text = inputText.trimmingCharacters(in: .whitespacesAndNewlines)

--- a/ios/MajorTom/Features/Control/Views/ChatView.swift
+++ b/ios/MajorTom/Features/Control/Views/ChatView.swift
@@ -11,7 +11,7 @@ struct ChatView: View {
         @Bindable var viewModel = viewModel
 
         VStack(spacing: 0) {
-            // Connection status bar
+            // Connection status bar + cost
             connectionBar
 
             // Pending approvals
@@ -19,8 +19,15 @@ struct ChatView: View {
                 approvalsList
             }
 
-            // Messages
-            messagesList
+            // Messages with smart scroll
+            ZStack(alignment: .bottomTrailing) {
+                messagesList
+
+                // Scroll-to-bottom FAB
+                if viewModel.showScrollFab {
+                    scrollToBottomFab
+                }
+            }
 
             // Input bar
             inputBar(text: $viewModel.inputText)
@@ -43,7 +50,16 @@ struct ChatView: View {
             Text(viewModel.connectionState.rawValue.capitalized)
                 .font(MajorTomTheme.Typography.caption)
                 .foregroundStyle(MajorTomTheme.Colors.textSecondary)
+
             Spacer()
+
+            // Cost badge
+            CostBadge(
+                costUsd: viewModel.sessionCostUsd,
+                turnCount: viewModel.sessionTurnCount,
+                inputTokens: viewModel.sessionInputTokens,
+                outputTokens: viewModel.sessionOutputTokens
+            )
         }
         .padding(.horizontal, MajorTomTheme.Spacing.lg)
         .padding(.vertical, MajorTomTheme.Spacing.sm)
@@ -77,27 +93,122 @@ struct ChatView: View {
         .background(MajorTomTheme.Colors.surface.opacity(0.5))
     }
 
-    // MARK: - Messages
+    // MARK: - Messages List (Smart Scroll)
 
     private var messagesList: some View {
         ScrollViewReader { proxy in
             ScrollView {
                 LazyVStack(spacing: MajorTomTheme.Spacing.sm) {
-                    ForEach(viewModel.messages) { message in
-                        MessageBubble(message: message)
-                            .id(message.id)
+                    ForEach(Array(viewModel.messages.enumerated()), id: \.element.id) { index, message in
+                        // Turn separator: insert between user→assistant transitions
+                        if shouldShowTurnSeparator(at: index) {
+                            TurnSeparator(timestamp: message.timestamp)
+                        }
+
+                        // Route to appropriate view
+                        if message.role == .tool {
+                            ToolMessageView(message: message)
+                                .id(message.id)
+                        } else {
+                            MessageBubble(message: message)
+                                .id(message.id)
+                        }
                     }
+
+                    // Streaming indicator
+                    if viewModel.isStreaming {
+                        HStack {
+                            StreamingIndicator()
+                            Spacer()
+                        }
+                    }
+
+                    // Scroll anchor
+                    Color.clear
+                        .frame(height: 1)
+                        .id("bottom")
                 }
                 .padding(MajorTomTheme.Spacing.md)
+
+                // Track scroll position
+                GeometryReader { geometry in
+                    Color.clear
+                        .preference(
+                            key: ScrollOffsetPreferenceKey.self,
+                            value: geometry.frame(in: .named("chatScroll")).maxY
+                        )
+                }
+                .frame(height: 0)
+            }
+            .coordinateSpace(name: "chatScroll")
+            .onPreferenceChange(ScrollOffsetPreferenceKey.self) { maxY in
+                viewModel.updateScrollPosition(contentMaxY: maxY)
             }
             .onChange(of: viewModel.messages.count) {
-                if let last = viewModel.messages.last {
+                if viewModel.isNearBottom {
                     withAnimation(.spring(duration: 0.3)) {
-                        proxy.scrollTo(last.id, anchor: .bottom)
+                        proxy.scrollTo("bottom", anchor: .bottom)
                     }
+                    viewModel.unreadCount = 0
+                } else {
+                    viewModel.unreadCount += 1
+                }
+            }
+            .onChange(of: viewModel.scrollToBottomTrigger) {
+                withAnimation(.spring(duration: 0.3)) {
+                    proxy.scrollTo("bottom", anchor: .bottom)
+                }
+                viewModel.unreadCount = 0
+                viewModel.isNearBottom = true
+                viewModel.showScrollFab = false
+            }
+        }
+    }
+
+    // MARK: - Scroll to Bottom FAB
+
+    private var scrollToBottomFab: some View {
+        Button {
+            HapticService.buttonTap()
+            viewModel.scrollToBottomTrigger += 1
+        } label: {
+            ZStack(alignment: .topTrailing) {
+                Image(systemName: "chevron.down")
+                    .font(.body.weight(.semibold))
+                    .foregroundStyle(MajorTomTheme.Colors.textPrimary)
+                    .frame(width: 40, height: 40)
+                    .background(MajorTomTheme.Colors.surfaceElevated)
+                    .clipShape(Circle())
+                    .shadow(color: .black.opacity(0.3), radius: 4, y: 2)
+
+                // Unread badge
+                if viewModel.unreadCount > 0 {
+                    Text("\(min(viewModel.unreadCount, 99))")
+                        .font(.caption2.weight(.bold))
+                        .foregroundStyle(MajorTomTheme.Colors.textPrimary)
+                        .padding(.horizontal, 5)
+                        .padding(.vertical, 2)
+                        .background(MajorTomTheme.Colors.accent)
+                        .clipShape(Capsule())
+                        .offset(x: 6, y: -6)
                 }
             }
         }
+        .padding(.trailing, MajorTomTheme.Spacing.lg)
+        .padding(.bottom, MajorTomTheme.Spacing.md)
+        .transition(.scale.combined(with: .opacity))
+    }
+
+    // MARK: - Turn Separator Logic
+
+    private func shouldShowTurnSeparator(at index: Int) -> Bool {
+        guard index > 0 else { return false }
+        let messages = viewModel.messages
+        let current = messages[index]
+        let previous = messages[index - 1]
+
+        // Show separator when transitioning from non-user to user (new turn)
+        return current.role == .user && previous.role != .user
     }
 
     // MARK: - Input Bar
@@ -128,6 +239,15 @@ struct ChatView: View {
         }
         .padding(MajorTomTheme.Spacing.md)
         .background(MajorTomTheme.Colors.surface)
+    }
+}
+
+// MARK: - Scroll Offset Preference Key
+
+private struct ScrollOffsetPreferenceKey: PreferenceKey {
+    static var defaultValue: CGFloat = 0
+    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
+        value = nextValue()
     }
 }
 


### PR DESCRIPTION
## Summary
- **Markdown rendering** via SwiftUI native `AttributedString(markdown:)` (iOS 17+)
- **Code blocks** with syntax highlighting, language labels, copy-to-clipboard buttons
- **Collapsible tool messages** with SF Symbol icons, status badges (spinner/check/x)
- **Smart auto-scroll** — only scrolls if user is near bottom (150pt threshold)
- **Scroll-to-bottom FAB** with unread message count badge
- **Turn separators** with relative timestamps between conversation cycles
- **Streaming indicator** — 3-dot bouncing animation
- **Cost display** — collapsible badge showing cost, turns, tokens
- **MessageBubble rewrite** — mixed markdown + code block rendering

## Test plan
- [ ] Send a message containing markdown (bold, italic, code) — verify renders correctly
- [ ] Receive a response with a fenced code block — verify syntax highlighting + copy button
- [ ] Scroll up during streaming — verify auto-scroll stops and FAB appears
- [ ] Tap FAB — verify scrolls to bottom and badge clears
- [ ] Verify tool messages show collapsed with icon/status, expand on tap

🤖 Generated with [Claude Code](https://claude.com/claude-code)