### PR TITLE
feat(ios): Wave 6 — Session management

### DIFF
--- a/ios/MajorTom.xcodeproj/project.pbxproj
+++ b/ios/MajorTom.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		01CF88DD53BD425A8BB52F59 /* OfficeLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2A5F6ECD6AEA9681C140DA3 /* OfficeLayout.swift */; };
+		1140D09C6E9CA80DD5394F6B /* SessionRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F03B0FF2B39E3FA0F97CA66E /* SessionRowView.swift */; };
 		1ECF57AD1993033DCCF73DB5 /* OfficeViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 794D98FF20DC91F49542FE7D /* OfficeViewModel.swift */; };
 		2CD2BE4AF89623E36046AEF2 /* ApprovalRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CAFA24AC1299FAEA55E2C0B /* ApprovalRequest.swift */; };
 		3320719E65C7D12EC787C929 /* PairingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CB6C01422BAAA8E4C996172 /* PairingView.swift */; };
@@ -25,6 +26,7 @@
 		818FA51F81C18CFE08B3C097 /* PairingViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 526DF9EAD13F47F747C7ACC3 /* PairingViewModel.swift */; };
 		8294293F9EF30CBEED38BFC6 /* HapticService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7794C5813F5964F288D432AD /* HapticService.swift */; };
 		8AD9CF79749CD5BE5EF22487 /* AgentInspectorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A6B155FB1E10E586EFA12AC /* AgentInspectorView.swift */; };
+		8FBFC47F6355543CB70F368F /* SessionListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A571183D8F82C0A0373A42D /* SessionListView.swift */; };
 		924AA688A4D5BF0B708C40A4 /* ApprovalView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B99FD8B1AB490C5124F962DC /* ApprovalView.swift */; };
 		926D953D313C1AF78A9041EE /* MessageBubble.swift in Sources */ = {isa = PBXBuildFile; fileRef = E659E1885E32B1187E8C3703 /* MessageBubble.swift */; };
 		9F2F95450060416CA67BA3FB /* OfficeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD500881DC6249D63A9E0ACA /* OfficeView.swift */; };
@@ -36,6 +38,8 @@
 		C9BB54E28A623F2765BB3A95 /* SettingsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A981C64512EE7700D1A27BAB /* SettingsViewModel.swift */; };
 		C9D6EF3F81D2EB74C1C3C741 /* ConnectionViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4862EDC8F8386FEB727657BF /* ConnectionViewModel.swift */; };
 		CFCBB89895F30259222DD268 /* ChatViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FA484DB960E122B25A8773F /* ChatViewModel.swift */; };
+		DA36546275A88A7B490C69F1 /* SessionStorageService.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4C73E14C8A94C37A496B3FF /* SessionStorageService.swift */; };
+		DAC0C66B42E11C19896C7FC9 /* SessionListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6ED47D05EBAEFF05755F1CF6 /* SessionListViewModel.swift */; };
 		DEC7A03BAD629CB026FDD77F /* DeviceManagementView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B2D2956D7BBBE520D548CED /* DeviceManagementView.swift */; };
 		E4C11D19C5CBC7B5653532FD /* Theme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 345B4AA475B96036D85853BA /* Theme.swift */; };
 		ECD4CC99C031E1B803D88C76 /* Session.swift in Sources */ = {isa = PBXBuildFile; fileRef = 591E0D4455AD31B2BBD8761C /* Session.swift */; };
@@ -44,6 +48,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		0A571183D8F82C0A0373A42D /* SessionListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionListView.swift; sourceTree = "<group>"; };
 		2155A4D6123944C4CDE2BEE8 /* MajorTom.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = MajorTom.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		21F681FC6A3D7B14792DDC15 /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
 		345B4AA475B96036D85853BA /* Theme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Theme.swift; sourceTree = "<group>"; };
@@ -58,6 +63,7 @@
 		5FA484DB960E122B25A8773F /* ChatViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatViewModel.swift; sourceTree = "<group>"; };
 		6657773292DC21D71241871E /* ChatView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatView.swift; sourceTree = "<group>"; };
 		6A6B155FB1E10E586EFA12AC /* AgentInspectorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentInspectorView.swift; sourceTree = "<group>"; };
+		6ED47D05EBAEFF05755F1CF6 /* SessionListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionListViewModel.swift; sourceTree = "<group>"; };
 		6EF58FBAC8341407F9E3E7A0 /* RelayService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RelayService.swift; sourceTree = "<group>"; };
 		7152E60188E13153CF4B5C85 /* PixelArtBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PixelArtBuilder.swift; sourceTree = "<group>"; };
 		73D57C1446E7A203616CCE20 /* StreamingText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StreamingText.swift; sourceTree = "<group>"; };
@@ -78,7 +84,9 @@
 		C3C4E64AF88E24ABC75AB59E /* AgentState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentState.swift; sourceTree = "<group>"; };
 		CC19E99FB3AAD181F192CD3B /* MessageCodec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageCodec.swift; sourceTree = "<group>"; };
 		E659E1885E32B1187E8C3703 /* MessageBubble.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageBubble.swift; sourceTree = "<group>"; };
+		F03B0FF2B39E3FA0F97CA66E /* SessionRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionRowView.swift; sourceTree = "<group>"; };
 		F2E379544E5140C04B00F724 /* ConnectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectionView.swift; sourceTree = "<group>"; };
+		F4C73E14C8A94C37A496B3FF /* SessionStorageService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionStorageService.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXGroup section */
@@ -176,6 +184,7 @@
 				3A2253D14191C88F64B0A16E /* Control */,
 				1BF75AA0800A3C72B67D050E /* Office */,
 				021CB1EE92B194C990B58AAE /* Pairing */,
+				829D205AA8A32D0DEBEF329E /* Sessions */,
 				B785C26F2874B8A4F530FD1D /* Settings */,
 			);
 			path = Features;
@@ -235,6 +244,33 @@
 			path = Scenes;
 			sourceTree = "<group>";
 		};
+		7635D5EE73CB47582AE3A8E9 /* Views */ = {
+			isa = PBXGroup;
+			children = (
+				0A571183D8F82C0A0373A42D /* SessionListView.swift */,
+			);
+			path = Views;
+			sourceTree = "<group>";
+		};
+		78C52C28EFCB196F9FA98F29 /* Components */ = {
+			isa = PBXGroup;
+			children = (
+				F03B0FF2B39E3FA0F97CA66E /* SessionRowView.swift */,
+			);
+			path = Components;
+			sourceTree = "<group>";
+		};
+		829D205AA8A32D0DEBEF329E /* Sessions */ = {
+			isa = PBXGroup;
+			children = (
+				78C52C28EFCB196F9FA98F29 /* Components */,
+				E1395283E6753462041CA77D /* Services */,
+				BFF38BAD48E9A812A5572F80 /* ViewModels */,
+				7635D5EE73CB47582AE3A8E9 /* Views */,
+			);
+			path = Sessions;
+			sourceTree = "<group>";
+		};
 		8C658BE5B9A9D17534D08697 = {
 			isa = PBXGroup;
 			children = (
@@ -279,11 +315,18 @@
 		B785C26F2874B8A4F530FD1D /* Settings */ = {
 			isa = PBXGroup;
 			children = (
-				F4CC29694F42E4B5FD57C761 /* Components */,
 				D28A628DB467A01A77C6F494 /* ViewModels */,
 				DE1EBD87DDB29A1DB6A9A638 /* Views */,
 			);
 			path = Settings;
+			sourceTree = "<group>";
+		};
+		BFF38BAD48E9A812A5572F80 /* ViewModels */ = {
+			isa = PBXGroup;
+			children = (
+				6ED47D05EBAEFF05755F1CF6 /* SessionListViewModel.swift */,
+			);
+			path = ViewModels;
 			sourceTree = "<group>";
 		};
 		C0D9B55A94E1B4F6C888C36E /* ViewModels */ = {
@@ -338,6 +381,14 @@
 			path = Views;
 			sourceTree = "<group>";
 		};
+		E1395283E6753462041CA77D /* Services */ = {
+			isa = PBXGroup;
+			children = (
+				F4C73E14C8A94C37A496B3FF /* SessionStorageService.swift */,
+			);
+			path = Services;
+			sourceTree = "<group>";
+		};
 		E5B5E7A789A6033C62B122B8 /* Models */ = {
 			isa = PBXGroup;
 			children = (
@@ -346,13 +397,6 @@
 				591E0D4455AD31B2BBD8761C /* Session.swift */,
 			);
 			path = Models;
-			sourceTree = "<group>";
-		};
-		F4CC29694F42E4B5FD57C761 /* Components */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			path = Components;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -454,6 +498,10 @@
 				BB6D1475199DE9F8814F33DE /* PixelArtBuilder.swift in Sources */,
 				3C07EFEF4D80196CACF66B4F /* RelayService.swift in Sources */,
 				ECD4CC99C031E1B803D88C76 /* Session.swift in Sources */,
+				8FBFC47F6355543CB70F368F /* SessionListView.swift in Sources */,
+				DAC0C66B42E11C19896C7FC9 /* SessionListViewModel.swift in Sources */,
+				1140D09C6E9CA80DD5394F6B /* SessionRowView.swift in Sources */,
+				DA36546275A88A7B490C69F1 /* SessionStorageService.swift in Sources */,
 				4F564AFF2C107C396235D252 /* SettingsView.swift in Sources */,
 				C9BB54E28A623F2765BB3A95 /* SettingsViewModel.swift in Sources */,
 				FFB20C4BF1BD6D83D3404F2B /* StreamingText.swift in Sources */,

--- a/ios/MajorTom/App/MajorTomApp.swift
+++ b/ios/MajorTom/App/MajorTomApp.swift
@@ -5,6 +5,7 @@ struct MajorTomApp: App {
     @State private var relay = RelayService()
     @State private var officeViewModel = OfficeViewModel()
     @State private var auth = AuthService()
+    @State private var sessionStorage = SessionStorageService()
 
     var body: some Scene {
         WindowGroup {
@@ -33,7 +34,7 @@ struct MajorTomApp: App {
 
     private var mainTabView: some View {
         TabView {
-            ChatView(relay: relay)
+            ChatView(relay: relay, storage: sessionStorage)
                 .tabItem {
                     Label("Control", systemImage: "terminal")
                 }

--- a/ios/MajorTom/Core/Services/RelayService.swift
+++ b/ios/MajorTom/Core/Services/RelayService.swift
@@ -452,14 +452,32 @@ final class RelayService {
 // MARK: - Chat Message Model
 
 struct ChatMessage: Identifiable {
-    let id = UUID()
+    let id: UUID
     let role: ChatRole
     var content: String
-    let timestamp = Date()
+    let timestamp: Date
     var toolName: String?
     var toolStatus: ToolStatus?
     var toolOutput: String?
     var isCollapsed: Bool = true
+
+    init(
+        role: ChatRole,
+        content: String,
+        toolName: String? = nil,
+        toolStatus: ToolStatus? = nil,
+        toolOutput: String? = nil,
+        id: UUID = UUID(),
+        timestamp: Date = Date()
+    ) {
+        self.id = id
+        self.role = role
+        self.content = content
+        self.timestamp = timestamp
+        self.toolName = toolName
+        self.toolStatus = toolStatus
+        self.toolOutput = toolOutput
+    }
 }
 
 enum ChatRole {

--- a/ios/MajorTom/Features/Control/Views/ChatView.swift
+++ b/ios/MajorTom/Features/Control/Views/ChatView.swift
@@ -2,8 +2,15 @@ import SwiftUI
 
 struct ChatView: View {
     @State private var viewModel: ChatViewModel
+    @State private var showSessionList = false
+    @Environment(\.scenePhase) private var scenePhase
 
-    init(relay: RelayService) {
+    private let relay: RelayService
+    private let storage: SessionStorageService
+
+    init(relay: RelayService, storage: SessionStorageService) {
+        self.relay = relay
+        self.storage = storage
         _viewModel = State(initialValue: ChatViewModel(relay: relay))
     }
 
@@ -26,11 +33,25 @@ struct ChatView: View {
             inputBar(text: $viewModel.inputText)
         }
         .background(MajorTomTheme.Colors.background)
+        .sheet(isPresented: $showSessionList) {
+            SessionListView(relay: relay, storage: storage)
+        }
+        .onChange(of: scenePhase) { _, newPhase in
+            if newPhase == .background {
+                saveCurrentSession()
+            }
+        }
         .task {
             if !viewModel.hasSession {
                 await viewModel.startSession()
             }
         }
+    }
+
+    private func saveCurrentSession() {
+        guard let session = relay.currentSession else { return }
+        storage.saveMessages(relay.chatMessages, for: session.id)
+        storage.saveFromSessionInfo(session, messageCount: relay.chatMessages.count)
     }
 
     // MARK: - Connection Bar
@@ -43,7 +64,26 @@ struct ChatView: View {
             Text(viewModel.connectionState.rawValue.capitalized)
                 .font(MajorTomTheme.Typography.caption)
                 .foregroundStyle(MajorTomTheme.Colors.textSecondary)
+
+            if let session = relay.currentSession {
+                Text("·")
+                    .foregroundStyle(MajorTomTheme.Colors.textTertiary)
+                Text(session.workingDir ?? session.id.prefix(8).description)
+                    .font(MajorTomTheme.Typography.caption)
+                    .foregroundStyle(MajorTomTheme.Colors.textSecondary)
+                    .lineLimit(1)
+            }
+
             Spacer()
+
+            Button {
+                showSessionList = true
+                HapticService.buttonTap()
+            } label: {
+                Image(systemName: "list.bullet.rectangle")
+                    .font(.system(size: 16, weight: .medium))
+                    .foregroundStyle(MajorTomTheme.Colors.accent)
+            }
         }
         .padding(.horizontal, MajorTomTheme.Spacing.lg)
         .padding(.vertical, MajorTomTheme.Spacing.sm)
@@ -132,5 +172,5 @@ struct ChatView: View {
 }
 
 #Preview {
-    ChatView(relay: RelayService())
+    ChatView(relay: RelayService(), storage: SessionStorageService())
 }

--- a/ios/MajorTom/Features/Sessions/Components/SessionRowView.swift
+++ b/ios/MajorTom/Features/Sessions/Components/SessionRowView.swift
@@ -1,0 +1,142 @@
+import SwiftUI
+
+struct SessionRowView: View {
+    let session: SessionMetaInfo
+    let isCurrentSession: Bool
+
+    var body: some View {
+        HStack(spacing: MajorTomTheme.Spacing.md) {
+            // Status indicator
+            Circle()
+                .fill(isActive ? MajorTomTheme.Colors.allow : MajorTomTheme.Colors.textTertiary)
+                .frame(width: 10, height: 10)
+
+            VStack(alignment: .leading, spacing: MajorTomTheme.Spacing.xs) {
+                // Working dir name + current indicator
+                HStack(spacing: MajorTomTheme.Spacing.sm) {
+                    Text(session.workingDirName)
+                        .font(MajorTomTheme.Typography.headline)
+                        .foregroundStyle(MajorTomTheme.Colors.textPrimary)
+                        .lineLimit(1)
+
+                    if isCurrentSession {
+                        Text("ACTIVE")
+                            .font(.system(.caption2, design: .default, weight: .bold))
+                            .foregroundStyle(MajorTomTheme.Colors.background)
+                            .padding(.horizontal, 6)
+                            .padding(.vertical, 2)
+                            .background(MajorTomTheme.Colors.accent)
+                            .clipShape(Capsule())
+                    }
+                }
+
+                // Stats row
+                HStack(spacing: MajorTomTheme.Spacing.md) {
+                    Label(formattedCost, systemImage: "dollarsign.circle")
+                    Label(tokenSummary, systemImage: "textformat.size")
+                    Label(formattedDuration, systemImage: "clock")
+                }
+                .font(MajorTomTheme.Typography.caption)
+                .foregroundStyle(MajorTomTheme.Colors.textSecondary)
+                .lineLimit(1)
+            }
+
+            Spacer()
+
+            Image(systemName: "chevron.right")
+                .font(.caption)
+                .foregroundStyle(MajorTomTheme.Colors.textTertiary)
+        }
+        .padding(MajorTomTheme.Spacing.md)
+        .background(
+            isCurrentSession
+                ? MajorTomTheme.Colors.accentSubtle
+                : MajorTomTheme.Colors.surface
+        )
+        .clipShape(RoundedRectangle(cornerRadius: MajorTomTheme.Radius.small))
+        .overlay(
+            RoundedRectangle(cornerRadius: MajorTomTheme.Radius.small)
+                .stroke(
+                    isCurrentSession
+                        ? MajorTomTheme.Colors.accent.opacity(0.4)
+                        : Color.clear,
+                    lineWidth: 1
+                )
+        )
+    }
+
+    // MARK: - Computed
+
+    private var isActive: Bool {
+        session.status == "active"
+    }
+
+    private var formattedCost: String {
+        if session.totalCost < 0.01 {
+            return "<$0.01"
+        }
+        return String(format: "$%.2f", session.totalCost)
+    }
+
+    private var tokenSummary: String {
+        let total = session.inputTokens + session.outputTokens
+        if total >= 1_000_000 {
+            return String(format: "%.1fM tok", Double(total) / 1_000_000)
+        } else if total >= 1_000 {
+            return String(format: "%.1fK tok", Double(total) / 1_000)
+        }
+        return "\(total) tok"
+    }
+
+    private var formattedDuration: String {
+        let seconds = session.totalDuration / 1000
+        if seconds < 60 {
+            return "\(seconds)s"
+        }
+        let minutes = seconds / 60
+        if minutes < 60 {
+            return "\(minutes)m"
+        }
+        let hours = minutes / 60
+        let remainMinutes = minutes % 60
+        return "\(hours)h \(remainMinutes)m"
+    }
+}
+
+#Preview {
+    VStack(spacing: MajorTomTheme.Spacing.sm) {
+        SessionRowView(
+            session: SessionMetaInfo(
+                id: "abc-123",
+                adapter: "cli",
+                workingDirName: "major-tom",
+                status: "active",
+                startedAt: "2024-01-01T12:00:00Z",
+                totalCost: 0.42,
+                inputTokens: 15200,
+                outputTokens: 8300,
+                turnCount: 5,
+                totalDuration: 180000
+            ),
+            isCurrentSession: true
+        )
+
+        SessionRowView(
+            session: SessionMetaInfo(
+                id: "def-456",
+                adapter: "cli",
+                workingDirName: "other-project",
+                status: "ended",
+                startedAt: "2024-01-01T10:00:00Z",
+                totalCost: 1.23,
+                inputTokens: 52000,
+                outputTokens: 31000,
+                turnCount: 12,
+                totalDuration: 720000
+            ),
+            isCurrentSession: false
+        )
+    }
+    .padding()
+    .background(MajorTomTheme.Colors.background)
+}

--- a/ios/MajorTom/Features/Sessions/Services/SessionStorageService.swift
+++ b/ios/MajorTom/Features/Sessions/Services/SessionStorageService.swift
@@ -1,0 +1,175 @@
+import Foundation
+
+/// Persists session transcripts and metadata locally using UserDefaults.
+@Observable
+@MainActor
+final class SessionStorageService {
+    private let defaults = UserDefaults.standard
+    private let metadataKey = "session_metadata_index"
+    private let maxStoredSessions = 50
+
+    // MARK: - Message Persistence
+
+    /// Save chat messages for a session.
+    func saveMessages(_ messages: [ChatMessage], for sessionId: String) {
+        let entries = messages.map { StoredMessage(from: $0) }
+        if let data = try? JSONEncoder().encode(entries) {
+            defaults.set(data, forKey: messageKey(for: sessionId))
+        }
+        updateLastActive(for: sessionId)
+    }
+
+    /// Load chat messages for a session.
+    func loadMessages(for sessionId: String) -> [ChatMessage] {
+        guard let data = defaults.data(forKey: messageKey(for: sessionId)),
+              let entries = try? JSONDecoder().decode([StoredMessage].self, from: data) else {
+            return []
+        }
+        return entries.map { $0.toChatMessage() }
+    }
+
+    /// Remove stored messages for a session.
+    func removeMessages(for sessionId: String) {
+        defaults.removeObject(forKey: messageKey(for: sessionId))
+    }
+
+    // MARK: - Metadata Persistence
+
+    /// Save or update metadata for a session.
+    func saveMetadata(_ meta: StoredSessionMetadata) {
+        var index = loadMetadataIndex()
+        if let existing = index.firstIndex(where: { $0.id == meta.id }) {
+            index[existing] = meta
+        } else {
+            index.append(meta)
+        }
+        // Purge oldest if over limit
+        if index.count > maxStoredSessions {
+            let sorted = index.sorted { $0.lastActive < $1.lastActive }
+            let toPurge = sorted.prefix(index.count - maxStoredSessions)
+            for old in toPurge {
+                removeMessages(for: old.id)
+            }
+            index = Array(sorted.suffix(maxStoredSessions))
+        }
+        saveMetadataIndex(index)
+    }
+
+    /// Load all stored session metadata.
+    func loadAllMetadata() -> [StoredSessionMetadata] {
+        loadMetadataIndex()
+    }
+
+    /// Remove metadata for a session.
+    func removeMetadata(for sessionId: String) {
+        var index = loadMetadataIndex()
+        index.removeAll { $0.id == sessionId }
+        saveMetadataIndex(index)
+        removeMessages(for: sessionId)
+    }
+
+    // MARK: - Helpers
+
+    /// Save metadata for a session from relay info, preserving message count.
+    func saveFromSessionInfo(_ session: RelaySession, messageCount: Int) {
+        let meta = StoredSessionMetadata(
+            id: session.id,
+            adapter: session.adapter.rawValue,
+            workingDir: session.workingDir,
+            lastActive: Date(),
+            messageCount: messageCount
+        )
+        saveMetadata(meta)
+    }
+
+    // MARK: - Private
+
+    private func messageKey(for sessionId: String) -> String {
+        "session_\(sessionId)_messages"
+    }
+
+    private func updateLastActive(for sessionId: String) {
+        var index = loadMetadataIndex()
+        if let i = index.firstIndex(where: { $0.id == sessionId }) {
+            index[i].lastActive = Date()
+            saveMetadataIndex(index)
+        }
+    }
+
+    private func loadMetadataIndex() -> [StoredSessionMetadata] {
+        guard let data = defaults.data(forKey: metadataKey),
+              let index = try? JSONDecoder().decode([StoredSessionMetadata].self, from: data) else {
+            return []
+        }
+        return index
+    }
+
+    private func saveMetadataIndex(_ index: [StoredSessionMetadata]) {
+        if let data = try? JSONEncoder().encode(index) {
+            defaults.set(data, forKey: metadataKey)
+        }
+    }
+}
+
+// MARK: - Stored Models
+
+struct StoredSessionMetadata: Codable, Identifiable {
+    let id: String
+    let adapter: String
+    var workingDir: String?
+    var lastActive: Date
+    var messageCount: Int
+}
+
+struct StoredMessage: Codable {
+    let role: String
+    let content: String
+    let timestamp: Date
+    var toolName: String?
+    var toolStatusRaw: String?
+    var toolOutput: String?
+
+    init(from msg: ChatMessage) {
+        self.role = switch msg.role {
+        case .user: "user"
+        case .assistant: "assistant"
+        case .tool: "tool"
+        case .system: "system"
+        }
+        self.content = msg.content
+        self.timestamp = msg.timestamp
+        self.toolName = msg.toolName
+        self.toolStatusRaw = msg.toolStatus.map { status in
+            switch status {
+            case .running: "running"
+            case .success: "success"
+            case .failure: "failure"
+            }
+        }
+        self.toolOutput = msg.toolOutput
+    }
+
+    func toChatMessage() -> ChatMessage {
+        let chatRole: ChatRole = switch role {
+        case "user": .user
+        case "assistant": .assistant
+        case "tool": .tool
+        default: .system
+        }
+        let toolStatus: ToolStatus? = toolStatusRaw.map { raw in
+            switch raw {
+            case "running": .running
+            case "success": .success
+            case "failure": .failure
+            default: .running
+            }
+        }
+        return ChatMessage(
+            role: chatRole,
+            content: content,
+            toolName: toolName,
+            toolStatus: toolStatus,
+            toolOutput: toolOutput
+        )
+    }
+}

--- a/ios/MajorTom/Features/Sessions/ViewModels/SessionListViewModel.swift
+++ b/ios/MajorTom/Features/Sessions/ViewModels/SessionListViewModel.swift
@@ -1,0 +1,126 @@
+import Foundation
+
+@Observable
+@MainActor
+final class SessionListViewModel {
+    var isLoading = false
+    var newSessionWorkingDir = ""
+    var showNewSessionInput = false
+
+    private let relay: RelayService
+    private let storage: SessionStorageService
+
+    init(relay: RelayService, storage: SessionStorageService) {
+        self.relay = relay
+        self.storage = storage
+    }
+
+    // MARK: - Computed
+
+    var sessions: [SessionMetaInfo] {
+        relay.sessionList
+    }
+
+    var currentSessionId: String? {
+        relay.currentSession?.id
+    }
+
+    var hasCurrentSession: Bool {
+        relay.currentSession != nil
+    }
+
+    // MARK: - Actions
+
+    /// Refresh the session list from the relay.
+    func refreshSessions() async {
+        isLoading = true
+        defer { isLoading = false }
+        do {
+            try await relay.requestSessionList()
+            // Brief pause to let the response arrive
+            try? await Task.sleep(for: .milliseconds(300))
+        } catch {
+            // Silently fail — list will just not update
+        }
+    }
+
+    /// Switch to a different session.
+    func switchToSession(_ session: SessionMetaInfo) async {
+        guard session.id != currentSessionId else { return }
+
+        HapticService.modeSwitch()
+
+        // Save current messages before switching
+        if let currentId = relay.currentSession?.id {
+            storage.saveMessages(relay.chatMessages, for: currentId)
+            storage.saveFromSessionInfo(relay.currentSession!, messageCount: relay.chatMessages.count)
+        }
+
+        // Clear current chat
+        relay.chatMessages.removeAll()
+
+        // Attach to the new session
+        do {
+            try await relay.attachSession(id: session.id)
+            // Brief pause for session.info to arrive
+            try? await Task.sleep(for: .milliseconds(300))
+
+            // Restore locally saved messages for this session
+            let restored = storage.loadMessages(for: session.id)
+            if !restored.isEmpty {
+                relay.chatMessages = restored
+            }
+        } catch {
+            relay.chatMessages.append(
+                ChatMessage(role: .system, content: "Failed to switch session: \(error.localizedDescription)")
+            )
+        }
+    }
+
+    /// Start a new session.
+    func startNewSession() async {
+        HapticService.notification(.success)
+
+        // Save current messages before starting new
+        if let currentId = relay.currentSession?.id {
+            storage.saveMessages(relay.chatMessages, for: currentId)
+            storage.saveFromSessionInfo(relay.currentSession!, messageCount: relay.chatMessages.count)
+        }
+
+        // Clear chat
+        relay.chatMessages.removeAll()
+
+        let dir = newSessionWorkingDir.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        do {
+            try await relay.startSession(
+                adapter: .cli,
+                workingDir: dir.isEmpty ? nil : dir
+            )
+            newSessionWorkingDir = ""
+            showNewSessionInput = false
+        } catch {
+            relay.chatMessages.append(
+                ChatMessage(role: .system, content: "Failed to start session: \(error.localizedDescription)")
+            )
+        }
+    }
+
+    /// Save current session messages (called on backgrounding, etc.)
+    func saveCurrentSession() {
+        guard let session = relay.currentSession else { return }
+        storage.saveMessages(relay.chatMessages, for: session.id)
+        storage.saveFromSessionInfo(session, messageCount: relay.chatMessages.count)
+    }
+
+    /// Restore messages for current session on launch.
+    func restoreCurrentSession() {
+        guard let session = relay.currentSession else { return }
+        if relay.chatMessages.isEmpty {
+            let restored = storage.loadMessages(for: session.id)
+            if !restored.isEmpty {
+                relay.chatMessages = restored
+            }
+        }
+    }
+}

--- a/ios/MajorTom/Features/Sessions/Views/SessionListView.swift
+++ b/ios/MajorTom/Features/Sessions/Views/SessionListView.swift
@@ -1,0 +1,172 @@
+import SwiftUI
+
+struct SessionListView: View {
+    @State private var viewModel: SessionListViewModel
+    @Environment(\.dismiss) private var dismiss
+
+    init(relay: RelayService, storage: SessionStorageService) {
+        _viewModel = State(initialValue: SessionListViewModel(relay: relay, storage: storage))
+    }
+
+    var body: some View {
+        @Bindable var viewModel = viewModel
+
+        NavigationStack {
+            ZStack {
+                MajorTomTheme.Colors.background
+                    .ignoresSafeArea()
+
+                VStack(spacing: 0) {
+                    if viewModel.sessions.isEmpty && !viewModel.isLoading {
+                        emptyState
+                    } else {
+                        sessionsList
+                    }
+
+                    // New session input area
+                    if viewModel.showNewSessionInput {
+                        newSessionBar
+                    }
+                }
+            }
+            .navigationTitle("Sessions")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbarBackground(MajorTomTheme.Colors.surface, for: .navigationBar)
+            .toolbarBackground(.visible, for: .navigationBar)
+            .toolbar {
+                ToolbarItem(placement: .topBarLeading) {
+                    Button("Done") {
+                        dismiss()
+                    }
+                    .foregroundStyle(MajorTomTheme.Colors.accent)
+                }
+
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button {
+                        withAnimation(.spring(duration: 0.3)) {
+                            viewModel.showNewSessionInput.toggle()
+                        }
+                        HapticService.buttonTap()
+                    } label: {
+                        Image(systemName: "plus.circle.fill")
+                            .font(.title3)
+                            .foregroundStyle(MajorTomTheme.Colors.accent)
+                    }
+                }
+            }
+            .task {
+                await viewModel.refreshSessions()
+            }
+        }
+    }
+
+    // MARK: - Sessions List
+
+    private var sessionsList: some View {
+        ScrollView {
+            LazyVStack(spacing: MajorTomTheme.Spacing.sm) {
+                ForEach(viewModel.sessions) { session in
+                    Button {
+                        Task {
+                            await viewModel.switchToSession(session)
+                            dismiss()
+                        }
+                    } label: {
+                        SessionRowView(
+                            session: session,
+                            isCurrentSession: session.id == viewModel.currentSessionId
+                        )
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+            .padding(MajorTomTheme.Spacing.md)
+        }
+        .refreshable {
+            await viewModel.refreshSessions()
+        }
+    }
+
+    // MARK: - Empty State
+
+    private var emptyState: some View {
+        VStack(spacing: MajorTomTheme.Spacing.lg) {
+            Spacer()
+
+            Image(systemName: "terminal.fill")
+                .font(.system(size: 48))
+                .foregroundStyle(MajorTomTheme.Colors.textTertiary)
+
+            Text("No Sessions")
+                .font(MajorTomTheme.Typography.title)
+                .foregroundStyle(MajorTomTheme.Colors.textPrimary)
+
+            Text("Start a new session to begin\nworking with Claude Code.")
+                .font(MajorTomTheme.Typography.body)
+                .foregroundStyle(MajorTomTheme.Colors.textSecondary)
+                .multilineTextAlignment(.center)
+
+            Button {
+                Task {
+                    await viewModel.startNewSession()
+                    dismiss()
+                }
+            } label: {
+                Label("New Session", systemImage: "plus")
+                    .font(MajorTomTheme.Typography.headline)
+                    .foregroundStyle(.white)
+                    .padding(.horizontal, MajorTomTheme.Spacing.xl)
+                    .padding(.vertical, MajorTomTheme.Spacing.md)
+                    .background(MajorTomTheme.Colors.accent)
+                    .clipShape(Capsule())
+            }
+
+            Spacer()
+        }
+        .frame(maxWidth: .infinity)
+    }
+
+    // MARK: - New Session Bar
+
+    private var newSessionBar: some View {
+        @Bindable var viewModel = viewModel
+
+        return VStack(spacing: MajorTomTheme.Spacing.sm) {
+            Divider()
+                .background(MajorTomTheme.Colors.textTertiary)
+
+            HStack(spacing: MajorTomTheme.Spacing.md) {
+                TextField("Working directory (optional)", text: $viewModel.newSessionWorkingDir)
+                    .textFieldStyle(.plain)
+                    .font(MajorTomTheme.Typography.body)
+                    .foregroundStyle(MajorTomTheme.Colors.textPrimary)
+                    .autocorrectionDisabled()
+                    .textInputAutocapitalization(.never)
+
+                Button {
+                    Task {
+                        await viewModel.startNewSession()
+                        dismiss()
+                    }
+                } label: {
+                    Text("Start")
+                        .font(MajorTomTheme.Typography.headline)
+                        .foregroundStyle(.white)
+                        .padding(.horizontal, MajorTomTheme.Spacing.lg)
+                        .padding(.vertical, MajorTomTheme.Spacing.sm)
+                        .background(MajorTomTheme.Colors.accent)
+                        .clipShape(Capsule())
+                }
+            }
+            .padding(.horizontal, MajorTomTheme.Spacing.lg)
+            .padding(.vertical, MajorTomTheme.Spacing.sm)
+        }
+        .background(MajorTomTheme.Colors.surface)
+        .transition(.move(edge: .bottom).combined(with: .opacity))
+    }
+}
+
+#Preview {
+    SessionListView(relay: RelayService(), storage: SessionStorageService())
+        .preferredColorScheme(.dark)
+}


### PR DESCRIPTION
## Summary
- **Session list** — sheet showing all sessions with status, cost, tokens, duration
- **Session switching** — tap to switch, saves/restores per-session chat messages
- **New session** — "+" button with optional working directory input
- **Session persistence** — UserDefaults-backed storage, 50-session LRU purge
- **Session info in connection bar** — shows working dir or session ID prefix
- Auto-save on app background via scenePhase

## Test plan
- [ ] Tap session list button → verify sheet with session list
- [ ] Start new session → verify new entry appears in list
- [ ] Switch sessions → verify chat messages swap correctly
- [ ] Kill and relaunch app → verify session messages restored

🤖 Generated with [Claude Code](https://claude.com/claude-code)