### PR TITLE
feat(ios): Wave 3 — Permission system (ClaudeGod)

### DIFF
--- a/ios/MajorTom.xcodeproj/project.pbxproj
+++ b/ios/MajorTom.xcodeproj/project.pbxproj
@@ -8,15 +8,18 @@
 
 /* Begin PBXBuildFile section */
 		01CF88DD53BD425A8BB52F59 /* OfficeLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2A5F6ECD6AEA9681C140DA3 /* OfficeLayout.swift */; };
+		105DA16D4A98B26952BC1756 /* PermissionModeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A8199AB9D26A914D6633EF0 /* PermissionModeView.swift */; };
 		1ECF57AD1993033DCCF73DB5 /* OfficeViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 794D98FF20DC91F49542FE7D /* OfficeViewModel.swift */; };
 		2CD2BE4AF89623E36046AEF2 /* ApprovalRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CAFA24AC1299FAEA55E2C0B /* ApprovalRequest.swift */; };
 		3320719E65C7D12EC787C929 /* PairingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CB6C01422BAAA8E4C996172 /* PairingView.swift */; };
 		36B33910C927C9BBAC0813A7 /* KeychainService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9BD8A95DFAD6160FF41E83F /* KeychainService.swift */; };
+		38E33EB668F17E0408DEBF7C /* DelayCountdownView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 735C53A97B86E2331E03A4F0 /* DelayCountdownView.swift */; };
 		3C07EFEF4D80196CACF66B4F /* RelayService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EF58FBAC8341407F9E3E7A0 /* RelayService.swift */; };
 		3F5D30750D5451D281E3E246 /* STATUS.md in Resources */ = {isa = PBXBuildFile; fileRef = 944EEB19C6C12FD8F9F43846 /* STATUS.md */; };
 		43FBF1E65395F38364EDB020 /* MessageCodec.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC19E99FB3AAD181F192CD3B /* MessageCodec.swift */; };
 		47EC9244ECBFED3B28C37DBA /* AgentState.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3C4E64AF88E24ABC75AB59E /* AgentState.swift */; };
 		4F564AFF2C107C396235D252 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21F681FC6A3D7B14792DDC15 /* SettingsView.swift */; };
+		508D62FEA85292B273E3D167 /* PermissionViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1494C1C717DD39A7E7813BF7 /* PermissionViewModel.swift */; };
 		50BB1C73D342CB99FCFD747C /* ConnectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2E379544E5140C04B00F724 /* ConnectionView.swift */; };
 		54DF40806CDE825D4201BB6B /* ApprovalCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AC497E5E769C0087E856232 /* ApprovalCard.swift */; };
 		6842CC155924DD2F8E828C18 /* WebSocketClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = C13191C0A248C84CA6959981 /* WebSocketClient.swift */; };
@@ -24,6 +27,7 @@
 		6E4EDEA7EBF6C0B069F3654C /* OfficeScene.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7643A52E74C92A59EFA82ED7 /* OfficeScene.swift */; };
 		818FA51F81C18CFE08B3C097 /* PairingViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 526DF9EAD13F47F747C7ACC3 /* PairingViewModel.swift */; };
 		8294293F9EF30CBEED38BFC6 /* HapticService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7794C5813F5964F288D432AD /* HapticService.swift */; };
+		83C02DEBD2B6488A47A08A65 /* ModePickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66594811ED284A67510E10AE /* ModePickerView.swift */; };
 		8AD9CF79749CD5BE5EF22487 /* AgentInspectorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A6B155FB1E10E586EFA12AC /* AgentInspectorView.swift */; };
 		924AA688A4D5BF0B708C40A4 /* ApprovalView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B99FD8B1AB490C5124F962DC /* ApprovalView.swift */; };
 		926D953D313C1AF78A9041EE /* MessageBubble.swift in Sources */ = {isa = PBXBuildFile; fileRef = E659E1885E32B1187E8C3703 /* MessageBubble.swift */; };
@@ -33,6 +37,7 @@
 		BB6D1475199DE9F8814F33DE /* PixelArtBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7152E60188E13153CF4B5C85 /* PixelArtBuilder.swift */; };
 		BD4DE18F7D89A6E7BE778875 /* CharacterConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49975C50EF000FB470E30360 /* CharacterConfig.swift */; };
 		BF6D1C0B63D35D14E62F514B /* MajorTomApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CF1FCD49533EE6197E807D1 /* MajorTomApp.swift */; };
+		C73A60CB24EFABD14D9C2A2F /* GodModeConfirmation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3521453D8CF8B9AC8F1D53C4 /* GodModeConfirmation.swift */; };
 		C9BB54E28A623F2765BB3A95 /* SettingsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A981C64512EE7700D1A27BAB /* SettingsViewModel.swift */; };
 		C9D6EF3F81D2EB74C1C3C741 /* ConnectionViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4862EDC8F8386FEB727657BF /* ConnectionViewModel.swift */; };
 		CFCBB89895F30259222DD268 /* ChatViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FA484DB960E122B25A8773F /* ChatViewModel.swift */; };
@@ -44,9 +49,11 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		1494C1C717DD39A7E7813BF7 /* PermissionViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionViewModel.swift; sourceTree = "<group>"; };
 		2155A4D6123944C4CDE2BEE8 /* MajorTom.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = MajorTom.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		21F681FC6A3D7B14792DDC15 /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
 		345B4AA475B96036D85853BA /* Theme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Theme.swift; sourceTree = "<group>"; };
+		3521453D8CF8B9AC8F1D53C4 /* GodModeConfirmation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GodModeConfirmation.swift; sourceTree = "<group>"; };
 		3AC497E5E769C0087E856232 /* ApprovalCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApprovalCard.swift; sourceTree = "<group>"; };
 		4862EDC8F8386FEB727657BF /* ConnectionViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectionViewModel.swift; sourceTree = "<group>"; };
 		49975C50EF000FB470E30360 /* CharacterConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CharacterConfig.swift; sourceTree = "<group>"; };
@@ -57,13 +64,16 @@
 		5CF1FCD49533EE6197E807D1 /* MajorTomApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MajorTomApp.swift; sourceTree = "<group>"; };
 		5FA484DB960E122B25A8773F /* ChatViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatViewModel.swift; sourceTree = "<group>"; };
 		6657773292DC21D71241871E /* ChatView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatView.swift; sourceTree = "<group>"; };
+		66594811ED284A67510E10AE /* ModePickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModePickerView.swift; sourceTree = "<group>"; };
 		6A6B155FB1E10E586EFA12AC /* AgentInspectorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentInspectorView.swift; sourceTree = "<group>"; };
 		6EF58FBAC8341407F9E3E7A0 /* RelayService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RelayService.swift; sourceTree = "<group>"; };
 		7152E60188E13153CF4B5C85 /* PixelArtBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PixelArtBuilder.swift; sourceTree = "<group>"; };
+		735C53A97B86E2331E03A4F0 /* DelayCountdownView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DelayCountdownView.swift; sourceTree = "<group>"; };
 		73D57C1446E7A203616CCE20 /* StreamingText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StreamingText.swift; sourceTree = "<group>"; };
 		7643A52E74C92A59EFA82ED7 /* OfficeScene.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OfficeScene.swift; sourceTree = "<group>"; };
 		7794C5813F5964F288D432AD /* HapticService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HapticService.swift; sourceTree = "<group>"; };
 		794D98FF20DC91F49542FE7D /* OfficeViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OfficeViewModel.swift; sourceTree = "<group>"; };
+		7A8199AB9D26A914D6633EF0 /* PermissionModeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionModeView.swift; sourceTree = "<group>"; };
 		8CAFA24AC1299FAEA55E2C0B /* ApprovalRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApprovalRequest.swift; sourceTree = "<group>"; };
 		8DD1D371AFD4698EE21925BF /* AgentSprite.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentSprite.swift; sourceTree = "<group>"; };
 		8FEBD49051DFF465363BBE2B /* Message.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Message.swift; sourceTree = "<group>"; };
@@ -176,6 +186,7 @@
 				3A2253D14191C88F64B0A16E /* Control */,
 				1BF75AA0800A3C72B67D050E /* Office */,
 				021CB1EE92B194C990B58AAE /* Pairing */,
+				B7D1F9FF4E901DFFF5A307A0 /* Permissions */,
 				B785C26F2874B8A4F530FD1D /* Settings */,
 			);
 			path = Features;
@@ -243,6 +254,14 @@
 			);
 			sourceTree = "<group>";
 		};
+		9DA91202A8D802A0E5D47845 /* Views */ = {
+			isa = PBXGroup;
+			children = (
+				7A8199AB9D26A914D6633EF0 /* PermissionModeView.swift */,
+			);
+			path = Views;
+			sourceTree = "<group>";
+		};
 		A22D078EA1DE5077E7DCE757 /* App */ = {
 			isa = PBXGroup;
 			children = (
@@ -276,14 +295,31 @@
 			path = Views;
 			sourceTree = "<group>";
 		};
+		AEEE140D72D5948967714BB3 /* ViewModels */ = {
+			isa = PBXGroup;
+			children = (
+				1494C1C717DD39A7E7813BF7 /* PermissionViewModel.swift */,
+			);
+			path = ViewModels;
+			sourceTree = "<group>";
+		};
 		B785C26F2874B8A4F530FD1D /* Settings */ = {
 			isa = PBXGroup;
 			children = (
-				F4CC29694F42E4B5FD57C761 /* Components */,
 				D28A628DB467A01A77C6F494 /* ViewModels */,
 				DE1EBD87DDB29A1DB6A9A638 /* Views */,
 			);
 			path = Settings;
+			sourceTree = "<group>";
+		};
+		B7D1F9FF4E901DFFF5A307A0 /* Permissions */ = {
+			isa = PBXGroup;
+			children = (
+				FC692138F9ADFFD86A3FDE4A /* Components */,
+				AEEE140D72D5948967714BB3 /* ViewModels */,
+				9DA91202A8D802A0E5D47845 /* Views */,
+			);
+			path = Permissions;
 			sourceTree = "<group>";
 		};
 		C0D9B55A94E1B4F6C888C36E /* ViewModels */ = {
@@ -348,9 +384,12 @@
 			path = Models;
 			sourceTree = "<group>";
 		};
-		F4CC29694F42E4B5FD57C761 /* Components */ = {
+		FC692138F9ADFFD86A3FDE4A /* Components */ = {
 			isa = PBXGroup;
 			children = (
+				735C53A97B86E2331E03A4F0 /* DelayCountdownView.swift */,
+				3521453D8CF8B9AC8F1D53C4 /* GodModeConfirmation.swift */,
+				66594811ED284A67510E10AE /* ModePickerView.swift */,
 			);
 			path = Components;
 			sourceTree = "<group>";
@@ -438,19 +477,24 @@
 				CFCBB89895F30259222DD268 /* ChatViewModel.swift in Sources */,
 				50BB1C73D342CB99FCFD747C /* ConnectionView.swift in Sources */,
 				C9D6EF3F81D2EB74C1C3C741 /* ConnectionViewModel.swift in Sources */,
+				38E33EB668F17E0408DEBF7C /* DelayCountdownView.swift in Sources */,
 				DEC7A03BAD629CB026FDD77F /* DeviceManagementView.swift in Sources */,
+				C73A60CB24EFABD14D9C2A2F /* GodModeConfirmation.swift in Sources */,
 				8294293F9EF30CBEED38BFC6 /* HapticService.swift in Sources */,
 				36B33910C927C9BBAC0813A7 /* KeychainService.swift in Sources */,
 				BF6D1C0B63D35D14E62F514B /* MajorTomApp.swift in Sources */,
 				AECFF1EF021E81589ADBC052 /* Message.swift in Sources */,
 				926D953D313C1AF78A9041EE /* MessageBubble.swift in Sources */,
 				43FBF1E65395F38364EDB020 /* MessageCodec.swift in Sources */,
+				83C02DEBD2B6488A47A08A65 /* ModePickerView.swift in Sources */,
 				01CF88DD53BD425A8BB52F59 /* OfficeLayout.swift in Sources */,
 				6E4EDEA7EBF6C0B069F3654C /* OfficeScene.swift in Sources */,
 				9F2F95450060416CA67BA3FB /* OfficeView.swift in Sources */,
 				1ECF57AD1993033DCCF73DB5 /* OfficeViewModel.swift in Sources */,
 				3320719E65C7D12EC787C929 /* PairingView.swift in Sources */,
 				818FA51F81C18CFE08B3C097 /* PairingViewModel.swift in Sources */,
+				105DA16D4A98B26952BC1756 /* PermissionModeView.swift in Sources */,
+				508D62FEA85292B273E3D167 /* PermissionViewModel.swift in Sources */,
 				BB6D1475199DE9F8814F33DE /* PixelArtBuilder.swift in Sources */,
 				3C07EFEF4D80196CACF66B4F /* RelayService.swift in Sources */,
 				ECD4CC99C031E1B803D88C76 /* Session.swift in Sources */,

--- a/ios/MajorTom/Features/Control/Views/ChatView.swift
+++ b/ios/MajorTom/Features/Control/Views/ChatView.swift
@@ -2,8 +2,11 @@ import SwiftUI
 
 struct ChatView: View {
     @State private var viewModel: ChatViewModel
+    @State private var isPermissionExpanded = false
+    private let relay: RelayService
 
     init(relay: RelayService) {
+        self.relay = relay
         _viewModel = State(initialValue: ChatViewModel(relay: relay))
     }
 
@@ -11,8 +14,17 @@ struct ChatView: View {
         @Bindable var viewModel = viewModel
 
         VStack(spacing: 0) {
-            // Connection status bar
+            // Connection status bar with permission pill
             connectionBar
+
+            // Expandable permission mode picker
+            if isPermissionExpanded {
+                PermissionModeView(relay: relay)
+                    .padding(.horizontal, MajorTomTheme.Spacing.md)
+                    .padding(.vertical, MajorTomTheme.Spacing.sm)
+                    .background(MajorTomTheme.Colors.surface)
+                    .transition(.opacity.combined(with: .move(edge: .top)))
+            }
 
             // Pending approvals
             if !viewModel.pendingApprovals.isEmpty {
@@ -26,6 +38,7 @@ struct ChatView: View {
             inputBar(text: $viewModel.inputText)
         }
         .background(MajorTomTheme.Colors.background)
+        .animation(.spring(duration: 0.3), value: isPermissionExpanded)
         .task {
             if !viewModel.hasSession {
                 await viewModel.startSession()
@@ -44,6 +57,14 @@ struct ChatView: View {
                 .font(MajorTomTheme.Typography.caption)
                 .foregroundStyle(MajorTomTheme.Colors.textSecondary)
             Spacer()
+            PermissionModePill(
+                mode: relay.permissionMode,
+                godSubMode: relay.godSubMode,
+                isExpanded: isPermissionExpanded
+            ) {
+                HapticService.buttonTap()
+                isPermissionExpanded.toggle()
+            }
         }
         .padding(.horizontal, MajorTomTheme.Spacing.lg)
         .padding(.vertical, MajorTomTheme.Spacing.sm)

--- a/ios/MajorTom/Features/Permissions/Components/DelayCountdownView.swift
+++ b/ios/MajorTom/Features/Permissions/Components/DelayCountdownView.swift
@@ -1,0 +1,136 @@
+import SwiftUI
+
+struct DelayCountdownView: View {
+    let state: DelayCountdownState
+    let onCancel: () -> Void
+
+    var body: some View {
+        HStack(spacing: MajorTomTheme.Spacing.md) {
+            // Circular countdown
+            ZStack {
+                // Track
+                Circle()
+                    .stroke(
+                        MajorTomTheme.Colors.warning.opacity(0.2),
+                        lineWidth: 3
+                    )
+
+                // Progress
+                Circle()
+                    .trim(from: 0, to: 1 - state.progress)
+                    .stroke(
+                        MajorTomTheme.Colors.warning,
+                        style: StrokeStyle(lineWidth: 3, lineCap: .round)
+                    )
+                    .rotationEffect(.degrees(-90))
+                    .animation(.linear(duration: 1), value: state.progress)
+
+                // Seconds remaining
+                Text("\(state.remainingSeconds)")
+                    .font(.system(size: 14, weight: .bold, design: .monospaced))
+                    .foregroundStyle(MajorTomTheme.Colors.warning)
+                    .contentTransition(.numericText())
+                    .animation(.spring(duration: 0.3), value: state.remainingSeconds)
+            }
+            .frame(width: 36, height: 36)
+
+            // Label
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Auto-approving")
+                    .font(MajorTomTheme.Typography.caption)
+                    .foregroundStyle(MajorTomTheme.Colors.textSecondary)
+                Text("in \(state.remainingSeconds)s")
+                    .font(MajorTomTheme.Typography.caption)
+                    .foregroundStyle(MajorTomTheme.Colors.warning)
+            }
+
+            Spacer()
+
+            // Cancel button
+            Button {
+                HapticService.buttonTap()
+                onCancel()
+            } label: {
+                Text("Cancel")
+                    .font(MajorTomTheme.Typography.caption)
+                    .foregroundStyle(MajorTomTheme.Colors.textSecondary)
+                    .padding(.horizontal, MajorTomTheme.Spacing.md)
+                    .padding(.vertical, MajorTomTheme.Spacing.xs)
+                    .background(MajorTomTheme.Colors.surfaceElevated)
+                    .clipShape(Capsule())
+            }
+            .buttonStyle(.plain)
+        }
+        .padding(MajorTomTheme.Spacing.md)
+        .background(MajorTomTheme.Colors.warning.opacity(0.08))
+        .clipShape(RoundedRectangle(cornerRadius: MajorTomTheme.Radius.small))
+    }
+}
+
+// MARK: - Delay Picker
+
+struct DelaySecondsPicker: View {
+    let selectedSeconds: Int
+    let onSelected: (Int) -> Void
+
+    private let options = [3, 5, 10, 15, 30]
+
+    var body: some View {
+        HStack(spacing: MajorTomTheme.Spacing.sm) {
+            Image(systemName: "timer")
+                .font(.system(size: 14))
+                .foregroundStyle(MajorTomTheme.Colors.textSecondary)
+
+            ForEach(options, id: \.self) { seconds in
+                Button {
+                    HapticService.buttonTap()
+                    onSelected(seconds)
+                } label: {
+                    Text("\(seconds)s")
+                        .font(.system(size: 13, weight: selectedSeconds == seconds ? .bold : .regular, design: .monospaced))
+                        .foregroundStyle(
+                            selectedSeconds == seconds
+                                ? MajorTomTheme.Colors.warning
+                                : MajorTomTheme.Colors.textTertiary
+                        )
+                        .padding(.horizontal, MajorTomTheme.Spacing.sm)
+                        .padding(.vertical, MajorTomTheme.Spacing.xs)
+                        .background(
+                            selectedSeconds == seconds
+                                ? MajorTomTheme.Colors.warning.opacity(0.15)
+                                : Color.clear
+                        )
+                        .clipShape(Capsule())
+                }
+                .buttonStyle(.plain)
+            }
+        }
+    }
+}
+
+#Preview {
+    VStack(spacing: 16) {
+        DelayCountdownView(
+            state: DelayCountdownState(
+                requestId: "test-1",
+                totalSeconds: 10,
+                remainingSeconds: 7
+            ),
+            onCancel: {}
+        )
+
+        DelayCountdownView(
+            state: DelayCountdownState(
+                requestId: "test-2",
+                totalSeconds: 5,
+                remainingSeconds: 2
+            ),
+            onCancel: {}
+        )
+
+        DelaySecondsPicker(selectedSeconds: 5) { _ in }
+        DelaySecondsPicker(selectedSeconds: 15) { _ in }
+    }
+    .padding()
+    .background(MajorTomTheme.Colors.background)
+}

--- a/ios/MajorTom/Features/Permissions/Components/GodModeConfirmation.swift
+++ b/ios/MajorTom/Features/Permissions/Components/GodModeConfirmation.swift
@@ -1,0 +1,165 @@
+import SwiftUI
+
+struct GodModeConfirmation: View {
+    @Binding var selectedSubMode: GodSubMode
+    let onConfirm: (GodSubMode) -> Void
+    let onCancel: () -> Void
+
+    var body: some View {
+        VStack(spacing: MajorTomTheme.Spacing.lg) {
+            // Warning icon
+            Image(systemName: "bolt.trianglebadge.exclamationmark.fill")
+                .font(.system(size: 40))
+                .foregroundStyle(MajorTomTheme.Colors.danger)
+                .padding(.top, MajorTomTheme.Spacing.md)
+
+            // Title
+            Text("Enable God Mode?")
+                .font(MajorTomTheme.Typography.title)
+                .foregroundStyle(MajorTomTheme.Colors.textPrimary)
+
+            // Warning text
+            Text("This will auto-approve ALL tool executions without manual review.")
+                .font(MajorTomTheme.Typography.body)
+                .foregroundStyle(MajorTomTheme.Colors.textSecondary)
+                .multilineTextAlignment(.center)
+                .padding(.horizontal, MajorTomTheme.Spacing.md)
+
+            // Sub-mode picker
+            VStack(spacing: MajorTomTheme.Spacing.md) {
+                subModeOption(
+                    mode: .normal,
+                    icon: "bolt.fill",
+                    title: "Normal",
+                    description: "Auto-approves with standard safety checks"
+                )
+
+                subModeOption(
+                    mode: .yolo,
+                    icon: "flame.fill",
+                    title: "YOLO",
+                    description: "Bypasses ALL safety checks"
+                )
+
+                // Extra YOLO warning
+                if selectedSubMode == .yolo {
+                    HStack(spacing: MajorTomTheme.Spacing.sm) {
+                        Image(systemName: "exclamationmark.triangle.fill")
+                            .font(.system(size: 12))
+                        Text("YOLO mode disables all safety guards. Use at your own risk.")
+                            .font(MajorTomTheme.Typography.caption)
+                    }
+                    .foregroundStyle(MajorTomTheme.Colors.danger)
+                    .padding(MajorTomTheme.Spacing.md)
+                    .background(MajorTomTheme.Colors.danger.opacity(0.1))
+                    .clipShape(RoundedRectangle(cornerRadius: MajorTomTheme.Radius.small))
+                    .transition(.opacity.combined(with: .move(edge: .top)))
+                }
+            }
+            .padding(.horizontal, MajorTomTheme.Spacing.md)
+
+            // Action buttons
+            HStack(spacing: MajorTomTheme.Spacing.md) {
+                Button {
+                    HapticService.buttonTap()
+                    onCancel()
+                } label: {
+                    Text("Cancel")
+                        .font(MajorTomTheme.Typography.headline)
+                        .foregroundStyle(MajorTomTheme.Colors.textSecondary)
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, MajorTomTheme.Spacing.md)
+                        .background(MajorTomTheme.Colors.surfaceElevated)
+                        .clipShape(RoundedRectangle(cornerRadius: MajorTomTheme.Radius.medium))
+                }
+                .buttonStyle(.plain)
+
+                Button {
+                    HapticService.modeSwitch()
+                    onConfirm(selectedSubMode)
+                } label: {
+                    HStack(spacing: MajorTomTheme.Spacing.sm) {
+                        Image(systemName: selectedSubMode == .yolo ? "flame.fill" : "bolt.fill")
+                        Text("Enable")
+                    }
+                    .font(MajorTomTheme.Typography.headline)
+                    .foregroundStyle(.white)
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, MajorTomTheme.Spacing.md)
+                    .background(MajorTomTheme.Colors.danger)
+                    .clipShape(RoundedRectangle(cornerRadius: MajorTomTheme.Radius.medium))
+                }
+                .buttonStyle(.plain)
+            }
+            .padding(.horizontal, MajorTomTheme.Spacing.md)
+            .padding(.bottom, MajorTomTheme.Spacing.lg)
+        }
+        .background(MajorTomTheme.Colors.surface)
+        .clipShape(RoundedRectangle(cornerRadius: MajorTomTheme.Radius.large))
+        .padding(.horizontal, MajorTomTheme.Spacing.xl)
+        .animation(.spring(duration: 0.3), value: selectedSubMode)
+    }
+
+    private func subModeOption(mode: GodSubMode, icon: String, title: String, description: String) -> some View {
+        let isSelected = selectedSubMode == mode
+
+        return Button {
+            HapticService.selection()
+            selectedSubMode = mode
+        } label: {
+            HStack(spacing: MajorTomTheme.Spacing.md) {
+                Image(systemName: icon)
+                    .font(.system(size: 18))
+                    .foregroundStyle(isSelected ? modeColor(mode) : MajorTomTheme.Colors.textTertiary)
+                    .frame(width: 28)
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(title)
+                        .font(MajorTomTheme.Typography.headline)
+                        .foregroundStyle(isSelected ? MajorTomTheme.Colors.textPrimary : MajorTomTheme.Colors.textSecondary)
+                    Text(description)
+                        .font(MajorTomTheme.Typography.caption)
+                        .foregroundStyle(MajorTomTheme.Colors.textTertiary)
+                }
+
+                Spacer()
+
+                Image(systemName: isSelected ? "checkmark.circle.fill" : "circle")
+                    .font(.system(size: 20))
+                    .foregroundStyle(isSelected ? modeColor(mode) : MajorTomTheme.Colors.textTertiary)
+            }
+            .padding(MajorTomTheme.Spacing.md)
+            .background(
+                isSelected
+                    ? modeColor(mode).opacity(0.1)
+                    : MajorTomTheme.Colors.surfaceElevated
+            )
+            .clipShape(RoundedRectangle(cornerRadius: MajorTomTheme.Radius.small))
+            .overlay(
+                RoundedRectangle(cornerRadius: MajorTomTheme.Radius.small)
+                    .stroke(isSelected ? modeColor(mode).opacity(0.4) : Color.clear, lineWidth: 1)
+            )
+        }
+        .buttonStyle(.plain)
+    }
+
+    private func modeColor(_ mode: GodSubMode) -> Color {
+        switch mode {
+        case .normal: MajorTomTheme.Colors.danger
+        case .yolo: Color(red: 1.0, green: 0.45, blue: 0.0)
+        }
+    }
+}
+
+#Preview {
+    ZStack {
+        MajorTomTheme.Colors.background
+            .ignoresSafeArea()
+
+        GodModeConfirmation(
+            selectedSubMode: .constant(.normal),
+            onConfirm: { _ in },
+            onCancel: {}
+        )
+    }
+}

--- a/ios/MajorTom/Features/Permissions/Components/ModePickerView.swift
+++ b/ios/MajorTom/Features/Permissions/Components/ModePickerView.swift
@@ -1,0 +1,69 @@
+import SwiftUI
+
+struct ModePickerView: View {
+    let currentMode: PermissionMode
+    let onModeSelected: (PermissionMode) -> Void
+
+    private let modes: [(PermissionMode, String, String)] = [
+        (.manual, "hand.raised", "Manual"),
+        (.smart, "brain", "Smart"),
+        (.delay, "timer", "Delay"),
+        (.god, "bolt.fill", "God"),
+    ]
+
+    var body: some View {
+        HStack(spacing: MajorTomTheme.Spacing.xs) {
+            ForEach(modes, id: \.0) { mode, icon, label in
+                modeButton(mode: mode, icon: icon, label: label)
+            }
+        }
+        .padding(MajorTomTheme.Spacing.xs)
+        .background(MajorTomTheme.Colors.surface)
+        .clipShape(RoundedRectangle(cornerRadius: MajorTomTheme.Radius.medium))
+    }
+
+    private func modeButton(mode: PermissionMode, icon: String, label: String) -> some View {
+        let isSelected = currentMode == mode
+
+        return Button {
+            onModeSelected(mode)
+        } label: {
+            VStack(spacing: MajorTomTheme.Spacing.xs) {
+                Image(systemName: icon)
+                    .font(.system(size: 16, weight: .semibold))
+                Text(label)
+                    .font(MajorTomTheme.Typography.caption)
+            }
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, MajorTomTheme.Spacing.sm)
+            .foregroundStyle(isSelected ? modeColor(mode) : MajorTomTheme.Colors.textTertiary)
+            .background(
+                isSelected
+                    ? modeColor(mode).opacity(0.15)
+                    : Color.clear
+            )
+            .clipShape(RoundedRectangle(cornerRadius: MajorTomTheme.Radius.small))
+        }
+        .buttonStyle(.plain)
+    }
+
+    private func modeColor(_ mode: PermissionMode) -> Color {
+        switch mode {
+        case .manual: MajorTomTheme.Colors.accent
+        case .smart: Color(red: 0.40, green: 0.70, blue: 0.95)
+        case .delay: MajorTomTheme.Colors.warning
+        case .god: MajorTomTheme.Colors.danger
+        }
+    }
+}
+
+#Preview {
+    VStack(spacing: 20) {
+        ModePickerView(currentMode: .manual) { _ in }
+        ModePickerView(currentMode: .smart) { _ in }
+        ModePickerView(currentMode: .delay) { _ in }
+        ModePickerView(currentMode: .god) { _ in }
+    }
+    .padding()
+    .background(MajorTomTheme.Colors.background)
+}

--- a/ios/MajorTom/Features/Permissions/ViewModels/PermissionViewModel.swift
+++ b/ios/MajorTom/Features/Permissions/ViewModels/PermissionViewModel.swift
@@ -1,0 +1,145 @@
+import Foundation
+
+@Observable
+@MainActor
+final class PermissionViewModel {
+    var currentMode: PermissionMode { relay.permissionMode }
+    var delaySeconds: Int { relay.delaySeconds }
+    var godSubMode: GodSubMode { relay.godSubMode }
+
+    var isShowingGodConfirmation = false
+    var pendingGodSubMode: GodSubMode = .normal
+
+    // Active delay countdowns keyed by approval request ID
+    var activeCountdowns: [String: DelayCountdownState] = [:]
+
+    private let relay: RelayService
+
+    init(relay: RelayService) {
+        self.relay = relay
+    }
+
+    var pendingApprovalCount: Int {
+        relay.pendingApprovals.count
+    }
+
+    // MARK: - Mode Switching
+
+    func setMode(_ mode: PermissionMode) async {
+        if mode == .god {
+            // Show confirmation before switching to god mode
+            pendingGodSubMode = .normal
+            isShowingGodConfirmation = true
+            return
+        }
+
+        await applyMode(mode)
+    }
+
+    func confirmGodMode(subMode: GodSubMode) async {
+        isShowingGodConfirmation = false
+        await applyMode(.god, godSubMode: subMode)
+    }
+
+    func cancelGodMode() {
+        isShowingGodConfirmation = false
+    }
+
+    func setDelaySeconds(_ seconds: Int) async {
+        do {
+            try await relay.setPermissionMode(.delay, delaySeconds: seconds)
+        } catch {
+            // Relay service handles error state
+        }
+    }
+
+    // MARK: - Delay Countdown
+
+    func startCountdown(for requestId: String) {
+        let state = DelayCountdownState(
+            requestId: requestId,
+            totalSeconds: delaySeconds,
+            remainingSeconds: delaySeconds
+        )
+        activeCountdowns[requestId] = state
+
+        Task {
+            await runCountdown(requestId: requestId)
+        }
+    }
+
+    func cancelCountdown(for requestId: String) {
+        activeCountdowns.removeValue(forKey: requestId)
+    }
+
+    // MARK: - Private
+
+    private func applyMode(_ mode: PermissionMode, godSubMode: GodSubMode? = nil) async {
+        HapticService.modeSwitch()
+
+        do {
+            let delay = mode == .delay ? delaySeconds : nil
+            try await relay.setPermissionMode(mode, delaySeconds: delay, godSubMode: godSubMode)
+
+            // Flush pending approvals based on new mode
+            await flushPendingApprovals(for: mode)
+        } catch {
+            // Relay service handles error state
+        }
+    }
+
+    private func flushPendingApprovals(for mode: PermissionMode) async {
+        let pending = relay.pendingApprovals
+        guard !pending.isEmpty else { return }
+
+        switch mode {
+        case .god, .smart:
+            // Auto-approve all pending
+            for request in pending {
+                try? await relay.sendApproval(requestId: request.id, decision: .allow)
+            }
+        case .delay:
+            // Start countdowns for all pending
+            for request in pending {
+                startCountdown(for: request.id)
+            }
+        case .manual:
+            // Keep all pending for manual review
+            break
+        }
+    }
+
+    private func runCountdown(requestId: String) async {
+        for tick in stride(from: delaySeconds, through: 1, by: -1) {
+            guard activeCountdowns[requestId] != nil else { return }
+            activeCountdowns[requestId]?.remainingSeconds = tick
+
+            try? await Task.sleep(for: .seconds(1))
+        }
+
+        // Countdown finished -- auto-approve
+        guard activeCountdowns[requestId] != nil else { return }
+        activeCountdowns.removeValue(forKey: requestId)
+
+        do {
+            try await relay.sendApproval(requestId: requestId, decision: .allow)
+        } catch {
+            // Failed to auto-approve; it will remain in manual queue
+        }
+    }
+}
+
+// MARK: - Delay Countdown State
+
+struct DelayCountdownState: Identifiable {
+    let requestId: String
+    let totalSeconds: Int
+    var remainingSeconds: Int
+
+    var id: String { requestId }
+
+    var progress: Double {
+        guard totalSeconds > 0 else { return 0 }
+        return Double(totalSeconds - remainingSeconds) / Double(totalSeconds)
+    }
+}

--- a/ios/MajorTom/Features/Permissions/Views/PermissionModeView.swift
+++ b/ios/MajorTom/Features/Permissions/Views/PermissionModeView.swift
@@ -1,0 +1,147 @@
+import SwiftUI
+
+struct PermissionModeView: View {
+    @State private var viewModel: PermissionViewModel
+
+    init(relay: RelayService) {
+        _viewModel = State(initialValue: PermissionViewModel(relay: relay))
+    }
+
+    var body: some View {
+        @Bindable var viewModel = viewModel
+
+        VStack(spacing: MajorTomTheme.Spacing.md) {
+            // Mode picker
+            ModePickerView(currentMode: viewModel.currentMode) { mode in
+                Task { await viewModel.setMode(mode) }
+            }
+
+            // Delay settings (only when delay mode active)
+            if viewModel.currentMode == .delay {
+                DelaySecondsPicker(selectedSeconds: viewModel.delaySeconds) { seconds in
+                    Task { await viewModel.setDelaySeconds(seconds) }
+                }
+                .transition(.opacity.combined(with: .move(edge: .top)))
+            }
+
+            // Active countdowns
+            if !viewModel.activeCountdowns.isEmpty {
+                VStack(spacing: MajorTomTheme.Spacing.sm) {
+                    ForEach(Array(viewModel.activeCountdowns.values)) { countdown in
+                        DelayCountdownView(state: countdown) {
+                            viewModel.cancelCountdown(for: countdown.requestId)
+                        }
+                    }
+                }
+                .transition(.opacity.combined(with: .move(edge: .top)))
+            }
+
+            // God mode sub-mode indicator
+            if viewModel.currentMode == .god {
+                godModeIndicator
+                    .transition(.opacity.combined(with: .move(edge: .top)))
+            }
+        }
+        .animation(.spring(duration: 0.3), value: viewModel.currentMode)
+        .animation(.spring(duration: 0.3), value: viewModel.activeCountdowns.count)
+        .sheet(isPresented: $viewModel.isShowingGodConfirmation) {
+            GodModeConfirmation(
+                selectedSubMode: $viewModel.pendingGodSubMode,
+                onConfirm: { subMode in
+                    Task { await viewModel.confirmGodMode(subMode: subMode) }
+                },
+                onCancel: { viewModel.cancelGodMode() }
+            )
+            .presentationDetents([.medium])
+            .presentationDragIndicator(.visible)
+            .presentationBackground(MajorTomTheme.Colors.background)
+        }
+    }
+
+    private var godModeIndicator: some View {
+        HStack(spacing: MajorTomTheme.Spacing.sm) {
+            Image(systemName: viewModel.godSubMode == .yolo ? "flame.fill" : "bolt.fill")
+                .font(.system(size: 12))
+            Text(viewModel.godSubMode == .yolo ? "YOLO Mode" : "God Mode")
+                .font(MajorTomTheme.Typography.caption)
+            Text("All tools auto-approved")
+                .font(MajorTomTheme.Typography.caption)
+                .foregroundStyle(MajorTomTheme.Colors.textTertiary)
+        }
+        .foregroundStyle(MajorTomTheme.Colors.danger)
+        .padding(.horizontal, MajorTomTheme.Spacing.md)
+        .padding(.vertical, MajorTomTheme.Spacing.xs)
+        .background(MajorTomTheme.Colors.danger.opacity(0.1))
+        .clipShape(Capsule())
+    }
+}
+
+// MARK: - Compact Permission Pill (for ChatView header)
+
+struct PermissionModePill: View {
+    let mode: PermissionMode
+    let godSubMode: GodSubMode
+    let isExpanded: Bool
+    let onTap: () -> Void
+
+    var body: some View {
+        Button(action: onTap) {
+            HStack(spacing: MajorTomTheme.Spacing.xs) {
+                Image(systemName: modeIcon)
+                    .font(.system(size: 11, weight: .semibold))
+                Text(modeLabel)
+                    .font(.system(size: 12, weight: .medium))
+                Image(systemName: isExpanded ? "chevron.up" : "chevron.down")
+                    .font(.system(size: 9, weight: .bold))
+            }
+            .foregroundStyle(modeColor)
+            .padding(.horizontal, MajorTomTheme.Spacing.md)
+            .padding(.vertical, MajorTomTheme.Spacing.xs)
+            .background(modeColor.opacity(0.12))
+            .clipShape(Capsule())
+        }
+        .buttonStyle(.plain)
+    }
+
+    private var modeIcon: String {
+        switch mode {
+        case .manual: "hand.raised"
+        case .smart: "brain"
+        case .delay: "timer"
+        case .god: godSubMode == .yolo ? "flame.fill" : "bolt.fill"
+        }
+    }
+
+    private var modeLabel: String {
+        switch mode {
+        case .manual: "Manual"
+        case .smart: "Smart"
+        case .delay: "Delay"
+        case .god: godSubMode == .yolo ? "YOLO" : "God"
+        }
+    }
+
+    private var modeColor: Color {
+        switch mode {
+        case .manual: MajorTomTheme.Colors.accent
+        case .smart: Color(red: 0.40, green: 0.70, blue: 0.95)
+        case .delay: MajorTomTheme.Colors.warning
+        case .god: MajorTomTheme.Colors.danger
+        }
+    }
+}
+
+#Preview {
+    VStack(spacing: 20) {
+        PermissionModeView(relay: RelayService())
+
+        HStack(spacing: 12) {
+            PermissionModePill(mode: .manual, godSubMode: .normal, isExpanded: false, onTap: {})
+            PermissionModePill(mode: .smart, godSubMode: .normal, isExpanded: false, onTap: {})
+            PermissionModePill(mode: .delay, godSubMode: .normal, isExpanded: true, onTap: {})
+            PermissionModePill(mode: .god, godSubMode: .yolo, isExpanded: false, onTap: {})
+        }
+    }
+    .padding()
+    .background(MajorTomTheme.Colors.background)
+}


### PR DESCRIPTION
## Summary
- **Permission mode switcher** — Manual / Smart / Delay / God with SF Symbol icons
- **Delay mode** — configurable countdown (3/5/10/15/30s) with circular animation, cancel to review
- **God mode confirmation** — warning sheet with Normal vs YOLO sub-mode picker
- **PermissionModePill** — compact pill in connection bar showing current mode
- **Mid-response mode switching** — auto-flushes pending approvals appropriately per mode
- All modes send `settings.approval` message to relay

## Test plan
- [ ] Tap permission pill → verify mode picker expands/collapses
- [ ] Switch between all 4 modes — verify haptic feedback and relay message sent
- [ ] Enter Delay mode → verify countdown appears on approval cards
- [ ] Enter God mode → verify confirmation sheet with YOLO warning
- [ ] Switch mode with pending approvals → verify appropriate flush behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)