### PR TITLE
feat(ios): Wave 7 — Tool activity feed

### DIFF
--- a/ios/MajorTom.xcodeproj/project.pbxproj
+++ b/ios/MajorTom.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		4F564AFF2C107C396235D252 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21F681FC6A3D7B14792DDC15 /* SettingsView.swift */; };
 		50BB1C73D342CB99FCFD747C /* ConnectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2E379544E5140C04B00F724 /* ConnectionView.swift */; };
 		54DF40806CDE825D4201BB6B /* ApprovalCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AC497E5E769C0087E856232 /* ApprovalCard.swift */; };
+		5C09E77A601A493E96E1CFF9 /* AutoApprovalBadge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F85361488C64454BCBD8D03 /* AutoApprovalBadge.swift */; };
 		6842CC155924DD2F8E828C18 /* WebSocketClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = C13191C0A248C84CA6959981 /* WebSocketClient.swift */; };
 		6C1C58D6705B5201DC10755F /* ChatView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6657773292DC21D71241871E /* ChatView.swift */; };
 		6E4EDEA7EBF6C0B069F3654C /* OfficeScene.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7643A52E74C92A59EFA82ED7 /* OfficeScene.swift */; };
@@ -27,6 +28,7 @@
 		8AD9CF79749CD5BE5EF22487 /* AgentInspectorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A6B155FB1E10E586EFA12AC /* AgentInspectorView.swift */; };
 		924AA688A4D5BF0B708C40A4 /* ApprovalView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B99FD8B1AB490C5124F962DC /* ApprovalView.swift */; };
 		926D953D313C1AF78A9041EE /* MessageBubble.swift in Sources */ = {isa = PBXBuildFile; fileRef = E659E1885E32B1187E8C3703 /* MessageBubble.swift */; };
+		997E92F8DD31136BCC683D65 /* ToolActivityRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A61BDDFAF4D3943E1355934 /* ToolActivityRow.swift */; };
 		9F2F95450060416CA67BA3FB /* OfficeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD500881DC6249D63A9E0ACA /* OfficeView.swift */; };
 		9FE4BFB91ACE225068E13E8F /* AgentSprite.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DD1D371AFD4698EE21925BF /* AgentSprite.swift */; };
 		AECFF1EF021E81589ADBC052 /* Message.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FEBD49051DFF465363BBE2B /* Message.swift */; };
@@ -38,8 +40,10 @@
 		CFCBB89895F30259222DD268 /* ChatViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FA484DB960E122B25A8773F /* ChatViewModel.swift */; };
 		DEC7A03BAD629CB026FDD77F /* DeviceManagementView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B2D2956D7BBBE520D548CED /* DeviceManagementView.swift */; };
 		E4C11D19C5CBC7B5653532FD /* Theme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 345B4AA475B96036D85853BA /* Theme.swift */; };
+		E9273E44A18DFDA65DE049CD /* ToolActivityView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61D2E96EC4746E43CE222912 /* ToolActivityView.swift */; };
 		ECD4CC99C031E1B803D88C76 /* Session.swift in Sources */ = {isa = PBXBuildFile; fileRef = 591E0D4455AD31B2BBD8761C /* Session.swift */; };
 		ED4F918BF0F4278063303B34 /* AuthService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2873A7A68C25BFA4E7C9756 /* AuthService.swift */; };
+		F59B2FB30D83FD15E16BA5D9 /* ToolActivityViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9D0828739E6805328165EA4 /* ToolActivityViewModel.swift */; };
 		FFB20C4BF1BD6D83D3404F2B /* StreamingText.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73D57C1446E7A203616CCE20 /* StreamingText.swift */; };
 /* End PBXBuildFile section */
 
@@ -53,9 +57,11 @@
 		4CB6C01422BAAA8E4C996172 /* PairingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PairingView.swift; sourceTree = "<group>"; };
 		526DF9EAD13F47F747C7ACC3 /* PairingViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PairingViewModel.swift; sourceTree = "<group>"; };
 		591E0D4455AD31B2BBD8761C /* Session.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Session.swift; sourceTree = "<group>"; };
+		5A61BDDFAF4D3943E1355934 /* ToolActivityRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolActivityRow.swift; sourceTree = "<group>"; };
 		5B2D2956D7BBBE520D548CED /* DeviceManagementView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceManagementView.swift; sourceTree = "<group>"; };
 		5CF1FCD49533EE6197E807D1 /* MajorTomApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MajorTomApp.swift; sourceTree = "<group>"; };
 		5FA484DB960E122B25A8773F /* ChatViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatViewModel.swift; sourceTree = "<group>"; };
+		61D2E96EC4746E43CE222912 /* ToolActivityView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolActivityView.swift; sourceTree = "<group>"; };
 		6657773292DC21D71241871E /* ChatView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatView.swift; sourceTree = "<group>"; };
 		6A6B155FB1E10E586EFA12AC /* AgentInspectorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentInspectorView.swift; sourceTree = "<group>"; };
 		6EF58FBAC8341407F9E3E7A0 /* RelayService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RelayService.swift; sourceTree = "<group>"; };
@@ -66,6 +72,7 @@
 		794D98FF20DC91F49542FE7D /* OfficeViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OfficeViewModel.swift; sourceTree = "<group>"; };
 		8CAFA24AC1299FAEA55E2C0B /* ApprovalRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApprovalRequest.swift; sourceTree = "<group>"; };
 		8DD1D371AFD4698EE21925BF /* AgentSprite.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentSprite.swift; sourceTree = "<group>"; };
+		8F85361488C64454BCBD8D03 /* AutoApprovalBadge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoApprovalBadge.swift; sourceTree = "<group>"; };
 		8FEBD49051DFF465363BBE2B /* Message.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Message.swift; sourceTree = "<group>"; };
 		944EEB19C6C12FD8F9F43846 /* STATUS.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = STATUS.md; sourceTree = "<group>"; };
 		A2873A7A68C25BFA4E7C9756 /* AuthService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthService.swift; sourceTree = "<group>"; };
@@ -76,6 +83,7 @@
 		BD500881DC6249D63A9E0ACA /* OfficeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OfficeView.swift; sourceTree = "<group>"; };
 		C13191C0A248C84CA6959981 /* WebSocketClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebSocketClient.swift; sourceTree = "<group>"; };
 		C3C4E64AF88E24ABC75AB59E /* AgentState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentState.swift; sourceTree = "<group>"; };
+		C9D0828739E6805328165EA4 /* ToolActivityViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolActivityViewModel.swift; sourceTree = "<group>"; };
 		CC19E99FB3AAD181F192CD3B /* MessageCodec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageCodec.swift; sourceTree = "<group>"; };
 		E659E1885E32B1187E8C3703 /* MessageBubble.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageBubble.swift; sourceTree = "<group>"; };
 		F2E379544E5140C04B00F724 /* ConnectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectionView.swift; sourceTree = "<group>"; };
@@ -132,10 +140,28 @@
 			path = Office;
 			sourceTree = "<group>";
 		};
+		28C5FCC112193F6E8C1391E1 /* Activity */ = {
+			isa = PBXGroup;
+			children = (
+				5E48C48CEE4EDC861660BC34 /* Components */,
+				351A065FCE725D382BCEE281 /* ViewModels */,
+				ED9CCB7F79B02F16C1507DE1 /* Views */,
+			);
+			path = Activity;
+			sourceTree = "<group>";
+		};
 		34B945EEC2AEA9029D361F68 /* ViewModels */ = {
 			isa = PBXGroup;
 			children = (
 				526DF9EAD13F47F747C7ACC3 /* PairingViewModel.swift */,
+			);
+			path = ViewModels;
+			sourceTree = "<group>";
+		};
+		351A065FCE725D382BCEE281 /* ViewModels */ = {
+			isa = PBXGroup;
+			children = (
+				C9D0828739E6805328165EA4 /* ToolActivityViewModel.swift */,
 			);
 			path = ViewModels;
 			sourceTree = "<group>";
@@ -172,6 +198,7 @@
 		3D3E7D9B1E6A46FE02377CF9 /* Features */ = {
 			isa = PBXGroup;
 			children = (
+				28C5FCC112193F6E8C1391E1 /* Activity */,
 				048C5B47DA4169F0F6E6B487 /* Connection */,
 				3A2253D14191C88F64B0A16E /* Control */,
 				1BF75AA0800A3C72B67D050E /* Office */,
@@ -217,6 +244,15 @@
 				7152E60188E13153CF4B5C85 /* PixelArtBuilder.swift */,
 			);
 			path = Sprites;
+			sourceTree = "<group>";
+		};
+		5E48C48CEE4EDC861660BC34 /* Components */ = {
+			isa = PBXGroup;
+			children = (
+				8F85361488C64454BCBD8D03 /* AutoApprovalBadge.swift */,
+				5A61BDDFAF4D3943E1355934 /* ToolActivityRow.swift */,
+			);
+			path = Components;
 			sourceTree = "<group>";
 		};
 		64F9566E5318F51B8D12E5B6 /* Views */ = {
@@ -279,7 +315,6 @@
 		B785C26F2874B8A4F530FD1D /* Settings */ = {
 			isa = PBXGroup;
 			children = (
-				F4CC29694F42E4B5FD57C761 /* Components */,
 				D28A628DB467A01A77C6F494 /* ViewModels */,
 				DE1EBD87DDB29A1DB6A9A638 /* Views */,
 			);
@@ -348,11 +383,12 @@
 			path = Models;
 			sourceTree = "<group>";
 		};
-		F4CC29694F42E4B5FD57C761 /* Components */ = {
+		ED9CCB7F79B02F16C1507DE1 /* Views */ = {
 			isa = PBXGroup;
 			children = (
+				61D2E96EC4746E43CE222912 /* ToolActivityView.swift */,
 			);
-			path = Components;
+			path = Views;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -433,6 +469,7 @@
 				2CD2BE4AF89623E36046AEF2 /* ApprovalRequest.swift in Sources */,
 				924AA688A4D5BF0B708C40A4 /* ApprovalView.swift in Sources */,
 				ED4F918BF0F4278063303B34 /* AuthService.swift in Sources */,
+				5C09E77A601A493E96E1CFF9 /* AutoApprovalBadge.swift in Sources */,
 				BD4DE18F7D89A6E7BE778875 /* CharacterConfig.swift in Sources */,
 				6C1C58D6705B5201DC10755F /* ChatView.swift in Sources */,
 				CFCBB89895F30259222DD268 /* ChatViewModel.swift in Sources */,
@@ -458,6 +495,9 @@
 				C9BB54E28A623F2765BB3A95 /* SettingsViewModel.swift in Sources */,
 				FFB20C4BF1BD6D83D3404F2B /* StreamingText.swift in Sources */,
 				E4C11D19C5CBC7B5653532FD /* Theme.swift in Sources */,
+				997E92F8DD31136BCC683D65 /* ToolActivityRow.swift in Sources */,
+				E9273E44A18DFDA65DE049CD /* ToolActivityView.swift in Sources */,
+				F59B2FB30D83FD15E16BA5D9 /* ToolActivityViewModel.swift in Sources */,
 				6842CC155924DD2F8E828C18 /* WebSocketClient.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/ios/MajorTom/Features/Activity/Components/AutoApprovalBadge.swift
+++ b/ios/MajorTom/Features/Activity/Components/AutoApprovalBadge.swift
@@ -1,0 +1,61 @@
+import SwiftUI
+
+struct AutoApprovalBadge: View {
+    let reason: AutoApprovalReason
+
+    var body: some View {
+        HStack(spacing: MajorTomTheme.Spacing.xs) {
+            Image(systemName: iconName)
+                .font(.system(size: 8))
+            Text(label)
+                .font(.system(size: 9, weight: .medium, design: .default))
+        }
+        .foregroundStyle(badgeColor)
+        .padding(.horizontal, 6)
+        .padding(.vertical, 2)
+        .background(badgeColor.opacity(0.15))
+        .clipShape(Capsule())
+    }
+
+    private var label: String {
+        switch reason {
+        case .smartSettings, .smartSession:
+            return "Smart"
+        case .godYolo, .godNormal:
+            return "God"
+        }
+    }
+
+    private var iconName: String {
+        switch reason {
+        case .smartSettings, .smartSession:
+            return "brain"
+        case .godYolo:
+            return "bolt.fill"
+        case .godNormal:
+            return "crown.fill"
+        }
+    }
+
+    private var badgeColor: Color {
+        switch reason {
+        case .smartSettings, .smartSession:
+            return MajorTomTheme.Colors.accent
+        case .godYolo:
+            return MajorTomTheme.Colors.danger
+        case .godNormal:
+            return MajorTomTheme.Colors.warning
+        }
+    }
+}
+
+#Preview {
+    VStack(spacing: 12) {
+        AutoApprovalBadge(reason: .smartSettings)
+        AutoApprovalBadge(reason: .smartSession)
+        AutoApprovalBadge(reason: .godNormal)
+        AutoApprovalBadge(reason: .godYolo)
+    }
+    .padding()
+    .background(MajorTomTheme.Colors.background)
+}

--- a/ios/MajorTom/Features/Activity/Components/ToolActivityRow.swift
+++ b/ios/MajorTom/Features/Activity/Components/ToolActivityRow.swift
@@ -1,0 +1,213 @@
+import SwiftUI
+
+struct ToolActivityRow: View {
+    let activity: ToolActivity
+    var autoApproval: AutoApprovedTool?
+
+    var body: some View {
+        HStack(spacing: MajorTomTheme.Spacing.md) {
+            // Tool icon
+            Image(systemName: toolIcon)
+                .font(.system(size: 16, weight: .medium))
+                .foregroundStyle(MajorTomTheme.Colors.accent)
+                .frame(width: 28, height: 28)
+                .background(MajorTomTheme.Colors.accent.opacity(0.12))
+                .clipShape(RoundedRectangle(cornerRadius: 6))
+
+            // Tool info
+            VStack(alignment: .leading, spacing: 2) {
+                HStack(spacing: MajorTomTheme.Spacing.sm) {
+                    Text(activity.tool)
+                        .font(MajorTomTheme.Typography.headline)
+                        .foregroundStyle(MajorTomTheme.Colors.textPrimary)
+
+                    if let autoApproval {
+                        AutoApprovalBadge(reason: autoApproval.reason)
+                    }
+                }
+
+                if let inputDescription = formatInput(activity.input) {
+                    Text(inputDescription)
+                        .font(MajorTomTheme.Typography.codeFontSmall)
+                        .foregroundStyle(MajorTomTheme.Colors.textTertiary)
+                        .lineLimit(1)
+                        .truncationMode(.tail)
+                }
+            }
+
+            Spacer()
+
+            // Status indicator
+            statusView
+        }
+        .padding(.vertical, MajorTomTheme.Spacing.sm)
+        .padding(.horizontal, MajorTomTheme.Spacing.md)
+    }
+
+    // MARK: - Tool Icon Mapping
+
+    private var toolIcon: String {
+        switch activity.tool.lowercased() {
+        case "bash":
+            return "terminal"
+        case "read":
+            return "doc.text"
+        case "write":
+            return "doc.text.fill"
+        case "edit":
+            return "pencil"
+        case "glob":
+            return "magnifyingglass"
+        case "grep":
+            return "text.magnifyingglass"
+        case "agent":
+            return "person.2"
+        default:
+            return "wrench"
+        }
+    }
+
+    // MARK: - Status View
+
+    @ViewBuilder
+    private var statusView: some View {
+        if activity.isRunning {
+            HStack(spacing: MajorTomTheme.Spacing.xs) {
+                ProgressView()
+                    .controlSize(.small)
+                    .tint(MajorTomTheme.Colors.accent)
+                Text("Running...")
+                    .font(MajorTomTheme.Typography.caption)
+                    .foregroundStyle(MajorTomTheme.Colors.accent)
+            }
+        } else if activity.success == true {
+            HStack(spacing: MajorTomTheme.Spacing.xs) {
+                Image(systemName: "checkmark.circle.fill")
+                    .font(.system(size: 14))
+                    .foregroundStyle(MajorTomTheme.Colors.allow)
+                Text(formattedDuration)
+                    .font(MajorTomTheme.Typography.caption)
+                    .foregroundStyle(MajorTomTheme.Colors.textSecondary)
+            }
+        } else {
+            HStack(spacing: MajorTomTheme.Spacing.xs) {
+                Image(systemName: "xmark.circle.fill")
+                    .font(.system(size: 14))
+                    .foregroundStyle(MajorTomTheme.Colors.deny)
+                Text("Failed")
+                    .font(MajorTomTheme.Typography.caption)
+                    .foregroundStyle(MajorTomTheme.Colors.deny)
+            }
+        }
+    }
+
+    // MARK: - Duration Formatting
+
+    private var formattedDuration: String {
+        guard let duration = activity.duration else { return "" }
+        if duration < 1 {
+            return String(format: "%.0fms", duration * 1000)
+        } else if duration < 60 {
+            return String(format: "%.1fs", duration)
+        } else {
+            let minutes = Int(duration) / 60
+            let seconds = Int(duration) % 60
+            return "\(minutes)m\(seconds)s"
+        }
+    }
+
+    // MARK: - Input Formatting
+
+    private func formatInput(_ input: [String: AnyCodableValue]?) -> String? {
+        guard let input else { return nil }
+
+        // Try common input fields in order of usefulness
+        if let command = input["command"]?.stringValue {
+            return command
+        }
+        if let filePath = input["file_path"]?.stringValue {
+            return filePath
+        }
+        if let path = input["path"]?.stringValue {
+            return path
+        }
+        if let pattern = input["pattern"]?.stringValue {
+            return pattern
+        }
+        if let content = input["content"]?.stringValue {
+            let truncated = content.prefix(80)
+            return String(truncated)
+        }
+
+        // Fallback: show first string value
+        for (_, value) in input {
+            if let str = value.stringValue {
+                return String(str.prefix(80))
+            }
+        }
+
+        return nil
+    }
+}
+
+#Preview("Running") {
+    ToolActivityRow(
+        activity: ToolActivity(
+            id: "1",
+            tool: "Bash",
+            input: ["command": .string("npm install")],
+            startedAt: Date()
+        )
+    )
+    .background(MajorTomTheme.Colors.surface)
+}
+
+#Preview("Success") {
+    ToolActivityRow(
+        activity: ToolActivity(
+            id: "2",
+            tool: "Read",
+            input: ["file_path": .string("/src/index.ts")],
+            startedAt: Date().addingTimeInterval(-1.2),
+            completedAt: Date(),
+            success: true,
+            output: "file contents..."
+        )
+    )
+    .background(MajorTomTheme.Colors.surface)
+}
+
+#Preview("Failed") {
+    ToolActivityRow(
+        activity: ToolActivity(
+            id: "3",
+            tool: "Write",
+            input: ["file_path": .string("/etc/hosts")],
+            startedAt: Date().addingTimeInterval(-0.5),
+            completedAt: Date(),
+            success: false,
+            output: "Permission denied"
+        )
+    )
+    .background(MajorTomTheme.Colors.surface)
+}
+
+#Preview("Auto-approved") {
+    ToolActivityRow(
+        activity: ToolActivity(
+            id: "4",
+            tool: "Grep",
+            input: ["pattern": .string("TODO")],
+            startedAt: Date().addingTimeInterval(-0.3),
+            completedAt: Date(),
+            success: true
+        ),
+        autoApproval: AutoApprovedTool(
+            tool: "Grep",
+            description: "Search for TODO",
+            reason: .smartSettings,
+            timestamp: Date()
+        )
+    )
+    .background(MajorTomTheme.Colors.surface)
+}

--- a/ios/MajorTom/Features/Activity/ViewModels/ToolActivityViewModel.swift
+++ b/ios/MajorTom/Features/Activity/ViewModels/ToolActivityViewModel.swift
@@ -1,0 +1,80 @@
+import Foundation
+
+@Observable
+@MainActor
+final class ToolActivityViewModel {
+    enum Tab: String, CaseIterable {
+        case active = "Active"
+        case all = "All"
+    }
+
+    var selectedTab: Tab = .active
+    var isPanelExpanded = false
+
+    private let relay: RelayService
+
+    init(relay: RelayService) {
+        self.relay = relay
+    }
+
+    // MARK: - Data Access
+
+    var activeTools: [ToolActivity] {
+        relay.activeTools
+    }
+
+    var completedTools: [ToolActivity] {
+        relay.completedTools
+    }
+
+    var autoApprovedTools: [AutoApprovedTool] {
+        relay.autoApprovedTools
+    }
+
+    // MARK: - Computed Properties
+
+    var totalToolCount: Int {
+        activeTools.count + completedTools.count
+    }
+
+    var runningCount: Int {
+        activeTools.count
+    }
+
+    var failedCount: Int {
+        completedTools.filter { $0.success == false }.count
+    }
+
+    /// All tools sorted: active first, then completed (most recent first).
+    var allToolsSorted: [ToolActivity] {
+        let sortedActive = activeTools.sorted { $0.startedAt > $1.startedAt }
+        let sortedCompleted = completedTools.sorted {
+            ($0.completedAt ?? $0.startedAt) > ($1.completedAt ?? $1.startedAt)
+        }
+        return sortedActive + sortedCompleted
+    }
+
+    /// Tools for the currently selected tab.
+    var displayedTools: [ToolActivity] {
+        switch selectedTab {
+        case .active:
+            return activeTools.sorted { $0.startedAt > $1.startedAt }
+        case .all:
+            return allToolsSorted
+        }
+    }
+
+    /// Find the auto-approval record for a given tool activity, if one exists.
+    func autoApproval(for activity: ToolActivity) -> AutoApprovedTool? {
+        autoApprovedTools.first { autoTool in
+            autoTool.tool == activity.tool &&
+            abs(autoTool.timestamp.timeIntervalSince(activity.startedAt)) < 2.0
+        }
+    }
+
+    // MARK: - Actions
+
+    func togglePanel() {
+        isPanelExpanded.toggle()
+    }
+}

--- a/ios/MajorTom/Features/Activity/Views/ToolActivityView.swift
+++ b/ios/MajorTom/Features/Activity/Views/ToolActivityView.swift
@@ -1,0 +1,239 @@
+import SwiftUI
+
+struct ToolActivityView: View {
+    @State private var viewModel: ToolActivityViewModel
+
+    init(relay: RelayService) {
+        _viewModel = State(initialValue: ToolActivityViewModel(relay: relay))
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            // Drag handle
+            dragHandle
+
+            // Header
+            header
+
+            // Tab picker
+            tabPicker
+
+            // Tool list
+            toolList
+        }
+        .background(MajorTomTheme.Colors.surface)
+        .clipShape(
+            UnevenRoundedRectangle(
+                topLeadingRadius: MajorTomTheme.Radius.large,
+                topTrailingRadius: MajorTomTheme.Radius.large
+            )
+        )
+    }
+
+    // MARK: - Drag Handle
+
+    private var dragHandle: some View {
+        RoundedRectangle(cornerRadius: 2.5)
+            .fill(MajorTomTheme.Colors.textTertiary)
+            .frame(width: 36, height: 5)
+            .padding(.top, MajorTomTheme.Spacing.sm)
+    }
+
+    // MARK: - Header
+
+    private var header: some View {
+        HStack {
+            Label {
+                Text("Tools")
+                    .font(MajorTomTheme.Typography.headline)
+                    .foregroundStyle(MajorTomTheme.Colors.textPrimary)
+            } icon: {
+                Image(systemName: "wrench.and.screwdriver")
+                    .foregroundStyle(MajorTomTheme.Colors.accent)
+            }
+
+            if viewModel.runningCount > 0 {
+                Text("\(viewModel.runningCount)")
+                    .font(.system(size: 11, weight: .bold, design: .rounded))
+                    .foregroundStyle(.white)
+                    .padding(.horizontal, 6)
+                    .padding(.vertical, 2)
+                    .background(MajorTomTheme.Colors.accent)
+                    .clipShape(Capsule())
+            }
+
+            Spacer()
+
+            if viewModel.failedCount > 0 {
+                HStack(spacing: 4) {
+                    Image(systemName: "exclamationmark.triangle.fill")
+                        .font(.system(size: 10))
+                    Text("\(viewModel.failedCount)")
+                        .font(.system(size: 11, weight: .bold, design: .rounded))
+                }
+                .foregroundStyle(MajorTomTheme.Colors.deny)
+            }
+
+            Text("\(viewModel.totalToolCount) total")
+                .font(MajorTomTheme.Typography.caption)
+                .foregroundStyle(MajorTomTheme.Colors.textTertiary)
+        }
+        .padding(.horizontal, MajorTomTheme.Spacing.lg)
+        .padding(.top, MajorTomTheme.Spacing.md)
+        .padding(.bottom, MajorTomTheme.Spacing.sm)
+    }
+
+    // MARK: - Tab Picker
+
+    private var tabPicker: some View {
+        HStack(spacing: 0) {
+            ForEach(ToolActivityViewModel.Tab.allCases, id: \.self) { tab in
+                Button {
+                    withAnimation(.easeInOut(duration: 0.2)) {
+                        viewModel.selectedTab = tab
+                    }
+                    HapticService.selection()
+                } label: {
+                    Text(tab.rawValue)
+                        .font(.system(size: 13, weight: .semibold))
+                        .foregroundStyle(
+                            viewModel.selectedTab == tab
+                                ? MajorTomTheme.Colors.textPrimary
+                                : MajorTomTheme.Colors.textTertiary
+                        )
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, MajorTomTheme.Spacing.sm)
+                        .background(
+                            viewModel.selectedTab == tab
+                                ? MajorTomTheme.Colors.surfaceElevated
+                                : Color.clear
+                        )
+                        .clipShape(RoundedRectangle(cornerRadius: MajorTomTheme.Radius.small))
+                }
+                .buttonStyle(.plain)
+            }
+        }
+        .padding(.horizontal, MajorTomTheme.Spacing.md)
+        .padding(.vertical, MajorTomTheme.Spacing.xs)
+    }
+
+    // MARK: - Tool List
+
+    private var toolList: some View {
+        Group {
+            let tools = viewModel.displayedTools
+            if tools.isEmpty {
+                emptyState
+            } else {
+                ScrollViewReader { proxy in
+                    ScrollView {
+                        LazyVStack(spacing: 0) {
+                            ForEach(tools) { tool in
+                                ToolActivityRow(
+                                    activity: tool,
+                                    autoApproval: viewModel.autoApproval(for: tool)
+                                )
+                                .id(tool.id)
+
+                                if tool.id != tools.last?.id {
+                                    Divider()
+                                        .overlay(MajorTomTheme.Colors.textTertiary.opacity(0.2))
+                                        .padding(.leading, 52)
+                                }
+                            }
+                        }
+                        .padding(.bottom, MajorTomTheme.Spacing.lg)
+                    }
+                    .onChange(of: viewModel.activeTools.count) {
+                        if let first = viewModel.activeTools.first {
+                            withAnimation(.spring(duration: 0.3)) {
+                                proxy.scrollTo(first.id, anchor: .top)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // MARK: - Empty State
+
+    private var emptyState: some View {
+        VStack(spacing: MajorTomTheme.Spacing.md) {
+            Image(systemName: "wrench.and.screwdriver")
+                .font(.system(size: 32))
+                .foregroundStyle(MajorTomTheme.Colors.textTertiary)
+            Text(viewModel.selectedTab == .active ? "No active tools" : "No tools used yet")
+                .font(MajorTomTheme.Typography.body)
+                .foregroundStyle(MajorTomTheme.Colors.textSecondary)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, MajorTomTheme.Spacing.xxl)
+    }
+}
+
+// MARK: - Floating Tool Bar (for ChatView integration)
+
+struct ToolActivityFloatingBar: View {
+    let runningCount: Int
+    let totalCount: Int
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            HStack(spacing: MajorTomTheme.Spacing.sm) {
+                Image(systemName: "wrench.and.screwdriver")
+                    .font(.system(size: 12, weight: .medium))
+                    .foregroundStyle(MajorTomTheme.Colors.accent)
+
+                if runningCount > 0 {
+                    HStack(spacing: 4) {
+                        ProgressView()
+                            .controlSize(.mini)
+                            .tint(MajorTomTheme.Colors.accent)
+                        Text("\(runningCount) running")
+                            .font(.system(size: 12, weight: .semibold))
+                            .foregroundStyle(MajorTomTheme.Colors.accent)
+                    }
+                } else if totalCount > 0 {
+                    Text("\(totalCount) tools used")
+                        .font(.system(size: 12, weight: .medium))
+                        .foregroundStyle(MajorTomTheme.Colors.textSecondary)
+                }
+
+                Spacer()
+
+                Image(systemName: "chevron.up")
+                    .font(.system(size: 10, weight: .bold))
+                    .foregroundStyle(MajorTomTheme.Colors.textTertiary)
+            }
+            .padding(.horizontal, MajorTomTheme.Spacing.md)
+            .padding(.vertical, MajorTomTheme.Spacing.sm)
+            .background(MajorTomTheme.Colors.surfaceElevated)
+            .clipShape(RoundedRectangle(cornerRadius: MajorTomTheme.Radius.small))
+            .overlay(
+                RoundedRectangle(cornerRadius: MajorTomTheme.Radius.small)
+                    .stroke(MajorTomTheme.Colors.accent.opacity(0.2), lineWidth: 0.5)
+            )
+        }
+        .buttonStyle(.plain)
+    }
+}
+
+#Preview("Activity Panel") {
+    ToolActivityView(relay: RelayService())
+        .frame(height: 400)
+        .background(MajorTomTheme.Colors.background)
+}
+
+#Preview("Floating Bar - Running") {
+    ToolActivityFloatingBar(runningCount: 3, totalCount: 7) {}
+        .padding()
+        .background(MajorTomTheme.Colors.background)
+}
+
+#Preview("Floating Bar - Idle") {
+    ToolActivityFloatingBar(runningCount: 0, totalCount: 12) {}
+        .padding()
+        .background(MajorTomTheme.Colors.background)
+}

--- a/ios/MajorTom/Features/Control/Views/ChatView.swift
+++ b/ios/MajorTom/Features/Control/Views/ChatView.swift
@@ -2,9 +2,15 @@ import SwiftUI
 
 struct ChatView: View {
     @State private var viewModel: ChatViewModel
+    @State private var activityViewModel: ToolActivityViewModel
+    @State private var showActivitySheet = false
+
+    private let relay: RelayService
 
     init(relay: RelayService) {
+        self.relay = relay
         _viewModel = State(initialValue: ChatViewModel(relay: relay))
+        _activityViewModel = State(initialValue: ToolActivityViewModel(relay: relay))
     }
 
     var body: some View {
@@ -22,10 +28,29 @@ struct ChatView: View {
             // Messages
             messagesList
 
+            // Tool activity floating bar
+            if activityViewModel.totalToolCount > 0 {
+                ToolActivityFloatingBar(
+                    runningCount: activityViewModel.runningCount,
+                    totalCount: activityViewModel.totalToolCount
+                ) {
+                    HapticService.impact(.medium)
+                    showActivitySheet = true
+                }
+                .padding(.horizontal, MajorTomTheme.Spacing.md)
+                .padding(.vertical, MajorTomTheme.Spacing.xs)
+            }
+
             // Input bar
             inputBar(text: $viewModel.inputText)
         }
         .background(MajorTomTheme.Colors.background)
+        .sheet(isPresented: $showActivitySheet) {
+            ToolActivityView(relay: relay)
+                .presentationDetents([.medium, .large])
+                .presentationDragIndicator(.hidden)
+                .presentationBackground(MajorTomTheme.Colors.surface)
+        }
         .task {
             if !viewModel.hasSession {
                 await viewModel.startSession()


### PR DESCRIPTION
## Summary
- **Tool activity panel** — sheet with Active/All tabs, running count badge
- **Per-tool details** — SF Symbol icon mapping, input description, duration, status
- **Auto-approval badges** — "Smart" or "God" badges on auto-approved tools
- **Floating bar** — compact bar above input showing running/total tool count
- Real-time updates as tools start and complete

## Test plan
- [ ] During active session → verify floating bar shows tool count
- [ ] Tap floating bar → verify activity sheet opens
- [ ] Verify running tools show spinner, completed show checkmark/duration
- [ ] In Smart/God mode → verify auto-approval badges appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)