### PR TITLE
feat(ios): Wave 5 — Productivity features

### DIFF
--- a/ios/MajorTom.xcodeproj/project.pbxproj
+++ b/ios/MajorTom.xcodeproj/project.pbxproj
@@ -8,35 +8,48 @@
 
 /* Begin PBXBuildFile section */
 		01CF88DD53BD425A8BB52F59 /* OfficeLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2A5F6ECD6AEA9681C140DA3 /* OfficeLayout.swift */; };
+		05C0C742F30E2EDFA11347D0 /* FileContextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB6DBE8EE08D1C4498E7F3D4 /* FileContextView.swift */; };
 		1ECF57AD1993033DCCF73DB5 /* OfficeViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 794D98FF20DC91F49542FE7D /* OfficeViewModel.swift */; };
+		241AFDC78C513CD9E223E14B /* PromptHistoryViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F01A77A2D40CD2418227CFFA /* PromptHistoryViewModel.swift */; };
 		2CD2BE4AF89623E36046AEF2 /* ApprovalRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CAFA24AC1299FAEA55E2C0B /* ApprovalRequest.swift */; };
 		3320719E65C7D12EC787C929 /* PairingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CB6C01422BAAA8E4C996172 /* PairingView.swift */; };
+		35BC4313A2E9AFEBD7B113B0 /* PromptTemplate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 105C7DF7508529E4C957FEE1 /* PromptTemplate.swift */; };
 		36B33910C927C9BBAC0813A7 /* KeychainService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9BD8A95DFAD6160FF41E83F /* KeychainService.swift */; };
 		3C07EFEF4D80196CACF66B4F /* RelayService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EF58FBAC8341407F9E3E7A0 /* RelayService.swift */; };
 		3F5D30750D5451D281E3E246 /* STATUS.md in Resources */ = {isa = PBXBuildFile; fileRef = 944EEB19C6C12FD8F9F43846 /* STATUS.md */; };
 		43FBF1E65395F38364EDB020 /* MessageCodec.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC19E99FB3AAD181F192CD3B /* MessageCodec.swift */; };
 		47EC9244ECBFED3B28C37DBA /* AgentState.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3C4E64AF88E24ABC75AB59E /* AgentState.swift */; };
+		4F038F899716358276CDA57D /* TemplateListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EFA6BF23E66D2305D236B9B /* TemplateListView.swift */; };
 		4F564AFF2C107C396235D252 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21F681FC6A3D7B14792DDC15 /* SettingsView.swift */; };
 		50BB1C73D342CB99FCFD747C /* ConnectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2E379544E5140C04B00F724 /* ConnectionView.swift */; };
 		54DF40806CDE825D4201BB6B /* ApprovalCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AC497E5E769C0087E856232 /* ApprovalCard.swift */; };
 		6842CC155924DD2F8E828C18 /* WebSocketClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = C13191C0A248C84CA6959981 /* WebSocketClient.swift */; };
 		6C1C58D6705B5201DC10755F /* ChatView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6657773292DC21D71241871E /* ChatView.swift */; };
 		6E4EDEA7EBF6C0B069F3654C /* OfficeScene.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7643A52E74C92A59EFA82ED7 /* OfficeScene.swift */; };
+		74BC84A25FAE29C592011D14 /* VoiceInputButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E56BE06976EFB6DAC4215EE /* VoiceInputButton.swift */; };
 		818FA51F81C18CFE08B3C097 /* PairingViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 526DF9EAD13F47F747C7ACC3 /* PairingViewModel.swift */; };
 		8294293F9EF30CBEED38BFC6 /* HapticService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7794C5813F5964F288D432AD /* HapticService.swift */; };
 		8AD9CF79749CD5BE5EF22487 /* AgentInspectorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A6B155FB1E10E586EFA12AC /* AgentInspectorView.swift */; };
+		8AF181059859C1E5F1FBEE38 /* TemplateViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7AE4280FD7BB7D618CCA3A8 /* TemplateViewModel.swift */; };
+		8FB3EDDC5BF48B634AD7D376 /* CommandPaletteView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8F913C8B009238B21ECFCD4 /* CommandPaletteView.swift */; };
 		924AA688A4D5BF0B708C40A4 /* ApprovalView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B99FD8B1AB490C5124F962DC /* ApprovalView.swift */; };
 		926D953D313C1AF78A9041EE /* MessageBubble.swift in Sources */ = {isa = PBXBuildFile; fileRef = E659E1885E32B1187E8C3703 /* MessageBubble.swift */; };
+		961131A6B840819BB8224A5A /* WorkspaceTreeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7C81160C4EC85E9F1578864 /* WorkspaceTreeView.swift */; };
+		9CD2E53B7E3E03544247C57C /* TemplateEditorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80B617D851AE7C2F2B1A9A15 /* TemplateEditorView.swift */; };
 		9F2F95450060416CA67BA3FB /* OfficeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD500881DC6249D63A9E0ACA /* OfficeView.swift */; };
 		9FE4BFB91ACE225068E13E8F /* AgentSprite.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DD1D371AFD4698EE21925BF /* AgentSprite.swift */; };
 		AECFF1EF021E81589ADBC052 /* Message.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FEBD49051DFF465363BBE2B /* Message.swift */; };
+		B384AD912E4F5F5AC8F5C0AE /* SpeechService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D7AADF76003BF7A6688FCD0 /* SpeechService.swift */; };
 		BB6D1475199DE9F8814F33DE /* PixelArtBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7152E60188E13153CF4B5C85 /* PixelArtBuilder.swift */; };
 		BD4DE18F7D89A6E7BE778875 /* CharacterConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49975C50EF000FB470E30360 /* CharacterConfig.swift */; };
 		BF6D1C0B63D35D14E62F514B /* MajorTomApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CF1FCD49533EE6197E807D1 /* MajorTomApp.swift */; };
 		C9BB54E28A623F2765BB3A95 /* SettingsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A981C64512EE7700D1A27BAB /* SettingsViewModel.swift */; };
 		C9D6EF3F81D2EB74C1C3C741 /* ConnectionViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4862EDC8F8386FEB727657BF /* ConnectionViewModel.swift */; };
+		CBDC742B6AFF453EFD91D131 /* PromptHistoryOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 633B30CEA16034B5B0669A9C /* PromptHistoryOverlay.swift */; };
 		CFCBB89895F30259222DD268 /* ChatViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FA484DB960E122B25A8773F /* ChatViewModel.swift */; };
+		D8FC65BE2DB58265EC48568B /* ContextChipView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8A12203B4DD9D8C97600EC6 /* ContextChipView.swift */; };
 		DEC7A03BAD629CB026FDD77F /* DeviceManagementView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B2D2956D7BBBE520D548CED /* DeviceManagementView.swift */; };
+		E33E3AB2F7B8D363195066CE /* Command.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85D1943B475C9654A302EA24 /* Command.swift */; };
 		E4C11D19C5CBC7B5653532FD /* Theme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 345B4AA475B96036D85853BA /* Theme.swift */; };
 		ECD4CC99C031E1B803D88C76 /* Session.swift in Sources */ = {isa = PBXBuildFile; fileRef = 591E0D4455AD31B2BBD8761C /* Session.swift */; };
 		ED4F918BF0F4278063303B34 /* AuthService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2873A7A68C25BFA4E7C9756 /* AuthService.swift */; };
@@ -44,10 +57,12 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		105C7DF7508529E4C957FEE1 /* PromptTemplate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromptTemplate.swift; sourceTree = "<group>"; };
 		2155A4D6123944C4CDE2BEE8 /* MajorTom.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = MajorTom.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		21F681FC6A3D7B14792DDC15 /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
 		345B4AA475B96036D85853BA /* Theme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Theme.swift; sourceTree = "<group>"; };
 		3AC497E5E769C0087E856232 /* ApprovalCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApprovalCard.swift; sourceTree = "<group>"; };
+		3EFA6BF23E66D2305D236B9B /* TemplateListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TemplateListView.swift; sourceTree = "<group>"; };
 		4862EDC8F8386FEB727657BF /* ConnectionViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectionViewModel.swift; sourceTree = "<group>"; };
 		49975C50EF000FB470E30360 /* CharacterConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CharacterConfig.swift; sourceTree = "<group>"; };
 		4CB6C01422BAAA8E4C996172 /* PairingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PairingView.swift; sourceTree = "<group>"; };
@@ -56,15 +71,20 @@
 		5B2D2956D7BBBE520D548CED /* DeviceManagementView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceManagementView.swift; sourceTree = "<group>"; };
 		5CF1FCD49533EE6197E807D1 /* MajorTomApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MajorTomApp.swift; sourceTree = "<group>"; };
 		5FA484DB960E122B25A8773F /* ChatViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatViewModel.swift; sourceTree = "<group>"; };
+		633B30CEA16034B5B0669A9C /* PromptHistoryOverlay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromptHistoryOverlay.swift; sourceTree = "<group>"; };
 		6657773292DC21D71241871E /* ChatView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatView.swift; sourceTree = "<group>"; };
 		6A6B155FB1E10E586EFA12AC /* AgentInspectorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentInspectorView.swift; sourceTree = "<group>"; };
+		6E56BE06976EFB6DAC4215EE /* VoiceInputButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceInputButton.swift; sourceTree = "<group>"; };
 		6EF58FBAC8341407F9E3E7A0 /* RelayService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RelayService.swift; sourceTree = "<group>"; };
 		7152E60188E13153CF4B5C85 /* PixelArtBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PixelArtBuilder.swift; sourceTree = "<group>"; };
 		73D57C1446E7A203616CCE20 /* StreamingText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StreamingText.swift; sourceTree = "<group>"; };
 		7643A52E74C92A59EFA82ED7 /* OfficeScene.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OfficeScene.swift; sourceTree = "<group>"; };
 		7794C5813F5964F288D432AD /* HapticService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HapticService.swift; sourceTree = "<group>"; };
 		794D98FF20DC91F49542FE7D /* OfficeViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OfficeViewModel.swift; sourceTree = "<group>"; };
+		80B617D851AE7C2F2B1A9A15 /* TemplateEditorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TemplateEditorView.swift; sourceTree = "<group>"; };
+		85D1943B475C9654A302EA24 /* Command.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Command.swift; sourceTree = "<group>"; };
 		8CAFA24AC1299FAEA55E2C0B /* ApprovalRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApprovalRequest.swift; sourceTree = "<group>"; };
+		8D7AADF76003BF7A6688FCD0 /* SpeechService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpeechService.swift; sourceTree = "<group>"; };
 		8DD1D371AFD4698EE21925BF /* AgentSprite.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentSprite.swift; sourceTree = "<group>"; };
 		8FEBD49051DFF465363BBE2B /* Message.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Message.swift; sourceTree = "<group>"; };
 		944EEB19C6C12FD8F9F43846 /* STATUS.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = STATUS.md; sourceTree = "<group>"; };
@@ -76,8 +96,14 @@
 		BD500881DC6249D63A9E0ACA /* OfficeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OfficeView.swift; sourceTree = "<group>"; };
 		C13191C0A248C84CA6959981 /* WebSocketClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebSocketClient.swift; sourceTree = "<group>"; };
 		C3C4E64AF88E24ABC75AB59E /* AgentState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentState.swift; sourceTree = "<group>"; };
+		C7C81160C4EC85E9F1578864 /* WorkspaceTreeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceTreeView.swift; sourceTree = "<group>"; };
 		CC19E99FB3AAD181F192CD3B /* MessageCodec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageCodec.swift; sourceTree = "<group>"; };
+		D7AE4280FD7BB7D618CCA3A8 /* TemplateViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TemplateViewModel.swift; sourceTree = "<group>"; };
+		D8F913C8B009238B21ECFCD4 /* CommandPaletteView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommandPaletteView.swift; sourceTree = "<group>"; };
 		E659E1885E32B1187E8C3703 /* MessageBubble.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageBubble.swift; sourceTree = "<group>"; };
+		E8A12203B4DD9D8C97600EC6 /* ContextChipView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextChipView.swift; sourceTree = "<group>"; };
+		EB6DBE8EE08D1C4498E7F3D4 /* FileContextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileContextView.swift; sourceTree = "<group>"; };
+		F01A77A2D40CD2418227CFFA /* PromptHistoryViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromptHistoryViewModel.swift; sourceTree = "<group>"; };
 		F2E379544E5140C04B00F724 /* ConnectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectionView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -108,6 +134,25 @@
 			path = Connection;
 			sourceTree = "<group>";
 		};
+		06E9597A52B77D414C801735 /* Views */ = {
+			isa = PBXGroup;
+			children = (
+				80B617D851AE7C2F2B1A9A15 /* TemplateEditorView.swift */,
+				3EFA6BF23E66D2305D236B9B /* TemplateListView.swift */,
+			);
+			path = Views;
+			sourceTree = "<group>";
+		};
+		0D3495D5E711CAAE544A8627 /* Templates */ = {
+			isa = PBXGroup;
+			children = (
+				A19055EF8528C2515B617F69 /* Models */,
+				C189C8A34C43110B89B4DD19 /* ViewModels */,
+				06E9597A52B77D414C801735 /* Views */,
+			);
+			path = Templates;
+			sourceTree = "<group>";
+		};
 		14D264EE95E6A3A2AB3E4A5A /* Core */ = {
 			isa = PBXGroup;
 			children = (
@@ -117,6 +162,15 @@
 				D8CCF77A0311B5F82936D83A /* Theme */,
 			);
 			path = Core;
+			sourceTree = "<group>";
+		};
+		16D67653DFF94D2F6CA5D13F /* History */ = {
+			isa = PBXGroup;
+			children = (
+				FF73009FE35D8B38739860F0 /* ViewModels */,
+				FF94BC0EA4424E7ACA1C50B7 /* Views */,
+			);
+			path = History;
 			sourceTree = "<group>";
 		};
 		1BF75AA0800A3C72B67D050E /* Office */ = {
@@ -130,6 +184,22 @@
 				A9495C588A2CD93C84EE00F2 /* Views */,
 			);
 			path = Office;
+			sourceTree = "<group>";
+		};
+		25FCF21458C13583D2DEA379 /* Views */ = {
+			isa = PBXGroup;
+			children = (
+				D8F913C8B009238B21ECFCD4 /* CommandPaletteView.swift */,
+			);
+			path = Views;
+			sourceTree = "<group>";
+		};
+		2DE04EF1BE229D6462CD322F /* Models */ = {
+			isa = PBXGroup;
+			children = (
+				85D1943B475C9654A302EA24 /* Command.swift */,
+			);
+			path = Models;
 			sourceTree = "<group>";
 		};
 		34B945EEC2AEA9029D361F68 /* ViewModels */ = {
@@ -159,6 +229,14 @@
 			path = MajorTom;
 			sourceTree = "<group>";
 		};
+		37D4E55D9070FA5CA8EB5485 /* Components */ = {
+			isa = PBXGroup;
+			children = (
+				E8A12203B4DD9D8C97600EC6 /* ContextChipView.swift */,
+			);
+			path = Components;
+			sourceTree = "<group>";
+		};
 		3A2253D14191C88F64B0A16E /* Control */ = {
 			isa = PBXGroup;
 			children = (
@@ -172,13 +250,26 @@
 		3D3E7D9B1E6A46FE02377CF9 /* Features */ = {
 			isa = PBXGroup;
 			children = (
+				60B9D8DD0297CB0AD458E6CD /* Commands */,
 				048C5B47DA4169F0F6E6B487 /* Connection */,
+				9C0A294A8C067158C29CA98E /* Context */,
 				3A2253D14191C88F64B0A16E /* Control */,
+				16D67653DFF94D2F6CA5D13F /* History */,
 				1BF75AA0800A3C72B67D050E /* Office */,
 				021CB1EE92B194C990B58AAE /* Pairing */,
 				B785C26F2874B8A4F530FD1D /* Settings */,
+				0D3495D5E711CAAE544A8627 /* Templates */,
+				D7711E693CA59FBF6F64E7C9 /* VoiceInput */,
 			);
 			path = Features;
+			sourceTree = "<group>";
+		};
+		3EC915C7297884D2D3328077 /* Services */ = {
+			isa = PBXGroup;
+			children = (
+				8D7AADF76003BF7A6688FCD0 /* SpeechService.swift */,
+			);
+			path = Services;
 			sourceTree = "<group>";
 		};
 		42EB58783C4C82C3775366F2 /* Models */ = {
@@ -219,6 +310,15 @@
 			path = Sprites;
 			sourceTree = "<group>";
 		};
+		60B9D8DD0297CB0AD458E6CD /* Commands */ = {
+			isa = PBXGroup;
+			children = (
+				2DE04EF1BE229D6462CD322F /* Models */,
+				25FCF21458C13583D2DEA379 /* Views */,
+			);
+			path = Commands;
+			sourceTree = "<group>";
+		};
 		64F9566E5318F51B8D12E5B6 /* Views */ = {
 			isa = PBXGroup;
 			children = (
@@ -235,12 +335,38 @@
 			path = Scenes;
 			sourceTree = "<group>";
 		};
+		7465C5CF7B3419BECA466669 /* Views */ = {
+			isa = PBXGroup;
+			children = (
+				EB6DBE8EE08D1C4498E7F3D4 /* FileContextView.swift */,
+				C7C81160C4EC85E9F1578864 /* WorkspaceTreeView.swift */,
+			);
+			path = Views;
+			sourceTree = "<group>";
+		};
 		8C658BE5B9A9D17534D08697 = {
 			isa = PBXGroup;
 			children = (
 				37AE361BC47FFA5B5542D8AF /* MajorTom */,
 				00EBF36EF8823CBEA092949A /* Products */,
 			);
+			sourceTree = "<group>";
+		};
+		9C0A294A8C067158C29CA98E /* Context */ = {
+			isa = PBXGroup;
+			children = (
+				37D4E55D9070FA5CA8EB5485 /* Components */,
+				7465C5CF7B3419BECA466669 /* Views */,
+			);
+			path = Context;
+			sourceTree = "<group>";
+		};
+		A19055EF8528C2515B617F69 /* Models */ = {
+			isa = PBXGroup;
+			children = (
+				105C7DF7508529E4C957FEE1 /* PromptTemplate.swift */,
+			);
+			path = Models;
 			sourceTree = "<group>";
 		};
 		A22D078EA1DE5077E7DCE757 /* App */ = {
@@ -279,7 +405,6 @@
 		B785C26F2874B8A4F530FD1D /* Settings */ = {
 			isa = PBXGroup;
 			children = (
-				F4CC29694F42E4B5FD57C761 /* Components */,
 				D28A628DB467A01A77C6F494 /* ViewModels */,
 				DE1EBD87DDB29A1DB6A9A638 /* Views */,
 			);
@@ -290,6 +415,14 @@
 			isa = PBXGroup;
 			children = (
 				5FA484DB960E122B25A8773F /* ChatViewModel.swift */,
+			);
+			path = ViewModels;
+			sourceTree = "<group>";
+		};
+		C189C8A34C43110B89B4DD19 /* ViewModels */ = {
+			isa = PBXGroup;
+			children = (
+				D7AE4280FD7BB7D618CCA3A8 /* TemplateViewModel.swift */,
 			);
 			path = ViewModels;
 			sourceTree = "<group>";
@@ -321,6 +454,15 @@
 			path = ViewModels;
 			sourceTree = "<group>";
 		};
+		D7711E693CA59FBF6F64E7C9 /* VoiceInput */ = {
+			isa = PBXGroup;
+			children = (
+				3EC915C7297884D2D3328077 /* Services */,
+				FC39392E081668952D1EA97B /* Views */,
+			);
+			path = VoiceInput;
+			sourceTree = "<group>";
+		};
 		D8CCF77A0311B5F82936D83A /* Theme */ = {
 			isa = PBXGroup;
 			children = (
@@ -348,11 +490,28 @@
 			path = Models;
 			sourceTree = "<group>";
 		};
-		F4CC29694F42E4B5FD57C761 /* Components */ = {
+		FC39392E081668952D1EA97B /* Views */ = {
 			isa = PBXGroup;
 			children = (
+				6E56BE06976EFB6DAC4215EE /* VoiceInputButton.swift */,
 			);
-			path = Components;
+			path = Views;
+			sourceTree = "<group>";
+		};
+		FF73009FE35D8B38739860F0 /* ViewModels */ = {
+			isa = PBXGroup;
+			children = (
+				F01A77A2D40CD2418227CFFA /* PromptHistoryViewModel.swift */,
+			);
+			path = ViewModels;
+			sourceTree = "<group>";
+		};
+		FF94BC0EA4424E7ACA1C50B7 /* Views */ = {
+			isa = PBXGroup;
+			children = (
+				633B30CEA16034B5B0669A9C /* PromptHistoryOverlay.swift */,
+			);
+			path = Views;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -436,9 +595,13 @@
 				BD4DE18F7D89A6E7BE778875 /* CharacterConfig.swift in Sources */,
 				6C1C58D6705B5201DC10755F /* ChatView.swift in Sources */,
 				CFCBB89895F30259222DD268 /* ChatViewModel.swift in Sources */,
+				E33E3AB2F7B8D363195066CE /* Command.swift in Sources */,
+				8FB3EDDC5BF48B634AD7D376 /* CommandPaletteView.swift in Sources */,
 				50BB1C73D342CB99FCFD747C /* ConnectionView.swift in Sources */,
 				C9D6EF3F81D2EB74C1C3C741 /* ConnectionViewModel.swift in Sources */,
+				D8FC65BE2DB58265EC48568B /* ContextChipView.swift in Sources */,
 				DEC7A03BAD629CB026FDD77F /* DeviceManagementView.swift in Sources */,
+				05C0C742F30E2EDFA11347D0 /* FileContextView.swift in Sources */,
 				8294293F9EF30CBEED38BFC6 /* HapticService.swift in Sources */,
 				36B33910C927C9BBAC0813A7 /* KeychainService.swift in Sources */,
 				BF6D1C0B63D35D14E62F514B /* MajorTomApp.swift in Sources */,
@@ -452,13 +615,22 @@
 				3320719E65C7D12EC787C929 /* PairingView.swift in Sources */,
 				818FA51F81C18CFE08B3C097 /* PairingViewModel.swift in Sources */,
 				BB6D1475199DE9F8814F33DE /* PixelArtBuilder.swift in Sources */,
+				CBDC742B6AFF453EFD91D131 /* PromptHistoryOverlay.swift in Sources */,
+				241AFDC78C513CD9E223E14B /* PromptHistoryViewModel.swift in Sources */,
+				35BC4313A2E9AFEBD7B113B0 /* PromptTemplate.swift in Sources */,
 				3C07EFEF4D80196CACF66B4F /* RelayService.swift in Sources */,
 				ECD4CC99C031E1B803D88C76 /* Session.swift in Sources */,
 				4F564AFF2C107C396235D252 /* SettingsView.swift in Sources */,
 				C9BB54E28A623F2765BB3A95 /* SettingsViewModel.swift in Sources */,
+				B384AD912E4F5F5AC8F5C0AE /* SpeechService.swift in Sources */,
 				FFB20C4BF1BD6D83D3404F2B /* StreamingText.swift in Sources */,
+				9CD2E53B7E3E03544247C57C /* TemplateEditorView.swift in Sources */,
+				4F038F899716358276CDA57D /* TemplateListView.swift in Sources */,
+				8AF181059859C1E5F1FBEE38 /* TemplateViewModel.swift in Sources */,
 				E4C11D19C5CBC7B5653532FD /* Theme.swift in Sources */,
+				74BC84A25FAE29C592011D14 /* VoiceInputButton.swift in Sources */,
 				6842CC155924DD2F8E828C18 /* WebSocketClient.swift in Sources */,
+				961131A6B840819BB8224A5A /* WorkspaceTreeView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ios/MajorTom/Features/Commands/Models/Command.swift
+++ b/ios/MajorTom/Features/Commands/Models/Command.swift
@@ -1,0 +1,121 @@
+import Foundation
+
+struct SlashCommand: Identifiable {
+    let id: String
+    let name: String
+    let icon: String
+    let description: String
+    let action: CommandAction
+
+    init(name: String, icon: String, description: String, action: CommandAction) {
+        self.id = name
+        self.name = name
+        self.icon = icon
+        self.description = description
+        self.action = action
+    }
+}
+
+enum CommandAction {
+    case newSession
+    case clearChat
+    case switchModel
+    case compactMode
+    case help
+    case showCost
+    case cancel
+    case templates
+    case history
+    case devices
+}
+
+// MARK: - All Commands
+
+extension SlashCommand {
+    static let allCommands: [SlashCommand] = [
+        SlashCommand(
+            name: "new",
+            icon: "plus.circle",
+            description: "Start a new session",
+            action: .newSession
+        ),
+        SlashCommand(
+            name: "clear",
+            icon: "trash",
+            description: "Clear chat messages",
+            action: .clearChat
+        ),
+        SlashCommand(
+            name: "model",
+            icon: "cpu",
+            description: "Switch Claude model",
+            action: .switchModel
+        ),
+        SlashCommand(
+            name: "compact",
+            icon: "rectangle.compress.vertical",
+            description: "Toggle compact mode",
+            action: .compactMode
+        ),
+        SlashCommand(
+            name: "help",
+            icon: "questionmark.circle",
+            description: "Show available commands",
+            action: .help
+        ),
+        SlashCommand(
+            name: "cost",
+            icon: "dollarsign.circle",
+            description: "Show session cost",
+            action: .showCost
+        ),
+        SlashCommand(
+            name: "cancel",
+            icon: "xmark.octagon",
+            description: "Cancel current operation",
+            action: .cancel
+        ),
+        SlashCommand(
+            name: "templates",
+            icon: "doc.text",
+            description: "Open prompt templates",
+            action: .templates
+        ),
+        SlashCommand(
+            name: "history",
+            icon: "clock.arrow.circlepath",
+            description: "Open prompt history",
+            action: .history
+        ),
+        SlashCommand(
+            name: "devices",
+            icon: "desktopcomputer",
+            description: "Show connected devices",
+            action: .devices
+        ),
+    ]
+
+    static func search(_ query: String) -> [SlashCommand] {
+        guard !query.isEmpty else { return allCommands }
+
+        let lowered = query.lowercased()
+        return allCommands.filter { command in
+            fuzzyMatch(query: lowered, target: command.name.lowercased()) ||
+            command.description.lowercased().contains(lowered)
+        }
+    }
+
+    private static func fuzzyMatch(query: String, target: String) -> Bool {
+        var queryIndex = query.startIndex
+        var targetIndex = target.startIndex
+
+        while queryIndex < query.endIndex && targetIndex < target.endIndex {
+            if query[queryIndex] == target[targetIndex] {
+                queryIndex = query.index(after: queryIndex)
+            }
+            targetIndex = target.index(after: targetIndex)
+        }
+
+        return queryIndex == query.endIndex
+    }
+}

--- a/ios/MajorTom/Features/Commands/Views/CommandPaletteView.swift
+++ b/ios/MajorTom/Features/Commands/Views/CommandPaletteView.swift
@@ -1,0 +1,83 @@
+import SwiftUI
+
+struct CommandPaletteView: View {
+    let query: String
+    var onSelectCommand: (SlashCommand) -> Void
+
+    private var commands: [SlashCommand] {
+        SlashCommand.search(query)
+    }
+
+    var body: some View {
+        if !commands.isEmpty {
+            VStack(alignment: .leading, spacing: 0) {
+                ForEach(commands) { command in
+                    commandRow(command)
+
+                    if command.id != commands.last?.id {
+                        Divider()
+                            .background(MajorTomTheme.Colors.textTertiary.opacity(0.2))
+                    }
+                }
+            }
+            .background(MajorTomTheme.Colors.surfaceElevated)
+            .clipShape(RoundedRectangle(cornerRadius: MajorTomTheme.Radius.medium))
+            .shadow(color: .black.opacity(0.3), radius: 10, y: -3)
+            .padding(.horizontal, MajorTomTheme.Spacing.md)
+            .padding(.bottom, MajorTomTheme.Spacing.sm)
+        }
+    }
+
+    private func commandRow(_ command: SlashCommand) -> some View {
+        Button {
+            HapticService.buttonTap()
+            onSelectCommand(command)
+        } label: {
+            HStack(spacing: MajorTomTheme.Spacing.md) {
+                Image(systemName: command.icon)
+                    .font(.body)
+                    .foregroundStyle(MajorTomTheme.Colors.accent)
+                    .frame(width: 24)
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("/\(command.name)")
+                        .font(MajorTomTheme.Typography.headline)
+                        .foregroundStyle(MajorTomTheme.Colors.textPrimary)
+
+                    Text(command.description)
+                        .font(MajorTomTheme.Typography.caption)
+                        .foregroundStyle(MajorTomTheme.Colors.textSecondary)
+                }
+
+                Spacer()
+            }
+            .padding(.horizontal, MajorTomTheme.Spacing.lg)
+            .padding(.vertical, MajorTomTheme.Spacing.md)
+            .contentShape(Rectangle())
+        }
+    }
+}
+
+#Preview {
+    VStack {
+        Spacer()
+        CommandPaletteView(
+            query: "",
+            onSelectCommand: { cmd in print(cmd.name) }
+        )
+    }
+    .background(MajorTomTheme.Colors.background)
+    .preferredColorScheme(.dark)
+}
+
+#Preview("Filtered") {
+    VStack {
+        Spacer()
+        CommandPaletteView(
+            query: "cl",
+            onSelectCommand: { cmd in print(cmd.name) }
+        )
+    }
+    .background(MajorTomTheme.Colors.background)
+    .preferredColorScheme(.dark)
+}

--- a/ios/MajorTom/Features/Context/Components/ContextChipView.swift
+++ b/ios/MajorTom/Features/Context/Components/ContextChipView.swift
@@ -1,0 +1,96 @@
+import SwiftUI
+
+struct ContextChipView: View {
+    let path: String
+    var onRemove: () -> Void
+
+    private var fileName: String {
+        (path as NSString).lastPathComponent
+    }
+
+    private var fileIcon: String {
+        let ext = (fileName as NSString).pathExtension.lowercased()
+        switch ext {
+        case "swift": return "swift"
+        case "ts", "tsx": return "doc.text"
+        case "js", "jsx": return "doc.text"
+        case "json": return "curlybraces"
+        case "md": return "doc.richtext"
+        case "yml", "yaml": return "list.bullet"
+        default: return "doc"
+        }
+    }
+
+    var body: some View {
+        HStack(spacing: MajorTomTheme.Spacing.xs) {
+            Image(systemName: fileIcon)
+                .font(.system(size: 10))
+                .foregroundStyle(MajorTomTheme.Colors.accent)
+
+            Text(fileName)
+                .font(MajorTomTheme.Typography.caption)
+                .foregroundStyle(MajorTomTheme.Colors.textPrimary)
+                .lineLimit(1)
+
+            Button {
+                HapticService.buttonTap()
+                onRemove()
+            } label: {
+                Image(systemName: "xmark")
+                    .font(.system(size: 8, weight: .bold))
+                    .foregroundStyle(MajorTomTheme.Colors.textTertiary)
+            }
+        }
+        .padding(.horizontal, MajorTomTheme.Spacing.sm)
+        .padding(.vertical, MajorTomTheme.Spacing.xs)
+        .background(MajorTomTheme.Colors.surface)
+        .clipShape(Capsule())
+        .overlay(
+            Capsule()
+                .strokeBorder(MajorTomTheme.Colors.accent.opacity(0.3), lineWidth: 1)
+        )
+    }
+}
+
+// MARK: - Context Chips Bar
+
+struct ContextChipsBar: View {
+    let paths: [String]
+    var onRemove: (String) -> Void
+
+    var body: some View {
+        if !paths.isEmpty {
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: MajorTomTheme.Spacing.sm) {
+                    Image(systemName: "at")
+                        .font(.caption2)
+                        .foregroundStyle(MajorTomTheme.Colors.textTertiary)
+
+                    ForEach(paths, id: \.self) { path in
+                        ContextChipView(path: path) {
+                            onRemove(path)
+                        }
+                    }
+                }
+                .padding(.horizontal, MajorTomTheme.Spacing.md)
+                .padding(.vertical, MajorTomTheme.Spacing.sm)
+            }
+            .background(MajorTomTheme.Colors.surface.opacity(0.5))
+        }
+    }
+}
+
+#Preview {
+    VStack(spacing: MajorTomTheme.Spacing.md) {
+        ContextChipView(path: "/src/App.swift") {}
+        ContextChipView(path: "/relay/server.ts") {}
+
+        ContextChipsBar(
+            paths: ["/src/App.swift", "/relay/server.ts", "/package.json"],
+            onRemove: { _ in }
+        )
+    }
+    .padding()
+    .background(MajorTomTheme.Colors.background)
+    .preferredColorScheme(.dark)
+}

--- a/ios/MajorTom/Features/Context/Views/FileContextView.swift
+++ b/ios/MajorTom/Features/Context/Views/FileContextView.swift
@@ -1,0 +1,283 @@
+import SwiftUI
+
+struct FileContextView: View {
+    let relay: RelayService
+    var onFilesSelected: ([String]) -> Void
+    @Binding var isPresented: Bool
+
+    @State private var selectedPaths: Set<String> = []
+    @State private var searchText = ""
+    @State private var isLoading = false
+
+    var body: some View {
+        NavigationStack {
+            VStack(spacing: 0) {
+                if isLoading {
+                    loadingView
+                } else if relay.workspaceFiles.isEmpty {
+                    emptyState
+                } else {
+                    fileTree
+                }
+
+                // Selection summary
+                if !selectedPaths.isEmpty {
+                    selectionBar
+                }
+            }
+            .background(MajorTomTheme.Colors.background)
+            .navigationTitle("Add Context")
+            .navigationBarTitleDisplayMode(.inline)
+            .searchable(text: $searchText, prompt: "Search files")
+            .toolbar {
+                ToolbarItem(placement: .topBarLeading) {
+                    Button("Cancel") {
+                        isPresented = false
+                    }
+                    .foregroundStyle(MajorTomTheme.Colors.textSecondary)
+                }
+
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button("Add") {
+                        HapticService.buttonTap()
+                        onFilesSelected(Array(selectedPaths))
+                        isPresented = false
+                    }
+                    .foregroundStyle(
+                        selectedPaths.isEmpty
+                            ? MajorTomTheme.Colors.textTertiary
+                            : MajorTomTheme.Colors.accent
+                    )
+                    .disabled(selectedPaths.isEmpty)
+                }
+            }
+            .task {
+                await loadWorkspaceTree()
+            }
+        }
+    }
+
+    // MARK: - File Tree
+
+    private var fileTree: some View {
+        List {
+            ForEach(filteredFiles) { node in
+                WorkspaceTreeRow(
+                    node: node,
+                    selectedPaths: $selectedPaths,
+                    searchText: searchText
+                )
+                .listRowBackground(MajorTomTheme.Colors.surface)
+                .listRowSeparatorTint(MajorTomTheme.Colors.textTertiary.opacity(0.2))
+            }
+        }
+        .listStyle(.plain)
+        .scrollContentBackground(.hidden)
+    }
+
+    private var filteredFiles: [FileNode] {
+        guard !searchText.isEmpty else { return relay.workspaceFiles }
+        return filterNodes(relay.workspaceFiles, query: searchText.lowercased())
+    }
+
+    private func filterNodes(_ nodes: [FileNode], query: String) -> [FileNode] {
+        nodes.compactMap { node in
+            if node.name.lowercased().contains(query) {
+                return node
+            }
+            if node.isDirectory, let children = node.children {
+                let filtered = filterNodes(children, query: query)
+                if !filtered.isEmpty {
+                    var copy = node
+                    copy.children = filtered
+                    return copy
+                }
+            }
+            return nil
+        }
+    }
+
+    // MARK: - Selection Bar
+
+    private var selectionBar: some View {
+        HStack(spacing: MajorTomTheme.Spacing.md) {
+            Image(systemName: "doc.on.doc")
+                .foregroundStyle(MajorTomTheme.Colors.accent)
+
+            Text("\(selectedPaths.count) file\(selectedPaths.count == 1 ? "" : "s") selected")
+                .font(MajorTomTheme.Typography.body)
+                .foregroundStyle(MajorTomTheme.Colors.textPrimary)
+
+            Spacer()
+
+            Button {
+                HapticService.buttonTap()
+                selectedPaths.removeAll()
+            } label: {
+                Text("Clear")
+                    .font(MajorTomTheme.Typography.caption)
+                    .foregroundStyle(MajorTomTheme.Colors.deny)
+            }
+        }
+        .padding(MajorTomTheme.Spacing.md)
+        .background(MajorTomTheme.Colors.surface)
+    }
+
+    // MARK: - Loading
+
+    private var loadingView: some View {
+        VStack(spacing: MajorTomTheme.Spacing.lg) {
+            Spacer()
+            ProgressView()
+                .tint(MajorTomTheme.Colors.accent)
+            Text("Loading workspace...")
+                .font(MajorTomTheme.Typography.body)
+                .foregroundStyle(MajorTomTheme.Colors.textSecondary)
+            Spacer()
+        }
+    }
+
+    // MARK: - Empty State
+
+    private var emptyState: some View {
+        VStack(spacing: MajorTomTheme.Spacing.lg) {
+            Spacer()
+            Image(systemName: "folder")
+                .font(.system(size: 48))
+                .foregroundStyle(MajorTomTheme.Colors.textTertiary)
+
+            Text("No workspace files")
+                .font(MajorTomTheme.Typography.headline)
+                .foregroundStyle(MajorTomTheme.Colors.textSecondary)
+
+            Text("Start a session to browse workspace files")
+                .font(MajorTomTheme.Typography.body)
+                .foregroundStyle(MajorTomTheme.Colors.textTertiary)
+            Spacer()
+        }
+        .padding(MajorTomTheme.Spacing.xl)
+    }
+
+    // MARK: - Actions
+
+    private func loadWorkspaceTree() async {
+        isLoading = true
+        defer { isLoading = false }
+
+        do {
+            try await relay.requestWorkspaceTree()
+            // Small delay to let the response come back
+            try? await Task.sleep(for: .milliseconds(500))
+        } catch {
+            // workspace files will remain empty
+        }
+    }
+}
+
+// MARK: - Workspace Tree Row
+
+struct WorkspaceTreeRow: View {
+    let node: FileNode
+    @Binding var selectedPaths: Set<String>
+    var searchText: String
+    var depth: Int = 0
+
+    @State private var isExpanded = false
+
+    private var isSelected: Bool {
+        selectedPaths.contains(node.path)
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            Button {
+                HapticService.buttonTap()
+                if node.isDirectory {
+                    isExpanded.toggle()
+                } else {
+                    toggleSelection()
+                }
+            } label: {
+                HStack(spacing: MajorTomTheme.Spacing.sm) {
+                    // Indent
+                    if depth > 0 {
+                        Spacer()
+                            .frame(width: CGFloat(depth) * 16)
+                    }
+
+                    // Icon
+                    Image(systemName: nodeIcon)
+                        .font(.caption)
+                        .foregroundStyle(node.isDirectory ? MajorTomTheme.Colors.accent : MajorTomTheme.Colors.textSecondary)
+                        .frame(width: 20)
+
+                    // Name
+                    Text(node.name)
+                        .font(MajorTomTheme.Typography.body)
+                        .foregroundStyle(MajorTomTheme.Colors.textPrimary)
+                        .lineLimit(1)
+
+                    Spacer()
+
+                    // Selection indicator
+                    if !node.isDirectory {
+                        Image(systemName: isSelected ? "checkmark.circle.fill" : "circle")
+                            .foregroundStyle(isSelected ? MajorTomTheme.Colors.accent : MajorTomTheme.Colors.textTertiary)
+                    }
+                }
+                .padding(.vertical, MajorTomTheme.Spacing.xs)
+            }
+
+            // Children
+            if node.isDirectory && isExpanded, let children = node.children {
+                ForEach(children) { child in
+                    WorkspaceTreeRow(
+                        node: child,
+                        selectedPaths: $selectedPaths,
+                        searchText: searchText,
+                        depth: depth + 1
+                    )
+                }
+            }
+        }
+        .onAppear {
+            // Auto-expand when searching
+            if !searchText.isEmpty && node.isDirectory {
+                isExpanded = true
+            }
+        }
+    }
+
+    private var nodeIcon: String {
+        if node.isDirectory {
+            return isExpanded ? "folder.fill" : "folder"
+        }
+
+        let ext = (node.name as NSString).pathExtension.lowercased()
+        switch ext {
+        case "swift": return "swift"
+        case "ts", "tsx", "js", "jsx": return "doc.text"
+        case "json": return "curlybraces"
+        case "md": return "doc.richtext"
+        case "yml", "yaml": return "list.bullet"
+        default: return "doc"
+        }
+    }
+
+    private func toggleSelection() {
+        if isSelected {
+            selectedPaths.remove(node.path)
+        } else {
+            selectedPaths.insert(node.path)
+        }
+    }
+}
+
+#Preview {
+    FileContextView(
+        relay: RelayService(),
+        onFilesSelected: { paths in print(paths) },
+        isPresented: .constant(true)
+    )
+    .preferredColorScheme(.dark)
+}

--- a/ios/MajorTom/Features/Context/Views/WorkspaceTreeView.swift
+++ b/ios/MajorTom/Features/Context/Views/WorkspaceTreeView.swift
@@ -1,0 +1,148 @@
+import SwiftUI
+
+struct WorkspaceTreeView: View {
+    let files: [FileNode]
+    @Binding var selectedPaths: Set<String>
+
+    var body: some View {
+        List {
+            ForEach(files) { node in
+                WorkspaceTreeNodeView(
+                    node: node,
+                    selectedPaths: $selectedPaths,
+                    depth: 0
+                )
+                .listRowBackground(MajorTomTheme.Colors.surface)
+                .listRowSeparatorTint(MajorTomTheme.Colors.textTertiary.opacity(0.2))
+            }
+        }
+        .listStyle(.plain)
+        .scrollContentBackground(.hidden)
+    }
+}
+
+// MARK: - Tree Node
+
+struct WorkspaceTreeNodeView: View {
+    let node: FileNode
+    @Binding var selectedPaths: Set<String>
+    let depth: Int
+
+    @State private var isExpanded = false
+
+    private var isSelected: Bool {
+        selectedPaths.contains(node.path)
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            // Node row
+            Button {
+                HapticService.buttonTap()
+                if node.isDirectory {
+                    withAnimation(.spring(duration: 0.2)) {
+                        isExpanded.toggle()
+                    }
+                } else {
+                    if isSelected {
+                        selectedPaths.remove(node.path)
+                    } else {
+                        selectedPaths.insert(node.path)
+                    }
+                }
+            } label: {
+                HStack(spacing: MajorTomTheme.Spacing.sm) {
+                    if depth > 0 {
+                        Spacer()
+                            .frame(width: CGFloat(depth) * 20)
+                    }
+
+                    // Disclosure indicator for directories
+                    if node.isDirectory {
+                        Image(systemName: isExpanded ? "chevron.down" : "chevron.right")
+                            .font(.system(size: 10, weight: .semibold))
+                            .foregroundStyle(MajorTomTheme.Colors.textTertiary)
+                            .frame(width: 12)
+                    } else {
+                        Spacer().frame(width: 12)
+                    }
+
+                    // Icon
+                    Image(systemName: iconForNode)
+                        .font(.caption)
+                        .foregroundStyle(
+                            node.isDirectory
+                                ? MajorTomTheme.Colors.accent
+                                : MajorTomTheme.Colors.textSecondary
+                        )
+
+                    // Name
+                    Text(node.name)
+                        .font(MajorTomTheme.Typography.body)
+                        .foregroundStyle(MajorTomTheme.Colors.textPrimary)
+                        .lineLimit(1)
+
+                    Spacer()
+
+                    // Selection
+                    if !node.isDirectory {
+                        Image(systemName: isSelected ? "checkmark.circle.fill" : "circle")
+                            .foregroundStyle(
+                                isSelected
+                                    ? MajorTomTheme.Colors.accent
+                                    : MajorTomTheme.Colors.textTertiary
+                            )
+                    }
+                }
+                .padding(.vertical, MajorTomTheme.Spacing.xs)
+                .contentShape(Rectangle())
+            }
+
+            // Children
+            if isExpanded, let children = node.children {
+                ForEach(children) { child in
+                    WorkspaceTreeNodeView(
+                        node: child,
+                        selectedPaths: $selectedPaths,
+                        depth: depth + 1
+                    )
+                }
+            }
+        }
+    }
+
+    private var iconForNode: String {
+        if node.isDirectory {
+            return isExpanded ? "folder.fill" : "folder"
+        }
+        let ext = (node.name as NSString).pathExtension.lowercased()
+        switch ext {
+        case "swift": return "swift"
+        case "ts", "tsx", "js", "jsx": return "doc.text"
+        case "json": return "curlybraces"
+        case "md": return "doc.richtext"
+        case "yml", "yaml": return "list.bullet"
+        case "css", "scss": return "paintbrush"
+        case "html": return "globe"
+        case "png", "jpg", "jpeg", "svg": return "photo"
+        default: return "doc"
+        }
+    }
+}
+
+#Preview {
+    WorkspaceTreeView(
+        files: [
+            FileNode(name: "src", path: "/src", isDirectory: true, children: [
+                FileNode(name: "App.swift", path: "/src/App.swift", isDirectory: false, children: nil),
+                FileNode(name: "Models", path: "/src/Models", isDirectory: true, children: [
+                    FileNode(name: "User.swift", path: "/src/Models/User.swift", isDirectory: false, children: nil),
+                ]),
+            ]),
+            FileNode(name: "Package.swift", path: "/Package.swift", isDirectory: false, children: nil),
+        ],
+        selectedPaths: .constant(["/src/App.swift"])
+    )
+    .background(MajorTomTheme.Colors.background)
+    .preferredColorScheme(.dark)
+}

--- a/ios/MajorTom/Features/Control/ViewModels/ChatViewModel.swift
+++ b/ios/MajorTom/Features/Control/ViewModels/ChatViewModel.swift
@@ -6,7 +6,19 @@ final class ChatViewModel {
     var inputText = ""
     var isLoading = false
 
-    private let relay: RelayService
+    // Productivity features
+    var showCommandPalette = false
+    var commandQuery = ""
+    var showFileContext = false
+    var showHistoryOverlay = false
+    var showTemplates = false
+    var contextPaths: [String] = []
+
+    let speechService = SpeechService()
+    let templateViewModel = TemplateViewModel()
+    let historyViewModel = PromptHistoryViewModel()
+
+    private(set) var relay: RelayService
 
     init(relay: RelayService) {
         self.relay = relay
@@ -28,22 +40,55 @@ final class ChatViewModel {
         relay.connectionState
     }
 
+    // MARK: - Input Text Handling
+
+    func handleInputChange(_ newValue: String) {
+        // Detect "/" at start for command palette
+        if newValue.hasPrefix("/") && !newValue.contains(" ") {
+            showCommandPalette = true
+            commandQuery = String(newValue.dropFirst())
+        } else {
+            showCommandPalette = false
+            commandQuery = ""
+        }
+
+        // Detect "@" for file context
+        if newValue.hasSuffix("@") {
+            showFileContext = true
+            // Remove the "@" trigger character
+            inputText = String(newValue.dropLast())
+        }
+    }
+
+    // MARK: - Send
+
     func sendPrompt() async {
         let text = inputText.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !text.isEmpty else { return }
 
+        // Record in history
+        historyViewModel.addEntry(text)
+
+        let context = contextPaths.isEmpty ? nil : contextPaths
         inputText = ""
+        showCommandPalette = false
         isLoading = true
         defer { isLoading = false }
 
+        // Clear context after sending
+        let sentContext = context
+        contextPaths.removeAll()
+
         do {
-            try await relay.sendPrompt(text)
+            try await relay.sendPrompt(text, context: sentContext)
         } catch {
             relay.chatMessages.append(
                 ChatMessage(role: .system, content: "Failed to send: \(error.localizedDescription)")
             )
         }
     }
+
+    // MARK: - Session
 
     func startSession() async {
         do {
@@ -73,5 +118,107 @@ final class ChatViewModel {
                 ChatMessage(role: .system, content: "Failed to cancel: \(error.localizedDescription)")
             )
         }
+    }
+
+    // MARK: - Commands
+
+    func executeCommand(_ command: SlashCommand) {
+        inputText = ""
+        showCommandPalette = false
+
+        switch command.action {
+        case .newSession:
+            Task { await startSession() }
+
+        case .clearChat:
+            relay.chatMessages.removeAll()
+
+        case .switchModel:
+            relay.chatMessages.append(
+                ChatMessage(role: .system, content: "Model switching coming soon")
+            )
+
+        case .compactMode:
+            relay.chatMessages.append(
+                ChatMessage(role: .system, content: "Compact mode coming soon")
+            )
+
+        case .help:
+            let helpText = SlashCommand.allCommands
+                .map { "/\($0.name) — \($0.description)" }
+                .joined(separator: "\n")
+            relay.chatMessages.append(
+                ChatMessage(role: .system, content: "Available commands:\n\(helpText)")
+            )
+
+        case .showCost:
+            let cost = String(format: "$%.4f", relay.sessionCostUsd)
+            let turns = relay.sessionTurnCount
+            relay.chatMessages.append(
+                ChatMessage(role: .system, content: "Session cost: \(cost) | Turns: \(turns)")
+            )
+
+        case .cancel:
+            Task { await cancelOperation() }
+
+        case .templates:
+            showTemplates = true
+
+        case .history:
+            showHistoryOverlay = true
+
+        case .devices:
+            Task { try? await relay.requestDeviceList() }
+            let devices = relay.deviceList
+            let deviceText = devices.isEmpty
+                ? "No devices connected"
+                : devices.map { $0.name }.joined(separator: ", ")
+            relay.chatMessages.append(
+                ChatMessage(role: .system, content: "Devices: \(deviceText)")
+            )
+        }
+    }
+
+    // MARK: - Context
+
+    func addContextFiles(_ paths: [String]) {
+        for path in paths {
+            if !contextPaths.contains(path) {
+                contextPaths.append(path)
+                // Also add server-side context
+                Task {
+                    try? await relay.addContext(path: path, type: .file)
+                }
+            }
+        }
+    }
+
+    func removeContextFile(_ path: String) {
+        contextPaths.removeAll { $0 == path }
+        Task {
+            try? await relay.removeContext(path: path)
+        }
+    }
+
+    // MARK: - Voice
+
+    func handleTranscription(_ text: String) {
+        if inputText.isEmpty {
+            inputText = text
+        } else {
+            inputText += " " + text
+        }
+    }
+
+    // MARK: - Templates
+
+    func insertTemplate(_ content: String) {
+        inputText = content
+    }
+
+    // MARK: - History
+
+    func insertHistoryEntry(_ text: String) {
+        inputText = text
     }
 }

--- a/ios/MajorTom/Features/Control/Views/ChatView.swift
+++ b/ios/MajorTom/Features/Control/Views/ChatView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct ChatView: View {
     @State private var viewModel: ChatViewModel
+    @State private var dragOffset: CGFloat = 0
 
     init(relay: RelayService) {
         _viewModel = State(initialValue: ChatViewModel(relay: relay))
@@ -10,22 +11,78 @@ struct ChatView: View {
     var body: some View {
         @Bindable var viewModel = viewModel
 
-        VStack(spacing: 0) {
-            // Connection status bar
-            connectionBar
+        ZStack(alignment: .bottom) {
+            VStack(spacing: 0) {
+                // Connection status bar
+                connectionBar
 
-            // Pending approvals
-            if !viewModel.pendingApprovals.isEmpty {
-                approvalsList
+                // Pending approvals
+                if !viewModel.pendingApprovals.isEmpty {
+                    approvalsList
+                }
+
+                // Messages
+                messagesList
+
+                // Command palette (above input bar)
+                if viewModel.showCommandPalette {
+                    CommandPaletteView(
+                        query: viewModel.commandQuery,
+                        onSelectCommand: { command in
+                            viewModel.executeCommand(command)
+                        }
+                    )
+                    .transition(.move(edge: .bottom).combined(with: .opacity))
+                }
+
+                // Context chips
+                ContextChipsBar(paths: viewModel.contextPaths) { path in
+                    viewModel.removeContextFile(path)
+                }
+
+                // Input bar
+                inputBar(text: $viewModel.inputText)
             }
+            .background(MajorTomTheme.Colors.background)
 
-            // Messages
-            messagesList
+            // History overlay
+            if viewModel.showHistoryOverlay {
+                Color.black.opacity(0.3)
+                    .ignoresSafeArea()
+                    .onTapGesture {
+                        viewModel.showHistoryOverlay = false
+                    }
 
-            // Input bar
-            inputBar(text: $viewModel.inputText)
+                PromptHistoryOverlay(
+                    viewModel: viewModel.historyViewModel,
+                    onSelectEntry: { text in
+                        viewModel.insertHistoryEntry(text)
+                    },
+                    isPresented: $viewModel.showHistoryOverlay
+                )
+                .frame(maxHeight: 400)
+                .transition(.move(edge: .bottom).combined(with: .opacity))
+            }
         }
-        .background(MajorTomTheme.Colors.background)
+        .animation(.spring(duration: 0.3), value: viewModel.showHistoryOverlay)
+        .animation(.spring(duration: 0.2), value: viewModel.showCommandPalette)
+        .sheet(isPresented: $viewModel.showTemplates) {
+            TemplateListView(
+                viewModel: viewModel.templateViewModel,
+                onSelectTemplate: { content in
+                    viewModel.insertTemplate(content)
+                }
+            )
+        }
+        .sheet(isPresented: $viewModel.showFileContext) {
+            FileContextView(
+                relay: viewModel.relay,
+                onFilesSelected: { paths in
+                    viewModel.addContextFiles(paths)
+                },
+                isPresented: $viewModel.showFileContext
+            )
+        }
         .task {
             if !viewModel.hasSession {
                 await viewModel.startSession()
@@ -103,31 +160,65 @@ struct ChatView: View {
     // MARK: - Input Bar
 
     private func inputBar(text: Binding<String>) -> some View {
-        HStack(spacing: MajorTomTheme.Spacing.md) {
-            TextField("Send a prompt...", text: text, axis: .vertical)
-                .textFieldStyle(.plain)
-                .font(MajorTomTheme.Typography.body)
-                .foregroundStyle(MajorTomTheme.Colors.textPrimary)
-                .lineLimit(1...5)
-                .onSubmit {
-                    Task { await viewModel.sendPrompt() }
-                }
+        VStack(spacing: 0) {
+            HStack(spacing: MajorTomTheme.Spacing.sm) {
+                // Voice input button
+                VoiceInputButton(
+                    speechService: viewModel.speechService,
+                    onTranscription: { transcribed in
+                        viewModel.handleTranscription(transcribed)
+                    }
+                )
 
-            Button {
-                Task { await viewModel.sendPrompt() }
-            } label: {
-                Image(systemName: "arrow.up.circle.fill")
-                    .font(.title2)
-                    .foregroundStyle(
-                        viewModel.inputText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-                            ? MajorTomTheme.Colors.textTertiary
-                            : MajorTomTheme.Colors.accent
-                    )
+                // Text field
+                TextField("Send a prompt...", text: text, axis: .vertical)
+                    .textFieldStyle(.plain)
+                    .font(MajorTomTheme.Typography.body)
+                    .foregroundStyle(MajorTomTheme.Colors.textPrimary)
+                    .lineLimit(1...5)
+                    .onChange(of: viewModel.inputText) { _, newValue in
+                        viewModel.handleInputChange(newValue)
+                    }
+                    .onSubmit {
+                        Task { await viewModel.sendPrompt() }
+                    }
+
+                // Send button
+                Button {
+                    Task { await viewModel.sendPrompt() }
+                } label: {
+                    Image(systemName: "arrow.up.circle.fill")
+                        .font(.title2)
+                        .foregroundStyle(
+                            viewModel.inputText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                                ? MajorTomTheme.Colors.textTertiary
+                                : MajorTomTheme.Colors.accent
+                        )
+                }
+                .disabled(viewModel.inputText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+
+                // Templates button
+                Button {
+                    HapticService.buttonTap()
+                    viewModel.showTemplates = true
+                } label: {
+                    Image(systemName: "doc.text")
+                        .font(.body)
+                        .foregroundStyle(MajorTomTheme.Colors.textSecondary)
+                }
             }
-            .disabled(viewModel.inputText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+            .padding(MajorTomTheme.Spacing.md)
+            .background(MajorTomTheme.Colors.surface)
+            .gesture(
+                DragGesture(minimumDistance: 30)
+                    .onEnded { value in
+                        if value.translation.height < -30 {
+                            HapticService.buttonTap()
+                            viewModel.showHistoryOverlay = true
+                        }
+                    }
+            )
         }
-        .padding(MajorTomTheme.Spacing.md)
-        .background(MajorTomTheme.Colors.surface)
     }
 }
 

--- a/ios/MajorTom/Features/History/ViewModels/PromptHistoryViewModel.swift
+++ b/ios/MajorTom/Features/History/ViewModels/PromptHistoryViewModel.swift
@@ -1,0 +1,105 @@
+import Foundation
+
+@Observable
+@MainActor
+final class PromptHistoryViewModel {
+    var entries: [PromptHistoryEntry] = []
+    var searchText = ""
+
+    private let storageKey = "majortom.prompt_history"
+    private let maxEntries = 100
+
+    init() {
+        loadHistory()
+    }
+
+    // MARK: - Filtered Results
+
+    var filteredEntries: [PromptHistoryEntry] {
+        guard !searchText.isEmpty else { return entries }
+        let query = searchText.lowercased()
+        return entries.filter { $0.text.lowercased().contains(query) }
+    }
+
+    // MARK: - Operations
+
+    func addEntry(_ text: String) {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+
+        // Remove duplicate if exists
+        entries.removeAll { $0.text == trimmed }
+
+        // Add to front
+        let entry = PromptHistoryEntry(text: trimmed)
+        entries.insert(entry, at: 0)
+
+        // Trim to max
+        if entries.count > maxEntries {
+            entries = Array(entries.prefix(maxEntries))
+        }
+
+        saveHistory()
+    }
+
+    func removeEntry(_ entry: PromptHistoryEntry) {
+        entries.removeAll { $0.id == entry.id }
+        saveHistory()
+    }
+
+    func removeEntries(at offsets: IndexSet) {
+        let filtered = filteredEntries
+        for index in offsets {
+            let entry = filtered[index]
+            entries.removeAll { $0.id == entry.id }
+        }
+        saveHistory()
+    }
+
+    func clearHistory() {
+        entries.removeAll()
+        saveHistory()
+    }
+
+    // MARK: - Persistence
+
+    private func loadHistory() {
+        guard let data = UserDefaults.standard.data(forKey: storageKey),
+              let decoded = try? JSONDecoder().decode([PromptHistoryEntry].self, from: data) else {
+            return
+        }
+        entries = decoded
+    }
+
+    private func saveHistory() {
+        guard let data = try? JSONEncoder().encode(entries) else { return }
+        UserDefaults.standard.set(data, forKey: storageKey)
+    }
+}
+
+// MARK: - Model
+
+struct PromptHistoryEntry: Identifiable, Codable, Equatable {
+    let id: UUID
+    let text: String
+    let timestamp: Date
+
+    init(id: UUID = UUID(), text: String, timestamp: Date = Date()) {
+        self.id = id
+        self.text = text
+        self.timestamp = timestamp
+    }
+
+    var relativeTime: String {
+        let formatter = RelativeDateTimeFormatter()
+        formatter.unitsStyle = .abbreviated
+        return formatter.localizedString(for: timestamp, relativeTo: Date())
+    }
+
+    var truncatedText: String {
+        if text.count <= 80 {
+            return text
+        }
+        return String(text.prefix(80)) + "..."
+    }
+}

--- a/ios/MajorTom/Features/History/Views/PromptHistoryOverlay.swift
+++ b/ios/MajorTom/Features/History/Views/PromptHistoryOverlay.swift
@@ -1,0 +1,199 @@
+import SwiftUI
+
+struct PromptHistoryOverlay: View {
+    @Bindable var viewModel: PromptHistoryViewModel
+    var onSelectEntry: (String) -> Void
+    @Binding var isPresented: Bool
+
+    @State private var showClearConfirmation = false
+
+    var body: some View {
+        VStack(spacing: 0) {
+            // Handle bar
+            handleBar
+
+            // Search
+            searchBar
+
+            // History list
+            if viewModel.filteredEntries.isEmpty {
+                emptyState
+            } else {
+                historyList
+            }
+        }
+        .background(MajorTomTheme.Colors.surfaceElevated)
+        .clipShape(RoundedRectangle(cornerRadius: MajorTomTheme.Radius.large))
+        .shadow(color: .black.opacity(0.4), radius: 20, y: -5)
+        .confirmationDialog(
+            "Clear History",
+            isPresented: $showClearConfirmation,
+            titleVisibility: .visible
+        ) {
+            Button("Clear All", role: .destructive) {
+                viewModel.clearHistory()
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text("This will permanently delete all prompt history.")
+        }
+    }
+
+    // MARK: - Handle Bar
+
+    private var handleBar: some View {
+        VStack(spacing: MajorTomTheme.Spacing.sm) {
+            RoundedRectangle(cornerRadius: 3)
+                .fill(MajorTomTheme.Colors.textTertiary)
+                .frame(width: 40, height: 5)
+                .padding(.top, MajorTomTheme.Spacing.md)
+
+            HStack {
+                Text("Prompt History")
+                    .font(MajorTomTheme.Typography.headline)
+                    .foregroundStyle(MajorTomTheme.Colors.textPrimary)
+
+                Spacer()
+
+                if !viewModel.entries.isEmpty {
+                    Button {
+                        HapticService.buttonTap()
+                        showClearConfirmation = true
+                    } label: {
+                        Text("Clear")
+                            .font(MajorTomTheme.Typography.caption)
+                            .foregroundStyle(MajorTomTheme.Colors.deny)
+                    }
+                }
+
+                Button {
+                    HapticService.buttonTap()
+                    isPresented = false
+                } label: {
+                    Image(systemName: "xmark.circle.fill")
+                        .foregroundStyle(MajorTomTheme.Colors.textTertiary)
+                }
+            }
+            .padding(.horizontal, MajorTomTheme.Spacing.lg)
+        }
+    }
+
+    // MARK: - Search
+
+    private var searchBar: some View {
+        HStack(spacing: MajorTomTheme.Spacing.sm) {
+            Image(systemName: "magnifyingglass")
+                .foregroundStyle(MajorTomTheme.Colors.textTertiary)
+
+            TextField("Search history...", text: $viewModel.searchText)
+                .font(MajorTomTheme.Typography.body)
+                .foregroundStyle(MajorTomTheme.Colors.textPrimary)
+
+            if !viewModel.searchText.isEmpty {
+                Button {
+                    viewModel.searchText = ""
+                } label: {
+                    Image(systemName: "xmark.circle.fill")
+                        .foregroundStyle(MajorTomTheme.Colors.textTertiary)
+                }
+            }
+        }
+        .padding(MajorTomTheme.Spacing.md)
+        .background(MajorTomTheme.Colors.surface)
+        .clipShape(RoundedRectangle(cornerRadius: MajorTomTheme.Radius.small))
+        .padding(.horizontal, MajorTomTheme.Spacing.lg)
+        .padding(.vertical, MajorTomTheme.Spacing.sm)
+    }
+
+    // MARK: - History List
+
+    private var historyList: some View {
+        List {
+            ForEach(viewModel.filteredEntries) { entry in
+                historyRow(entry)
+                    .listRowBackground(Color.clear)
+                    .listRowSeparatorTint(MajorTomTheme.Colors.textTertiary.opacity(0.2))
+            }
+            .onDelete { offsets in
+                viewModel.removeEntries(at: offsets)
+            }
+        }
+        .listStyle(.plain)
+        .scrollContentBackground(.hidden)
+    }
+
+    private func historyRow(_ entry: PromptHistoryEntry) -> some View {
+        Button {
+            HapticService.buttonTap()
+            onSelectEntry(entry.text)
+            isPresented = false
+        } label: {
+            HStack(alignment: .top, spacing: MajorTomTheme.Spacing.md) {
+                VStack(alignment: .leading, spacing: MajorTomTheme.Spacing.xs) {
+                    Text(entry.truncatedText)
+                        .font(MajorTomTheme.Typography.body)
+                        .foregroundStyle(MajorTomTheme.Colors.textPrimary)
+                        .lineLimit(2)
+
+                    Text(entry.relativeTime)
+                        .font(MajorTomTheme.Typography.caption)
+                        .foregroundStyle(MajorTomTheme.Colors.textTertiary)
+                }
+
+                Spacer()
+
+                Image(systemName: "arrow.turn.down.left")
+                    .font(.caption)
+                    .foregroundStyle(MajorTomTheme.Colors.textTertiary)
+            }
+            .padding(.vertical, MajorTomTheme.Spacing.xs)
+        }
+    }
+
+    // MARK: - Empty State
+
+    private var emptyState: some View {
+        VStack(spacing: MajorTomTheme.Spacing.md) {
+            Spacer()
+            Image(systemName: "clock.arrow.circlepath")
+                .font(.system(size: 36))
+                .foregroundStyle(MajorTomTheme.Colors.textTertiary)
+
+            Text(viewModel.searchText.isEmpty ? "No history yet" : "No matching prompts")
+                .font(MajorTomTheme.Typography.headline)
+                .foregroundStyle(MajorTomTheme.Colors.textSecondary)
+
+            Text(viewModel.searchText.isEmpty
+                 ? "Your sent prompts will appear here"
+                 : "Try a different search term")
+                .font(MajorTomTheme.Typography.caption)
+                .foregroundStyle(MajorTomTheme.Colors.textTertiary)
+            Spacer()
+        }
+        .padding(MajorTomTheme.Spacing.xl)
+    }
+}
+
+#Preview {
+    ZStack {
+        MajorTomTheme.Colors.background
+            .ignoresSafeArea()
+
+        VStack {
+            Spacer()
+            PromptHistoryOverlay(
+                viewModel: {
+                    let vm = PromptHistoryViewModel()
+                    vm.addEntry("Fix the bug in the authentication flow")
+                    vm.addEntry("Refactor the WebSocket client to use async/await")
+                    vm.addEntry("Add unit tests for the RelayService")
+                    return vm
+                }(),
+                onSelectEntry: { _ in },
+                isPresented: .constant(true)
+            )
+            .frame(height: 400)
+        }
+    }
+    .preferredColorScheme(.dark)
+}

--- a/ios/MajorTom/Features/Templates/Models/PromptTemplate.swift
+++ b/ios/MajorTom/Features/Templates/Models/PromptTemplate.swift
@@ -1,0 +1,51 @@
+import Foundation
+
+struct PromptTemplate: Identifiable, Codable, Equatable {
+    let id: UUID
+    var name: String
+    var content: String
+    var category: TemplateCategory
+    var usageCount: Int
+    var createdAt: Date
+    var lastUsedAt: Date?
+
+    init(
+        id: UUID = UUID(),
+        name: String,
+        content: String,
+        category: TemplateCategory = .general,
+        usageCount: Int = 0,
+        createdAt: Date = Date(),
+        lastUsedAt: Date? = nil
+    ) {
+        self.id = id
+        self.name = name
+        self.content = content
+        self.category = category
+        self.usageCount = usageCount
+        self.createdAt = createdAt
+        self.lastUsedAt = lastUsedAt
+    }
+}
+
+enum TemplateCategory: String, Codable, CaseIterable, Identifiable {
+    case general = "General"
+    case debug = "Debug"
+    case refactor = "Refactor"
+    case review = "Review"
+    case test = "Test"
+    case custom = "Custom"
+
+    var id: String { rawValue }
+
+    var icon: String {
+        switch self {
+        case .general: "text.bubble"
+        case .debug: "ladybug"
+        case .refactor: "arrow.triangle.2.circlepath"
+        case .review: "eye"
+        case .test: "checkmark.shield"
+        case .custom: "star"
+        }
+    }
+}

--- a/ios/MajorTom/Features/Templates/ViewModels/TemplateViewModel.swift
+++ b/ios/MajorTom/Features/Templates/ViewModels/TemplateViewModel.swift
@@ -1,0 +1,136 @@
+import Foundation
+
+@Observable
+@MainActor
+final class TemplateViewModel {
+    var templates: [PromptTemplate] = []
+    var searchText = ""
+    var selectedCategory: TemplateCategory?
+
+    private let storageKey = "majortom.prompt_templates"
+
+    init() {
+        loadTemplates()
+    }
+
+    // MARK: - Filtered Results
+
+    var filteredTemplates: [PromptTemplate] {
+        var result = templates
+
+        if let category = selectedCategory {
+            result = result.filter { $0.category == category }
+        }
+
+        if !searchText.isEmpty {
+            let query = searchText.lowercased()
+            result = result.filter {
+                $0.name.lowercased().contains(query) ||
+                $0.content.lowercased().contains(query)
+            }
+        }
+
+        // Sort by most used, then most recent
+        return result.sorted { a, b in
+            if a.usageCount != b.usageCount {
+                return a.usageCount > b.usageCount
+            }
+            return a.createdAt > b.createdAt
+        }
+    }
+
+    // MARK: - CRUD
+
+    func addTemplate(name: String, content: String, category: TemplateCategory) {
+        let template = PromptTemplate(
+            name: name,
+            content: content,
+            category: category
+        )
+        templates.append(template)
+        saveTemplates()
+    }
+
+    func updateTemplate(_ template: PromptTemplate) {
+        guard let index = templates.firstIndex(where: { $0.id == template.id }) else { return }
+        templates[index] = template
+        saveTemplates()
+    }
+
+    func deleteTemplate(_ template: PromptTemplate) {
+        templates.removeAll { $0.id == template.id }
+        saveTemplates()
+    }
+
+    func deleteTemplates(at offsets: IndexSet) {
+        let sorted = filteredTemplates
+        for index in offsets {
+            let template = sorted[index]
+            templates.removeAll { $0.id == template.id }
+        }
+        saveTemplates()
+    }
+
+    func useTemplate(_ template: PromptTemplate) -> String {
+        guard let index = templates.firstIndex(where: { $0.id == template.id }) else {
+            return template.content
+        }
+        templates[index].usageCount += 1
+        templates[index].lastUsedAt = Date()
+        saveTemplates()
+        return templates[index].content
+    }
+
+    // MARK: - Persistence
+
+    private func loadTemplates() {
+        guard let data = UserDefaults.standard.data(forKey: storageKey),
+              let decoded = try? JSONDecoder().decode([PromptTemplate].self, from: data) else {
+            // Load default templates on first launch
+            templates = Self.defaultTemplates
+            saveTemplates()
+            return
+        }
+        templates = decoded
+    }
+
+    private func saveTemplates() {
+        guard let data = try? JSONEncoder().encode(templates) else { return }
+        UserDefaults.standard.set(data, forKey: storageKey)
+    }
+
+    // MARK: - Defaults
+
+    static let defaultTemplates: [PromptTemplate] = [
+        PromptTemplate(
+            name: "Explain Code",
+            content: "Explain this code in detail, including what it does and why:",
+            category: .general
+        ),
+        PromptTemplate(
+            name: "Find Bug",
+            content: "There's a bug in this code. Help me find and fix it:",
+            category: .debug
+        ),
+        PromptTemplate(
+            name: "Add Tests",
+            content: "Write comprehensive unit tests for:",
+            category: .test
+        ),
+        PromptTemplate(
+            name: "Refactor",
+            content: "Refactor this code to be more readable and maintainable:",
+            category: .refactor
+        ),
+        PromptTemplate(
+            name: "Code Review",
+            content: "Review this code for potential issues, best practices, and improvements:",
+            category: .review
+        ),
+        PromptTemplate(
+            name: "Debug Error",
+            content: "I'm getting this error. Help me understand and fix it:",
+            category: .debug
+        ),
+    ]
+}

--- a/ios/MajorTom/Features/Templates/Views/TemplateEditorView.swift
+++ b/ios/MajorTom/Features/Templates/Views/TemplateEditorView.swift
@@ -1,0 +1,122 @@
+import SwiftUI
+
+struct TemplateEditorView: View {
+    @Bindable var viewModel: TemplateViewModel
+    var existingTemplate: PromptTemplate?
+
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var name = ""
+    @State private var content = ""
+    @State private var category: TemplateCategory = .general
+
+    private var isEditing: Bool { existingTemplate != nil }
+    private var isValid: Bool {
+        !name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty &&
+        !content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section {
+                    TextField("Template name", text: $name)
+                        .foregroundStyle(MajorTomTheme.Colors.textPrimary)
+                } header: {
+                    Text("Name")
+                        .foregroundStyle(MajorTomTheme.Colors.textSecondary)
+                }
+                .listRowBackground(MajorTomTheme.Colors.surface)
+
+                Section {
+                    Picker("Category", selection: $category) {
+                        ForEach(TemplateCategory.allCases) { cat in
+                            Label(cat.rawValue, systemImage: cat.icon)
+                                .tag(cat)
+                        }
+                    }
+                    .foregroundStyle(MajorTomTheme.Colors.textPrimary)
+                } header: {
+                    Text("Category")
+                        .foregroundStyle(MajorTomTheme.Colors.textSecondary)
+                }
+                .listRowBackground(MajorTomTheme.Colors.surface)
+
+                Section {
+                    TextEditor(text: $content)
+                        .foregroundStyle(MajorTomTheme.Colors.textPrimary)
+                        .frame(minHeight: 120)
+                        .scrollContentBackground(.hidden)
+                } header: {
+                    Text("Prompt Content")
+                        .foregroundStyle(MajorTomTheme.Colors.textSecondary)
+                }
+                .listRowBackground(MajorTomTheme.Colors.surface)
+            }
+            .scrollContentBackground(.hidden)
+            .background(MajorTomTheme.Colors.background)
+            .navigationTitle(isEditing ? "Edit Template" : "New Template")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarLeading) {
+                    Button("Cancel") {
+                        dismiss()
+                    }
+                    .foregroundStyle(MajorTomTheme.Colors.textSecondary)
+                }
+
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button(isEditing ? "Save" : "Create") {
+                        HapticService.buttonTap()
+                        saveTemplate()
+                        dismiss()
+                    }
+                    .foregroundStyle(isValid ? MajorTomTheme.Colors.accent : MajorTomTheme.Colors.textTertiary)
+                    .disabled(!isValid)
+                }
+            }
+            .onAppear {
+                if let template = existingTemplate {
+                    name = template.name
+                    content = template.content
+                    category = template.category
+                }
+            }
+        }
+    }
+
+    private func saveTemplate() {
+        let trimmedName = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmedContent = content.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        if var existing = existingTemplate {
+            existing.name = trimmedName
+            existing.content = trimmedContent
+            existing.category = category
+            viewModel.updateTemplate(existing)
+        } else {
+            viewModel.addTemplate(
+                name: trimmedName,
+                content: trimmedContent,
+                category: category
+            )
+        }
+    }
+}
+
+#Preview {
+    TemplateEditorView(viewModel: TemplateViewModel())
+        .preferredColorScheme(.dark)
+}
+
+#Preview("Edit Mode") {
+    TemplateEditorView(
+        viewModel: TemplateViewModel(),
+        existingTemplate: PromptTemplate(
+            name: "Test Template",
+            content: "This is test content",
+            category: .debug
+        )
+    )
+    .preferredColorScheme(.dark)
+}

--- a/ios/MajorTom/Features/Templates/Views/TemplateListView.swift
+++ b/ios/MajorTom/Features/Templates/Views/TemplateListView.swift
@@ -1,0 +1,217 @@
+import SwiftUI
+
+struct TemplateListView: View {
+    @Bindable var viewModel: TemplateViewModel
+    var onSelectTemplate: (String) -> Void
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var showEditor = false
+    @State private var editingTemplate: PromptTemplate?
+
+    var body: some View {
+        NavigationStack {
+            VStack(spacing: 0) {
+                // Category filter
+                categoryFilter
+
+                // Template list
+                if viewModel.filteredTemplates.isEmpty {
+                    emptyState
+                } else {
+                    templateList
+                }
+            }
+            .background(MajorTomTheme.Colors.background)
+            .navigationTitle("Templates")
+            .navigationBarTitleDisplayMode(.inline)
+            .searchable(text: $viewModel.searchText, prompt: "Search templates")
+            .toolbar {
+                ToolbarItem(placement: .topBarLeading) {
+                    Button("Done") {
+                        dismiss()
+                    }
+                    .foregroundStyle(MajorTomTheme.Colors.accent)
+                }
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button {
+                        HapticService.buttonTap()
+                        editingTemplate = nil
+                        showEditor = true
+                    } label: {
+                        Image(systemName: "plus")
+                            .foregroundStyle(MajorTomTheme.Colors.accent)
+                    }
+                }
+            }
+            .sheet(isPresented: $showEditor) {
+                TemplateEditorView(
+                    viewModel: viewModel,
+                    existingTemplate: editingTemplate
+                )
+            }
+        }
+    }
+
+    // MARK: - Category Filter
+
+    private var categoryFilter: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: MajorTomTheme.Spacing.sm) {
+                // "All" chip
+                categoryChip(label: "All", icon: "square.grid.2x2", isSelected: viewModel.selectedCategory == nil) {
+                    viewModel.selectedCategory = nil
+                }
+
+                ForEach(TemplateCategory.allCases) { category in
+                    categoryChip(
+                        label: category.rawValue,
+                        icon: category.icon,
+                        isSelected: viewModel.selectedCategory == category
+                    ) {
+                        viewModel.selectedCategory = category
+                    }
+                }
+            }
+            .padding(.horizontal, MajorTomTheme.Spacing.lg)
+            .padding(.vertical, MajorTomTheme.Spacing.md)
+        }
+        .background(MajorTomTheme.Colors.surface)
+    }
+
+    private func categoryChip(label: String, icon: String, isSelected: Bool, action: @escaping () -> Void) -> some View {
+        Button {
+            HapticService.buttonTap()
+            action()
+        } label: {
+            HStack(spacing: MajorTomTheme.Spacing.xs) {
+                Image(systemName: icon)
+                    .font(.caption)
+                Text(label)
+                    .font(MajorTomTheme.Typography.caption)
+            }
+            .padding(.horizontal, MajorTomTheme.Spacing.md)
+            .padding(.vertical, MajorTomTheme.Spacing.sm)
+            .background(
+                isSelected
+                    ? MajorTomTheme.Colors.accent.opacity(0.2)
+                    : MajorTomTheme.Colors.surfaceElevated
+            )
+            .foregroundStyle(
+                isSelected
+                    ? MajorTomTheme.Colors.accent
+                    : MajorTomTheme.Colors.textSecondary
+            )
+            .clipShape(Capsule())
+        }
+    }
+
+    // MARK: - Template List
+
+    private var templateList: some View {
+        List {
+            ForEach(viewModel.filteredTemplates) { template in
+                templateRow(template)
+                    .listRowBackground(MajorTomTheme.Colors.surface)
+                    .listRowSeparatorTint(MajorTomTheme.Colors.textTertiary.opacity(0.3))
+            }
+            .onDelete { offsets in
+                viewModel.deleteTemplates(at: offsets)
+            }
+        }
+        .listStyle(.plain)
+        .scrollContentBackground(.hidden)
+    }
+
+    private func templateRow(_ template: PromptTemplate) -> some View {
+        Button {
+            HapticService.buttonTap()
+            let content = viewModel.useTemplate(template)
+            onSelectTemplate(content)
+            dismiss()
+        } label: {
+            VStack(alignment: .leading, spacing: MajorTomTheme.Spacing.xs) {
+                HStack {
+                    Image(systemName: template.category.icon)
+                        .font(.caption)
+                        .foregroundStyle(MajorTomTheme.Colors.accent)
+
+                    Text(template.name)
+                        .font(MajorTomTheme.Typography.headline)
+                        .foregroundStyle(MajorTomTheme.Colors.textPrimary)
+
+                    Spacer()
+
+                    if template.usageCount > 0 {
+                        Text("\(template.usageCount) uses")
+                            .font(MajorTomTheme.Typography.caption)
+                            .foregroundStyle(MajorTomTheme.Colors.textTertiary)
+                    }
+                }
+
+                Text(template.content)
+                    .font(MajorTomTheme.Typography.body)
+                    .foregroundStyle(MajorTomTheme.Colors.textSecondary)
+                    .lineLimit(2)
+            }
+            .padding(.vertical, MajorTomTheme.Spacing.xs)
+        }
+        .swipeActions(edge: .trailing) {
+            Button(role: .destructive) {
+                viewModel.deleteTemplate(template)
+            } label: {
+                Label("Delete", systemImage: "trash")
+            }
+
+            Button {
+                editingTemplate = template
+                showEditor = true
+            } label: {
+                Label("Edit", systemImage: "pencil")
+            }
+            .tint(MajorTomTheme.Colors.accent)
+        }
+    }
+
+    // MARK: - Empty State
+
+    private var emptyState: some View {
+        VStack(spacing: MajorTomTheme.Spacing.lg) {
+            Spacer()
+            Image(systemName: "doc.text")
+                .font(.system(size: 48))
+                .foregroundStyle(MajorTomTheme.Colors.textTertiary)
+
+            Text("No templates found")
+                .font(MajorTomTheme.Typography.headline)
+                .foregroundStyle(MajorTomTheme.Colors.textSecondary)
+
+            Text("Create a template to save prompts you use often")
+                .font(MajorTomTheme.Typography.body)
+                .foregroundStyle(MajorTomTheme.Colors.textTertiary)
+                .multilineTextAlignment(.center)
+
+            Button {
+                HapticService.buttonTap()
+                showEditor = true
+            } label: {
+                Text("Create Template")
+                    .font(MajorTomTheme.Typography.headline)
+                    .padding(.horizontal, MajorTomTheme.Spacing.xl)
+                    .padding(.vertical, MajorTomTheme.Spacing.md)
+                    .background(MajorTomTheme.Colors.accent)
+                    .foregroundStyle(.black)
+                    .clipShape(Capsule())
+            }
+            Spacer()
+        }
+        .padding(MajorTomTheme.Spacing.xl)
+    }
+}
+
+#Preview {
+    TemplateListView(
+        viewModel: TemplateViewModel(),
+        onSelectTemplate: { _ in }
+    )
+    .preferredColorScheme(.dark)
+}

--- a/ios/MajorTom/Features/VoiceInput/Services/SpeechService.swift
+++ b/ios/MajorTom/Features/VoiceInput/Services/SpeechService.swift
@@ -1,0 +1,144 @@
+import Foundation
+import Speech
+import AVFoundation
+
+@Observable
+@MainActor
+final class SpeechService {
+    var isRecording = false
+    var transcribedText = ""
+    var isAuthorized = false
+    var errorMessage: String?
+
+    private var recognitionRequest: SFSpeechAudioBufferRecognitionRequest?
+    private var recognitionTask: SFSpeechRecognitionTask?
+    private var audioEngine = AVAudioEngine()
+    private let speechRecognizer = SFSpeechRecognizer(locale: Locale(identifier: "en-US"))
+    private var silenceTimer: Timer?
+    private let silenceTimeout: TimeInterval = 2.0
+
+    func requestAuthorization() async {
+        let speechStatus = await withCheckedContinuation { continuation in
+            SFSpeechRecognizer.requestAuthorization { status in
+                continuation.resume(returning: status)
+            }
+        }
+
+        let audioStatus: Bool
+        if #available(iOS 17.0, *) {
+            audioStatus = await AVAudioApplication.requestRecordPermission()
+        } else {
+            audioStatus = await withCheckedContinuation { continuation in
+                AVAudioSession.sharedInstance().requestRecordPermission { granted in
+                    continuation.resume(returning: granted)
+                }
+            }
+        }
+
+        isAuthorized = speechStatus == .authorized && audioStatus
+        if !isAuthorized {
+            if speechStatus != .authorized {
+                errorMessage = "Speech recognition not authorized"
+            } else {
+                errorMessage = "Microphone access not authorized"
+            }
+        }
+    }
+
+    func startRecording() {
+        guard let speechRecognizer, speechRecognizer.isAvailable else {
+            errorMessage = "Speech recognition unavailable"
+            return
+        }
+
+        // Reset state
+        transcribedText = ""
+        errorMessage = nil
+
+        // Configure audio session
+        let audioSession = AVAudioSession.sharedInstance()
+        do {
+            try audioSession.setCategory(.record, mode: .measurement, options: .duckOthers)
+            try audioSession.setActive(true, options: .notifyOthersOnDeactivation)
+        } catch {
+            errorMessage = "Audio session error: \(error.localizedDescription)"
+            return
+        }
+
+        // Create recognition request
+        recognitionRequest = SFSpeechAudioBufferRecognitionRequest()
+        guard let recognitionRequest else { return }
+        recognitionRequest.shouldReportPartialResults = true
+
+        // Start recognition task
+        recognitionTask = speechRecognizer.recognitionTask(with: recognitionRequest) { [weak self] result, error in
+            Task { @MainActor [weak self] in
+                guard let self else { return }
+
+                if let result {
+                    self.transcribedText = result.bestTranscription.formattedString
+                    self.resetSilenceTimer()
+                }
+
+                if let error {
+                    // Don't report cancellation as an error
+                    let nsError = error as NSError
+                    if nsError.domain != "kAFAssistantErrorDomain" || nsError.code != 216 {
+                        self.errorMessage = error.localizedDescription
+                    }
+                    self.stopRecording()
+                }
+            }
+        }
+
+        // Start audio engine
+        let inputNode = audioEngine.inputNode
+        let recordingFormat = inputNode.outputFormat(forBus: 0)
+        inputNode.installTap(onBus: 0, bufferSize: 1024, format: recordingFormat) { [weak self] buffer, _ in
+            self?.recognitionRequest?.append(buffer)
+        }
+
+        do {
+            audioEngine.prepare()
+            try audioEngine.start()
+            isRecording = true
+            resetSilenceTimer()
+        } catch {
+            errorMessage = "Audio engine error: \(error.localizedDescription)"
+            stopRecording()
+        }
+    }
+
+    func stopRecording() {
+        silenceTimer?.invalidate()
+        silenceTimer = nil
+
+        audioEngine.stop()
+        audioEngine.inputNode.removeTap(onBus: 0)
+        recognitionRequest?.endAudio()
+        recognitionRequest = nil
+        recognitionTask?.cancel()
+        recognitionTask = nil
+        isRecording = false
+
+        let audioSession = AVAudioSession.sharedInstance()
+        try? audioSession.setActive(false, options: .notifyOthersOnDeactivation)
+    }
+
+    func toggleRecording() {
+        if isRecording {
+            stopRecording()
+        } else {
+            startRecording()
+        }
+    }
+
+    private func resetSilenceTimer() {
+        silenceTimer?.invalidate()
+        silenceTimer = Timer.scheduledTimer(withTimeInterval: silenceTimeout, repeats: false) { [weak self] _ in
+            Task { @MainActor [weak self] in
+                self?.stopRecording()
+            }
+        }
+    }
+}

--- a/ios/MajorTom/Features/VoiceInput/Views/VoiceInputButton.swift
+++ b/ios/MajorTom/Features/VoiceInput/Views/VoiceInputButton.swift
@@ -1,0 +1,104 @@
+import SwiftUI
+
+struct VoiceInputButton: View {
+    @Bindable var speechService: SpeechService
+    var onTranscription: (String) -> Void
+
+    @State private var pulseScale: CGFloat = 1.0
+
+    var body: some View {
+        Button {
+            HapticService.buttonTap()
+            handleTap()
+        } label: {
+            ZStack {
+                // Pulsing background when recording
+                if speechService.isRecording {
+                    Circle()
+                        .fill(MajorTomTheme.Colors.deny.opacity(0.3))
+                        .frame(width: 40, height: 40)
+                        .scaleEffect(pulseScale)
+                }
+
+                Image(systemName: speechService.isRecording ? "mic.fill" : "mic")
+                    .font(.title3)
+                    .foregroundStyle(
+                        speechService.isRecording
+                            ? MajorTomTheme.Colors.deny
+                            : MajorTomTheme.Colors.textSecondary
+                    )
+            }
+        }
+        .onChange(of: speechService.isRecording) { _, isRecording in
+            if isRecording {
+                startPulse()
+            } else {
+                pulseScale = 1.0
+                // Send transcription when recording stops
+                let text = speechService.transcribedText.trimmingCharacters(in: .whitespacesAndNewlines)
+                if !text.isEmpty {
+                    onTranscription(text)
+                }
+            }
+        }
+        .popover(isPresented: .constant(speechService.isRecording && !speechService.transcribedText.isEmpty)) {
+            transcriptionPreview
+                .presentationCompactAdaptation(.popover)
+        }
+    }
+
+    private var transcriptionPreview: some View {
+        VStack(alignment: .leading, spacing: MajorTomTheme.Spacing.sm) {
+            HStack(spacing: MajorTomTheme.Spacing.sm) {
+                Circle()
+                    .fill(MajorTomTheme.Colors.deny)
+                    .frame(width: 8, height: 8)
+                Text("Listening...")
+                    .font(MajorTomTheme.Typography.caption)
+                    .foregroundStyle(MajorTomTheme.Colors.textSecondary)
+            }
+
+            Text(speechService.transcribedText)
+                .font(MajorTomTheme.Typography.body)
+                .foregroundStyle(MajorTomTheme.Colors.textPrimary)
+                .lineLimit(3)
+        }
+        .padding(MajorTomTheme.Spacing.md)
+        .frame(maxWidth: 280)
+        .background(MajorTomTheme.Colors.surfaceElevated)
+    }
+
+    private func handleTap() {
+        if !speechService.isAuthorized {
+            Task {
+                await speechService.requestAuthorization()
+                if speechService.isAuthorized {
+                    speechService.toggleRecording()
+                }
+            }
+        } else {
+            speechService.toggleRecording()
+        }
+    }
+
+    private func startPulse() {
+        withAnimation(
+            .easeInOut(duration: 0.8)
+            .repeatForever(autoreverses: true)
+        ) {
+            pulseScale = 1.4
+        }
+    }
+}
+
+#Preview {
+    VoiceInputButton(
+        speechService: SpeechService(),
+        onTranscription: { text in
+            print("Transcribed: \(text)")
+        }
+    )
+    .padding()
+    .background(MajorTomTheme.Colors.background)
+    .preferredColorScheme(.dark)
+}


### PR DESCRIPTION
## Summary
- **Voice input** — SFSpeechRecognizer live transcription, mic button with pulsing red animation, 2s silence auto-stop
- **Prompt templates** — Save/load/search/delete, 6 categories, usage tracking, UserDefaults persistence
- **Prompt history** — Last 100 prompts, swipe-up overlay, search, relative timestamps
- **@file context** — Type "@" to browse workspace tree, multi-select, context chips below input
- **Command palette** — Type "/" for 10 slash commands with fuzzy search (/new, /clear, /cost, etc.)
- 13 new files, 2257 lines added

## Test plan
- [ ] Tap mic button → verify permission request, then live transcription
- [ ] Save a template → verify appears in template list, can be re-used
- [ ] Swipe up on input → verify history overlay with past prompts
- [ ] Type "@" → verify file browser opens, select files → verify chips appear
- [ ] Type "/help" → verify command palette shows, execute shows help

🤖 Generated with [Claude Code](https://claude.com/claude-code)