### PR TITLE
feat(ios): Wave 8 — Office enhancements

### DIFF
--- a/ios/MajorTom.xcodeproj/project.pbxproj
+++ b/ios/MajorTom.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		50BB1C73D342CB99FCFD747C /* ConnectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2E379544E5140C04B00F724 /* ConnectionView.swift */; };
 		54DF40806CDE825D4201BB6B /* ApprovalCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AC497E5E769C0087E856232 /* ApprovalCard.swift */; };
 		6842CC155924DD2F8E828C18 /* WebSocketClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = C13191C0A248C84CA6959981 /* WebSocketClient.swift */; };
+		688A8874D97CF87B709FC013 /* CharacterGalleryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E176705EB6880868FE05573E /* CharacterGalleryView.swift */; };
 		6C1C58D6705B5201DC10755F /* ChatView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6657773292DC21D71241871E /* ChatView.swift */; };
 		6E4EDEA7EBF6C0B069F3654C /* OfficeScene.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7643A52E74C92A59EFA82ED7 /* OfficeScene.swift */; };
 		818FA51F81C18CFE08B3C097 /* PairingViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 526DF9EAD13F47F747C7ACC3 /* PairingViewModel.swift */; };
@@ -27,6 +28,7 @@
 		8AD9CF79749CD5BE5EF22487 /* AgentInspectorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A6B155FB1E10E586EFA12AC /* AgentInspectorView.swift */; };
 		924AA688A4D5BF0B708C40A4 /* ApprovalView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B99FD8B1AB490C5124F962DC /* ApprovalView.swift */; };
 		926D953D313C1AF78A9041EE /* MessageBubble.swift in Sources */ = {isa = PBXBuildFile; fileRef = E659E1885E32B1187E8C3703 /* MessageBubble.swift */; };
+		93EFF11D75E2B7730AA50D4E /* ActivityStation.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1C51280EF867529A6909DDD /* ActivityStation.swift */; };
 		9F2F95450060416CA67BA3FB /* OfficeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD500881DC6249D63A9E0ACA /* OfficeView.swift */; };
 		9FE4BFB91ACE225068E13E8F /* AgentSprite.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DD1D371AFD4698EE21925BF /* AgentSprite.swift */; };
 		AECFF1EF021E81589ADBC052 /* Message.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FEBD49051DFF465363BBE2B /* Message.swift */; };
@@ -40,6 +42,7 @@
 		E4C11D19C5CBC7B5653532FD /* Theme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 345B4AA475B96036D85853BA /* Theme.swift */; };
 		ECD4CC99C031E1B803D88C76 /* Session.swift in Sources */ = {isa = PBXBuildFile; fileRef = 591E0D4455AD31B2BBD8761C /* Session.swift */; };
 		ED4F918BF0F4278063303B34 /* AuthService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2873A7A68C25BFA4E7C9756 /* AuthService.swift */; };
+		FB9ACD1627AF69650D07975D /* ActivityManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCDB924E236ABFE12B68C803 /* ActivityManager.swift */; };
 		FFB20C4BF1BD6D83D3404F2B /* StreamingText.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73D57C1446E7A203616CCE20 /* StreamingText.swift */; };
 /* End PBXBuildFile section */
 
@@ -77,7 +80,10 @@
 		C13191C0A248C84CA6959981 /* WebSocketClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebSocketClient.swift; sourceTree = "<group>"; };
 		C3C4E64AF88E24ABC75AB59E /* AgentState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentState.swift; sourceTree = "<group>"; };
 		CC19E99FB3AAD181F192CD3B /* MessageCodec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageCodec.swift; sourceTree = "<group>"; };
+		CCDB924E236ABFE12B68C803 /* ActivityManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityManager.swift; sourceTree = "<group>"; };
+		E176705EB6880868FE05573E /* CharacterGalleryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CharacterGalleryView.swift; sourceTree = "<group>"; };
 		E659E1885E32B1187E8C3703 /* MessageBubble.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageBubble.swift; sourceTree = "<group>"; };
+		F1C51280EF867529A6909DDD /* ActivityStation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityStation.swift; sourceTree = "<group>"; };
 		F2E379544E5140C04B00F724 /* ConnectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectionView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -125,11 +131,20 @@
 				944EEB19C6C12FD8F9F43846 /* STATUS.md */,
 				42EB58783C4C82C3775366F2 /* Models */,
 				6EA08F490503711FE5A981C9 /* Scenes */,
+				1C44AF48E61BFC99A7CC7FA9 /* Services */,
 				5BD6E53331D32CF42489B7FF /* Sprites */,
 				53A697AA7BC2945AF0AE4838 /* ViewModels */,
 				A9495C588A2CD93C84EE00F2 /* Views */,
 			);
 			path = Office;
+			sourceTree = "<group>";
+		};
+		1C44AF48E61BFC99A7CC7FA9 /* Services */ = {
+			isa = PBXGroup;
+			children = (
+				CCDB924E236ABFE12B68C803 /* ActivityManager.swift */,
+			);
+			path = Services;
 			sourceTree = "<group>";
 		};
 		34B945EEC2AEA9029D361F68 /* ViewModels */ = {
@@ -184,6 +199,7 @@
 		42EB58783C4C82C3775366F2 /* Models */ = {
 			isa = PBXGroup;
 			children = (
+				F1C51280EF867529A6909DDD /* ActivityStation.swift */,
 				C3C4E64AF88E24ABC75AB59E /* AgentState.swift */,
 				49975C50EF000FB470E30360 /* CharacterConfig.swift */,
 				B2A5F6ECD6AEA9681C140DA3 /* OfficeLayout.swift */,
@@ -263,6 +279,7 @@
 			isa = PBXGroup;
 			children = (
 				6A6B155FB1E10E586EFA12AC /* AgentInspectorView.swift */,
+				E176705EB6880868FE05573E /* CharacterGalleryView.swift */,
 				BD500881DC6249D63A9E0ACA /* OfficeView.swift */,
 			);
 			path = Views;
@@ -279,7 +296,6 @@
 		B785C26F2874B8A4F530FD1D /* Settings */ = {
 			isa = PBXGroup;
 			children = (
-				F4CC29694F42E4B5FD57C761 /* Components */,
 				D28A628DB467A01A77C6F494 /* ViewModels */,
 				DE1EBD87DDB29A1DB6A9A638 /* Views */,
 			);
@@ -346,13 +362,6 @@
 				591E0D4455AD31B2BBD8761C /* Session.swift */,
 			);
 			path = Models;
-			sourceTree = "<group>";
-		};
-		F4CC29694F42E4B5FD57C761 /* Components */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			path = Components;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -426,6 +435,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				FB9ACD1627AF69650D07975D /* ActivityManager.swift in Sources */,
+				93EFF11D75E2B7730AA50D4E /* ActivityStation.swift in Sources */,
 				8AD9CF79749CD5BE5EF22487 /* AgentInspectorView.swift in Sources */,
 				9FE4BFB91ACE225068E13E8F /* AgentSprite.swift in Sources */,
 				47EC9244ECBFED3B28C37DBA /* AgentState.swift in Sources */,
@@ -434,6 +445,7 @@
 				924AA688A4D5BF0B708C40A4 /* ApprovalView.swift in Sources */,
 				ED4F918BF0F4278063303B34 /* AuthService.swift in Sources */,
 				BD4DE18F7D89A6E7BE778875 /* CharacterConfig.swift in Sources */,
+				688A8874D97CF87B709FC013 /* CharacterGalleryView.swift in Sources */,
 				6C1C58D6705B5201DC10755F /* ChatView.swift in Sources */,
 				CFCBB89895F30259222DD268 /* ChatViewModel.swift in Sources */,
 				50BB1C73D342CB99FCFD747C /* ConnectionView.swift in Sources */,

--- a/ios/MajorTom/App/MajorTomApp.swift
+++ b/ios/MajorTom/App/MajorTomApp.swift
@@ -38,7 +38,7 @@ struct MajorTomApp: App {
                     Label("Control", systemImage: "terminal")
                 }
 
-            OfficeView(viewModel: officeViewModel)
+            OfficeView(viewModel: officeViewModel, relay: relay)
                 .tabItem {
                     Label("Office", systemImage: "building.2")
                 }

--- a/ios/MajorTom/Features/Office/Models/ActivityStation.swift
+++ b/ios/MajorTom/Features/Office/Models/ActivityStation.swift
@@ -1,0 +1,94 @@
+import Foundation
+
+// MARK: - Activity Station Type
+
+/// The types of idle activity stations available in the office.
+enum ActivityStationType: String, CaseIterable {
+    case pingPong
+    case coffeeMachine
+    case waterCooler
+    case arcade
+    case yoga
+    case nap
+    case whiteboard
+}
+
+// MARK: - Activity Station
+
+/// A physical location in the office where agents can perform idle activities.
+/// Each station has a position, capacity, and associated animation.
+struct ActivityStation: Identifiable {
+    let id: String
+    let type: ActivityStationType
+    let position: CGPoint
+    let capacity: Int
+    let label: String
+
+    /// Currently assigned agent IDs (up to capacity).
+    var occupantIds: Set<String> = []
+
+    var isAvailable: Bool { occupantIds.count < capacity }
+
+    init(type: ActivityStationType, position: CGPoint, capacity: Int = 2) {
+        self.id = type.rawValue
+        self.type = type
+        self.position = position
+        self.capacity = capacity
+
+        switch type {
+        case .pingPong: self.label = "Ping Pong"
+        case .coffeeMachine: self.label = "Coffee"
+        case .waterCooler: self.label = "Water Cooler"
+        case .arcade: self.label = "Arcade"
+        case .yoga: self.label = "Yoga"
+        case .nap: self.label = "Nap Zone"
+        case .whiteboard: self.label = "Whiteboard"
+        }
+    }
+
+    /// The office area this station is located in.
+    var areaType: OfficeAreaType {
+        switch type {
+        case .coffeeMachine, .waterCooler: return .kitchen
+        case .pingPong, .arcade: return .breakRoom
+        case .yoga, .nap: return .dogCorner
+        case .whiteboard: return .mainFloor
+        }
+    }
+
+    /// The station-specific sprite color for rendering in the scene.
+    var spriteColor: (r: CGFloat, g: CGFloat, b: CGFloat) {
+        switch type {
+        case .pingPong: return (0.2, 0.7, 0.3)       // Green
+        case .coffeeMachine: return (0.6, 0.4, 0.2)   // Brown
+        case .waterCooler: return (0.3, 0.6, 0.9)     // Blue
+        case .arcade: return (0.8, 0.3, 0.8)           // Purple
+        case .yoga: return (0.9, 0.7, 0.3)             // Gold
+        case .nap: return (0.4, 0.4, 0.6)              // Muted blue
+        case .whiteboard: return (0.9, 0.9, 0.9)       // White
+        }
+    }
+}
+
+// MARK: - Station Layout
+
+/// Pre-defined positions for all activity stations in the office.
+enum StationLayout {
+
+    static let stations: [ActivityStation] = [
+        // Break room stations
+        ActivityStation(type: .pingPong, position: CGPoint(x: 60, y: 350), capacity: 2),
+        ActivityStation(type: .arcade, position: CGPoint(x: 150, y: 280), capacity: 1),
+
+        // Kitchen stations
+        ActivityStation(type: .coffeeMachine, position: CGPoint(x: 280, y: 220), capacity: 1),
+        ActivityStation(type: .waterCooler, position: CGPoint(x: 380, y: 220), capacity: 2),
+
+        // Chill zone stations (in dog corner area)
+        ActivityStation(type: .yoga, position: CGPoint(x: 550, y: 220), capacity: 2),
+        ActivityStation(type: .nap, position: CGPoint(x: 700, y: 180), capacity: 2),
+
+        // Main floor station
+        ActivityStation(type: .whiteboard, position: CGPoint(x: 720, y: 400), capacity: 2),
+    ]
+}

--- a/ios/MajorTom/Features/Office/Scenes/OfficeScene.swift
+++ b/ios/MajorTom/Features/Office/Scenes/OfficeScene.swift
@@ -3,8 +3,7 @@ import SpriteKit
 // MARK: - Office Scene
 
 /// The main SpriteKit scene that renders the office floor plan and agent sprites.
-/// Placeholder version: colored rectangles for areas, colored sprites for agents.
-/// Pretty pixel art comes in a future phase.
+/// Includes activity stations, ambient animations, and agent management.
 final class OfficeScene: SKScene {
 
     /// Callback when an agent sprite is tapped (wired to SwiftUI via OfficeView).
@@ -15,6 +14,9 @@ final class OfficeScene: SKScene {
 
     /// Desk node references for visual rendering.
     private var deskNodes: [Int: SKShapeNode] = [:]
+
+    /// Station node references.
+    private var stationNodes: [ActivityStationType: SKNode] = [:]
 
     // MARK: - Scene Lifecycle
 
@@ -28,6 +30,8 @@ final class OfficeScene: SKScene {
         renderFloorPlan()
         renderDesks()
         renderDoor()
+        renderStations()
+        startAmbientAnimations()
     }
 
     // MARK: - Floor Plan Rendering
@@ -119,6 +123,150 @@ final class OfficeScene: SKScene {
         door.addChild(label)
     }
 
+    // MARK: - Station Rendering
+
+    /// Render activity station sprites in the scene.
+    private func renderStations() {
+        for station in StationLayout.stations {
+            let container = SKNode()
+            container.position = station.position
+            container.zPosition = 5
+            container.name = "station_\(station.type.rawValue)"
+
+            // Station icon (colored rectangle)
+            let iconSize: CGSize
+            switch station.type {
+            case .pingPong:
+                iconSize = CGSize(width: 30, height: 20)
+            case .coffeeMachine:
+                iconSize = CGSize(width: 16, height: 22)
+            case .waterCooler:
+                iconSize = CGSize(width: 14, height: 20)
+            case .arcade:
+                iconSize = CGSize(width: 22, height: 28)
+            case .yoga:
+                iconSize = CGSize(width: 28, height: 18)
+            case .nap:
+                iconSize = CGSize(width: 32, height: 14)
+            case .whiteboard:
+                iconSize = CGSize(width: 30, height: 24)
+            }
+
+            let (r, g, b) = station.spriteColor
+            let icon = SKShapeNode(rectOf: iconSize, cornerRadius: 3)
+            icon.fillColor = SKColor(red: r, green: g, blue: b, alpha: 0.7)
+            icon.strokeColor = SKColor(red: r, green: g, blue: b, alpha: 1.0)
+            icon.lineWidth = 1
+            container.addChild(icon)
+
+            // Station label
+            let label = SKLabelNode(fontNamed: "Menlo")
+            label.text = station.label.uppercased()
+            label.fontSize = 7
+            label.fontColor = SKColor(white: 0.6, alpha: 0.8)
+            label.position = CGPoint(x: 0, y: -(iconSize.height / 2 + 10))
+            label.horizontalAlignmentMode = .center
+            container.addChild(label)
+
+            // Station-specific decoration
+            addStationDecoration(to: container, type: station.type)
+
+            addChild(container)
+            stationNodes[station.type] = container
+        }
+    }
+
+    /// Add station-specific decorative elements.
+    private func addStationDecoration(to container: SKNode, type: ActivityStationType) {
+        switch type {
+        case .coffeeMachine:
+            // Coffee steam particles (3 small dots that float up)
+            for i in 0..<3 {
+                let steam = SKShapeNode(circleOfRadius: 1.5)
+                steam.fillColor = SKColor(white: 0.7, alpha: 0.4)
+                steam.strokeColor = .clear
+                steam.position = CGPoint(x: CGFloat(i - 1) * 3, y: 14)
+                steam.zPosition = 1
+                steam.name = "steam_\(i)"
+                container.addChild(steam)
+            }
+
+        case .pingPong:
+            // Ball indicator
+            let ball = SKShapeNode(circleOfRadius: 2)
+            ball.fillColor = SKColor(red: 1.0, green: 0.8, blue: 0.2, alpha: 0.9)
+            ball.strokeColor = .clear
+            ball.position = CGPoint(x: 0, y: 0)
+            ball.zPosition = 1
+            ball.name = "pingpong_ball"
+            container.addChild(ball)
+
+        case .arcade:
+            // Screen glow
+            let glow = SKShapeNode(rectOf: CGSize(width: 16, height: 12), cornerRadius: 2)
+            glow.fillColor = SKColor(red: 0.3, green: 0.9, blue: 0.3, alpha: 0.3)
+            glow.strokeColor = .clear
+            glow.position = CGPoint(x: 0, y: 4)
+            glow.zPosition = 1
+            glow.name = "arcade_glow"
+            container.addChild(glow)
+
+        default:
+            break
+        }
+    }
+
+    // MARK: - Ambient Animations
+
+    /// Start subtle ambient animations for stations.
+    private func startAmbientAnimations() {
+        // Coffee steam animation
+        if let coffeeStation = stationNodes[.coffeeMachine] {
+            for i in 0..<3 {
+                guard let steam = coffeeStation.childNode(withName: "steam_\(i)") else { continue }
+                let delay = Double(i) * 0.4
+                let rise = SKAction.sequence([
+                    SKAction.wait(forDuration: delay),
+                    SKAction.repeatForever(SKAction.sequence([
+                        SKAction.group([
+                            SKAction.moveBy(x: CGFloat.random(in: -2...2), y: 8, duration: 1.2),
+                            SKAction.fadeOut(withDuration: 1.2),
+                        ]),
+                        SKAction.run { [weak steam] in
+                            steam?.position = CGPoint(x: CGFloat(i - 1) * 3, y: 14)
+                            steam?.alpha = 0.4
+                        },
+                    ])),
+                ])
+                steam.run(rise)
+            }
+        }
+
+        // Ping pong ball bounce
+        if let ppStation = stationNodes[.pingPong],
+           let ball = ppStation.childNode(withName: "pingpong_ball") {
+            let bounce = SKAction.repeatForever(SKAction.sequence([
+                SKAction.moveBy(x: 12, y: 5, duration: 0.3),
+                SKAction.moveBy(x: -12, y: -5, duration: 0.3),
+                SKAction.moveBy(x: 12, y: -3, duration: 0.25),
+                SKAction.moveBy(x: -12, y: 3, duration: 0.25),
+            ]))
+            ball.run(bounce)
+        }
+
+        // Arcade screen flicker
+        if let arcadeStation = stationNodes[.arcade],
+           let glow = arcadeStation.childNode(withName: "arcade_glow") {
+            let flicker = SKAction.repeatForever(SKAction.sequence([
+                SKAction.fadeAlpha(to: 0.5, duration: 0.8),
+                SKAction.fadeAlpha(to: 0.2, duration: 0.4),
+                SKAction.fadeAlpha(to: 0.6, duration: 0.3),
+                SKAction.fadeAlpha(to: 0.3, duration: 0.5),
+            ]))
+            glow.run(flicker)
+        }
+    }
+
     // MARK: - Agent Sprite Management
 
     /// Add a new agent sprite to the scene at the door position.
@@ -171,6 +319,29 @@ final class OfficeScene: SKScene {
         sprite.moveTo(position: position, duration: 2.0) {
             sprite.updateStatus(.idle)
             sprite.startIdleAnimation()
+        }
+    }
+
+    /// Move an agent to a specific activity station.
+    func moveAgentToStation(id: String, stationType: ActivityStationType) {
+        guard let sprite = agentSprites[id] else { return }
+        guard let station = StationLayout.stations.first(where: { $0.type == stationType }) else { return }
+
+        // Offset slightly so multiple agents don't overlap exactly
+        let offset = CGPoint(
+            x: CGFloat.random(in: -10...10),
+            y: CGFloat.random(in: -8...8)
+        )
+        let targetPos = CGPoint(
+            x: station.position.x + offset.x,
+            y: station.position.y + offset.y + 20 // Above the station icon
+        )
+
+        sprite.updateStatus(.walking)
+        sprite.stopAnimations()
+        sprite.moveTo(position: targetPos, duration: 1.5) {
+            sprite.updateStatus(.idle)
+            sprite.startStationAnimation(stationType: stationType)
         }
     }
 

--- a/ios/MajorTom/Features/Office/Services/ActivityManager.swift
+++ b/ios/MajorTom/Features/Office/Services/ActivityManager.swift
@@ -1,0 +1,154 @@
+import Foundation
+
+// MARK: - Activity Assignment
+
+/// Tracks an agent's current station assignment and timing.
+struct ActivityAssignment {
+    let agentId: String
+    let stationType: ActivityStationType
+    let startedAt: Date
+    let duration: TimeInterval
+
+    var isExpired: Bool {
+        Date().timeIntervalSince(startedAt) >= duration
+    }
+
+    var timeRemaining: TimeInterval {
+        max(0, duration - Date().timeIntervalSince(startedAt))
+    }
+}
+
+// MARK: - Activity Manager
+
+/// Manages idle activity assignments for agents.
+/// When an agent goes idle, assigns them to a random available station.
+/// Handles station capacity, activity timing, and rotation.
+@Observable
+@MainActor
+final class ActivityManager {
+
+    /// All activity stations in the office.
+    var stations: [ActivityStation] = StationLayout.stations
+
+    /// Current activity assignments by agent ID.
+    private(set) var assignments: [String: ActivityAssignment] = [:]
+
+    /// Timer for cycling activities.
+    private var cycleTask: Task<Void, Never>?
+
+    // MARK: - Station Assignment
+
+    /// Assign an idle agent to a random available station.
+    /// Returns the station if one is available, nil if all are at capacity.
+    func assignStation(for agentId: String) -> ActivityStation? {
+        // Release any existing assignment first
+        releaseStation(for: agentId)
+
+        // Find available stations
+        let availableStations = stations.filter { $0.isAvailable }
+        guard let station = availableStations.randomElement() else { return nil }
+
+        // Assign agent to station
+        guard let stationIndex = stations.firstIndex(where: { $0.id == station.id }) else { return nil }
+        stations[stationIndex].occupantIds.insert(agentId)
+
+        // Create assignment with random duration (5-15 seconds)
+        let duration = TimeInterval.random(in: 5...15)
+        let assignment = ActivityAssignment(
+            agentId: agentId,
+            stationType: station.type,
+            startedAt: Date(),
+            duration: duration
+        )
+        assignments[agentId] = assignment
+
+        return station
+    }
+
+    /// Release an agent from their current station.
+    func releaseStation(for agentId: String) {
+        guard let assignment = assignments[agentId] else { return }
+
+        // Find and update the station
+        if let stationIndex = stations.firstIndex(where: { $0.type == assignment.stationType }) {
+            stations[stationIndex].occupantIds.remove(agentId)
+        }
+
+        assignments.removeValue(forKey: agentId)
+    }
+
+    /// Get the current assignment for an agent.
+    func currentActivity(for agentId: String) -> ActivityAssignment? {
+        assignments[agentId]
+    }
+
+    /// Get the station for a given type.
+    func station(for type: ActivityStationType) -> ActivityStation? {
+        stations.first { $0.type == type }
+    }
+
+    /// Check if an agent's activity has expired and needs rotation.
+    func needsRotation(agentId: String) -> Bool {
+        guard let assignment = assignments[agentId] else { return false }
+        return assignment.isExpired
+    }
+
+    /// Get all agents that need activity rotation.
+    func agentsNeedingRotation() -> [String] {
+        assignments.compactMap { agentId, assignment in
+            assignment.isExpired ? agentId : nil
+        }
+    }
+
+    // MARK: - Cycle Management
+
+    /// Start the activity cycling timer.
+    /// Checks every 2 seconds for expired activities and rotates agents.
+    func startCycling(onRotate: @escaping (String, ActivityStation?) -> Void) {
+        stopCycling()
+
+        cycleTask = Task { [weak self] in
+            while !Task.isCancelled {
+                try? await Task.sleep(for: .seconds(2))
+
+                guard let self else { return }
+
+                let agentsToRotate = self.agentsNeedingRotation()
+                for agentId in agentsToRotate {
+                    let newStation = self.assignStation(for: agentId)
+                    onRotate(agentId, newStation)
+                }
+            }
+        }
+    }
+
+    /// Stop the activity cycling timer.
+    func stopCycling() {
+        cycleTask?.cancel()
+        cycleTask = nil
+    }
+
+    /// Clear all assignments and stop cycling.
+    func reset() {
+        stopCycling()
+        assignments.removeAll()
+        stations = StationLayout.stations
+    }
+
+    // MARK: - Display Helpers
+
+    /// Human-readable description of an agent's current activity.
+    func activityDescription(for agentId: String) -> String? {
+        guard let assignment = assignments[agentId] else { return nil }
+
+        switch assignment.stationType {
+        case .pingPong: return "Playing ping pong"
+        case .coffeeMachine: return "Getting coffee"
+        case .waterCooler: return "At the water cooler"
+        case .arcade: return "Playing arcade games"
+        case .yoga: return "Doing yoga"
+        case .nap: return "Taking a nap"
+        case .whiteboard: return "Doodling on whiteboard"
+        }
+    }
+}

--- a/ios/MajorTom/Features/Office/Sprites/AgentSprite.swift
+++ b/ios/MajorTom/Features/Office/Sprites/AgentSprite.swift
@@ -131,6 +131,7 @@ final class AgentSprite: SKSpriteNode {
     /// Simple idle bobbing animation.
     func startIdleAnimation() {
         removeAction(forKey: "idle")
+        removeAction(forKey: "station")
         let bob = SKAction.sequence([
             SKAction.moveBy(x: 0, y: 3, duration: 0.8),
             SKAction.moveBy(x: 0, y: -3, duration: 0.8),
@@ -142,6 +143,7 @@ final class AgentSprite: SKSpriteNode {
     func startWorkAnimation() {
         removeAction(forKey: "idle")
         removeAction(forKey: "work")
+        removeAction(forKey: "station")
         let shake = SKAction.sequence([
             SKAction.moveBy(x: 2, y: 0, duration: 0.15),
             SKAction.moveBy(x: -4, y: 0, duration: 0.15),
@@ -161,6 +163,76 @@ final class AgentSprite: SKSpriteNode {
         let spin = SKAction.rotate(byAngle: .pi * 2, duration: 0.4)
         let celebrate = SKAction.group([jump, spin])
         run(SKAction.repeat(celebrate, count: 3), withKey: "celebrate")
+    }
+
+    /// Station-specific idle animations.
+    func startStationAnimation(stationType: ActivityStationType) {
+        removeAction(forKey: "idle")
+        removeAction(forKey: "work")
+        removeAction(forKey: "station")
+
+        let animation: SKAction
+
+        switch stationType {
+        case .pingPong:
+            // Side-to-side swinging motion
+            animation = SKAction.repeatForever(SKAction.sequence([
+                SKAction.moveBy(x: 6, y: 0, duration: 0.25),
+                SKAction.moveBy(x: -12, y: 0, duration: 0.5),
+                SKAction.moveBy(x: 6, y: 0, duration: 0.25),
+                SKAction.wait(forDuration: 0.3),
+            ]))
+
+        case .coffeeMachine:
+            // Slight lean forward (waiting for coffee)
+            animation = SKAction.repeatForever(SKAction.sequence([
+                SKAction.moveBy(x: 0, y: -2, duration: 0.6),
+                SKAction.moveBy(x: 0, y: 2, duration: 0.6),
+                SKAction.wait(forDuration: 1.5),
+            ]))
+
+        case .waterCooler:
+            // Gentle sway (chatting at the cooler)
+            animation = SKAction.repeatForever(SKAction.sequence([
+                SKAction.moveBy(x: 2, y: 1, duration: 0.7),
+                SKAction.moveBy(x: -4, y: 0, duration: 1.0),
+                SKAction.moveBy(x: 2, y: -1, duration: 0.7),
+            ]))
+
+        case .arcade:
+            // Rapid button mashing
+            animation = SKAction.repeatForever(SKAction.sequence([
+                SKAction.moveBy(x: 1, y: -1, duration: 0.1),
+                SKAction.moveBy(x: -2, y: 1, duration: 0.1),
+                SKAction.moveBy(x: 1, y: 0, duration: 0.1),
+                SKAction.wait(forDuration: 0.2),
+            ]))
+
+        case .yoga:
+            // Slow breathing motion
+            animation = SKAction.repeatForever(SKAction.sequence([
+                SKAction.moveBy(x: 0, y: 4, duration: 1.5),
+                SKAction.moveBy(x: 0, y: -4, duration: 1.5),
+            ]))
+
+        case .nap:
+            // Very slow bob (sleeping)
+            animation = SKAction.repeatForever(SKAction.sequence([
+                SKAction.moveBy(x: 0, y: 1, duration: 2.0),
+                SKAction.moveBy(x: 0, y: -1, duration: 2.0),
+            ]))
+
+        case .whiteboard:
+            // Drawing motion
+            animation = SKAction.repeatForever(SKAction.sequence([
+                SKAction.moveBy(x: 3, y: 2, duration: 0.3),
+                SKAction.moveBy(x: -1, y: -4, duration: 0.4),
+                SKAction.moveBy(x: -2, y: 2, duration: 0.3),
+                SKAction.wait(forDuration: 0.5),
+            ]))
+        }
+
+        run(animation, withKey: "station")
     }
 
     /// Stop all animations.

--- a/ios/MajorTom/Features/Office/ViewModels/OfficeViewModel.swift
+++ b/ios/MajorTom/Features/Office/ViewModels/OfficeViewModel.swift
@@ -1,5 +1,44 @@
 import Foundation
 
+// MARK: - Demo Agent Names & Tasks
+
+/// Pre-defined demo agents for demo mode.
+private enum DemoData {
+    struct DemoAgent {
+        let name: String
+        let role: String
+        let task: String
+        let characterType: CharacterType
+    }
+
+    static let agents: [DemoAgent] = [
+        DemoAgent(name: "Alice", role: "frontend", task: "Building the login page", characterType: .dev),
+        DemoAgent(name: "Bob", role: "backend", task: "Setting up API endpoints", characterType: .officeWorker),
+        DemoAgent(name: "Carol", role: "pm", task: "Sprint planning for Q2", characterType: .pm),
+        DemoAgent(name: "Dave", role: "fullstack", task: "Implementing dark mode", characterType: .dev),
+        DemoAgent(name: "Eve", role: "devops", task: "Configuring CI/CD pipeline", characterType: .officeWorker),
+        DemoAgent(name: "Bonkers", role: "morale", task: "Organizing team event", characterType: .clown),
+        DemoAgent(name: "Frank", role: "security", task: "Auditing auth system", characterType: .frankenstein),
+        DemoAgent(name: "Pretzel", role: "qa", task: "Running regression tests", characterType: .dachshund),
+        DemoAgent(name: "Heeler", role: "infra", task: "Scaling worker nodes", characterType: .cattleDog),
+        DemoAgent(name: "Shadow", role: "data", task: "Training ML model", characterType: .schnauzerBlack),
+        DemoAgent(name: "Pepper", role: "design", task: "Updating component library", characterType: .schnauzerPepper),
+        DemoAgent(name: "Grace", role: "architect", task: "Designing microservices", characterType: .pm),
+        DemoAgent(name: "Hank", role: "sre", task: "Monitoring production alerts", characterType: .dev),
+        DemoAgent(name: "Ziggy", role: "intern", task: "Learning the codebase", characterType: .clown),
+    ]
+}
+
+// MARK: - Demo State
+
+/// The lifecycle states for demo mode cycling.
+private enum DemoPhase: CaseIterable {
+    case idle
+    case work
+    case breakTime
+    case celebrate
+}
+
 // MARK: - Office View Model
 
 /// Manages the state of all agents in the office scene.
@@ -14,6 +53,13 @@ final class OfficeViewModel {
     var selectedAgentId: String?
     var desks: [Desk] = OfficeLayout.desks
 
+    /// Demo mode state
+    var isDemoMode: Bool = false
+    var showCharacterGallery: Bool = false
+
+    /// Activity manager for station-based idle activities
+    let activityManager = ActivityManager()
+
     /// Live lookup — always returns current state, never a stale copy.
     var selectedAgent: AgentState? {
         guard let id = selectedAgentId else { return nil }
@@ -26,6 +72,137 @@ final class OfficeViewModel {
     private var nextCharacterIndex = 0
     private let characterTypes = CharacterType.allCases
 
+    /// Demo mode cycling task
+    private var demoCycleTask: Task<Void, Never>?
+
+    // MARK: - Demo Mode
+
+    /// Start demo mode with 14 fake agents.
+    func startDemoMode() {
+        guard !isDemoMode else { return }
+        isDemoMode = true
+
+        // Clear existing state
+        agents.removeAll()
+        desks = OfficeLayout.desks
+        nextCharacterIndex = 0
+
+        // Spawn 14 demo agents
+        for (index, demo) in DemoData.agents.enumerated() {
+            let deskIndex = index < desks.count ? index : nil
+            if let deskIndex {
+                desks[deskIndex].occupantId = "demo-\(index)"
+            }
+
+            let agent = AgentState(
+                id: "demo-\(index)",
+                name: demo.name,
+                role: demo.role,
+                characterType: demo.characterType,
+                status: .working,
+                currentTask: demo.task,
+                deskIndex: deskIndex
+            )
+            agents.append(agent)
+        }
+
+        // Start cycling demo agents through states
+        startDemoCycling()
+    }
+
+    /// Stop demo mode and clear all demo agents.
+    func stopDemoMode() {
+        isDemoMode = false
+        demoCycleTask?.cancel()
+        demoCycleTask = nil
+        activityManager.reset()
+
+        // Clear demo agents
+        agents.removeAll { $0.id.hasPrefix("demo-") }
+        desks = OfficeLayout.desks
+    }
+
+    /// Toggle demo mode on/off.
+    func toggleDemoMode() {
+        if isDemoMode {
+            stopDemoMode()
+        } else {
+            startDemoMode()
+        }
+    }
+
+    /// Cycle demo agents through states: idle -> work -> break -> celebrate
+    private func startDemoCycling() {
+        demoCycleTask = Task { @MainActor [weak self] in
+            while !Task.isCancelled {
+                guard let self else { return }
+
+                // Pick 2-4 random agents to cycle
+                let count = Int.random(in: 2...4)
+                let shuffled = self.agents.filter { $0.id.hasPrefix("demo-") }.shuffled()
+                let selected = Array(shuffled.prefix(count))
+
+                for agent in selected {
+                    guard let index = self.agents.firstIndex(where: { $0.id == agent.id }) else { continue }
+
+                    // Pick next phase based on current status
+                    let nextPhase = self.nextDemoPhase(for: agent.status)
+
+                    switch nextPhase {
+                    case .idle:
+                        self.agents[index].status = .idle
+                        self.agents[index].currentTask = nil
+
+                    case .work:
+                        self.agents[index].status = .working
+                        self.agents[index].currentTask = DemoData.agents
+                            .randomElement()?.task ?? "Working hard"
+
+                    case .breakTime:
+                        self.agents[index].status = .idle
+                        self.agents[index].currentTask = nil
+
+                    case .celebrate:
+                        self.agents[index].status = .celebrating
+                        self.agents[index].currentTask = "Task completed!"
+                        // Reset after 2 seconds
+                        let agentId = agent.id
+                        Task { @MainActor [weak self] in
+                            try? await Task.sleep(for: .seconds(2))
+                            guard let self else { return }
+                            if let idx = self.agents.firstIndex(where: { $0.id == agentId }) {
+                                self.agents[idx].status = .working
+                                self.agents[idx].currentTask = DemoData.agents
+                                    .randomElement()?.task ?? "Back to work"
+                            }
+                        }
+                    }
+                }
+
+                // Wait 4-8 seconds before next cycle
+                let delay = TimeInterval.random(in: 4...8)
+                try? await Task.sleep(for: .seconds(delay))
+            }
+        }
+    }
+
+    /// Determine the next demo phase based on current status.
+    private func nextDemoPhase(for status: AgentStatus) -> DemoPhase {
+        switch status {
+        case .working:
+            // From working: go idle or celebrate
+            return Bool.random() ? .idle : .celebrate
+        case .idle:
+            // From idle: go back to work
+            return .work
+        case .celebrating:
+            // From celebrating: go back to work
+            return .work
+        default:
+            return .work
+        }
+    }
+
     // MARK: - Agent Lifecycle Handlers
 
     /// Called when the relay broadcasts `agent.spawn`.
@@ -33,6 +210,11 @@ final class OfficeViewModel {
     func handleAgentSpawn(id: String, role: String, task: String) {
         // Don't double-spawn
         guard !agents.contains(where: { $0.id == id }) else { return }
+
+        // If in demo mode, stop it when real agents arrive
+        if isDemoMode {
+            stopDemoMode()
+        }
 
         let characterType = assignNextCharacterType()
         let deskIndex = assignNextAvailableDesk(to: id)
@@ -55,6 +237,9 @@ final class OfficeViewModel {
         guard let index = agents.firstIndex(where: { $0.id == id }) else { return }
         agents[index].status = .working
         agents[index].currentTask = task
+
+        // Release any activity station
+        activityManager.releaseStation(for: id)
     }
 
     /// Called when the relay broadcasts `agent.idle`.
@@ -147,6 +332,7 @@ final class OfficeViewModel {
     /// Remove an agent entirely (after they've left the office).
     private func removeAgent(id: String) {
         releaseDesk(for: id)
+        activityManager.releaseStation(for: id)
         agents.removeAll { $0.id == id }
         if selectedAgentId == id {
             selectedAgentId = nil

--- a/ios/MajorTom/Features/Office/Views/AgentInspectorView.swift
+++ b/ios/MajorTom/Features/Office/Views/AgentInspectorView.swift
@@ -4,13 +4,17 @@ import SwiftUI
 
 /// Overlay panel showing details about a selected agent.
 /// Presented as a sheet when an agent sprite is tapped.
+/// Includes text input for sending messages to the agent via relay.
 struct AgentInspectorView: View {
     let agent: AgentState
+    let activityDescription: String?
     let onRename: (String) -> Void
+    let onSendMessage: ((String) -> Void)?
     let onDismiss: () -> Void
 
     @State private var isRenaming = false
     @State private var renameText = ""
+    @State private var messageText = ""
 
     var body: some View {
         VStack(alignment: .leading, spacing: MajorTomTheme.Spacing.md) {
@@ -20,22 +24,35 @@ struct AgentInspectorView: View {
             Divider()
                 .background(MajorTomTheme.Colors.textTertiary)
 
+            // Role & Task (prominent)
+            roleAndTask
+
+            // Activity (if at a station)
+            if let activity = activityDescription {
+                activitySection(activity)
+            }
+
             // Details
             detailRows
 
-            // Current task
+            // Current task (if any)
             if let task = agent.currentTask {
                 taskSection(task)
             }
 
             Spacer()
 
+            // Message input (only when connected to relay)
+            if onSendMessage != nil {
+                messageInput
+            }
+
             // Actions
             actions
         }
         .padding(MajorTomTheme.Spacing.lg)
         .background(MajorTomTheme.Colors.surface)
-        .presentationDetents([.medium])
+        .presentationDetents([.medium, .large])
         .presentationDragIndicator(.visible)
     }
 
@@ -85,9 +102,58 @@ struct AgentInspectorView: View {
         }
     }
 
+    // MARK: - Role & Task (Prominent)
+
+    private var roleAndTask: some View {
+        VStack(alignment: .leading, spacing: MajorTomTheme.Spacing.sm) {
+            // Role
+            HStack(spacing: MajorTomTheme.Spacing.sm) {
+                Image(systemName: "person.badge.key.fill")
+                    .font(.system(size: 14))
+                    .foregroundStyle(MajorTomTheme.Colors.accent)
+                Text(agent.role.capitalized)
+                    .font(MajorTomTheme.Typography.headline)
+                    .foregroundStyle(MajorTomTheme.Colors.textPrimary)
+            }
+
+            // Current task or status
+            if let task = agent.currentTask {
+                HStack(alignment: .top, spacing: MajorTomTheme.Spacing.sm) {
+                    Image(systemName: "chevron.right.circle.fill")
+                        .font(.system(size: 12))
+                        .foregroundStyle(MajorTomTheme.Colors.allow)
+                    Text(task)
+                        .font(MajorTomTheme.Typography.body)
+                        .foregroundStyle(MajorTomTheme.Colors.textSecondary)
+                        .lineLimit(2)
+                }
+            }
+        }
+        .padding(MajorTomTheme.Spacing.sm)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(MajorTomTheme.Colors.background)
+        .clipShape(RoundedRectangle(cornerRadius: MajorTomTheme.Radius.small))
+    }
+
+    // MARK: - Activity Section
+
+    private func activitySection(_ activity: String) -> some View {
+        HStack(spacing: MajorTomTheme.Spacing.sm) {
+            Image(systemName: "figure.walk")
+                .font(.system(size: 12))
+                .foregroundStyle(MajorTomTheme.Colors.accent)
+            Text(activity)
+                .font(MajorTomTheme.Typography.caption)
+                .foregroundStyle(MajorTomTheme.Colors.accent)
+        }
+        .padding(.horizontal, MajorTomTheme.Spacing.sm)
+        .padding(.vertical, MajorTomTheme.Spacing.xs)
+        .background(MajorTomTheme.Colors.accentSubtle)
+        .clipShape(Capsule())
+    }
+
     private var detailRows: some View {
         VStack(alignment: .leading, spacing: MajorTomTheme.Spacing.sm) {
-            detailRow(label: "Role", value: agent.role)
             detailRow(label: "Agent ID", value: String(agent.id.prefix(12)) + "...")
             detailRow(label: "Desk", value: agent.deskIndex.map { "Desk \($0 + 1)" } ?? "None")
             detailRow(label: "Uptime", value: agent.uptime)
@@ -120,6 +186,36 @@ struct AgentInspectorView: View {
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .background(MajorTomTheme.Colors.background)
                 .clipShape(RoundedRectangle(cornerRadius: MajorTomTheme.Radius.small))
+        }
+    }
+
+    // MARK: - Message Input
+
+    private var messageInput: some View {
+        VStack(alignment: .leading, spacing: MajorTomTheme.Spacing.xs) {
+            Text("Send Message")
+                .font(MajorTomTheme.Typography.caption)
+                .foregroundStyle(MajorTomTheme.Colors.textTertiary)
+
+            HStack(spacing: MajorTomTheme.Spacing.sm) {
+                TextField("Message to agent...", text: $messageText)
+                    .font(MajorTomTheme.Typography.codeFontSmall)
+                    .foregroundStyle(MajorTomTheme.Colors.textPrimary)
+                    .padding(MajorTomTheme.Spacing.sm)
+                    .background(MajorTomTheme.Colors.background)
+                    .clipShape(RoundedRectangle(cornerRadius: MajorTomTheme.Radius.small))
+
+                Button {
+                    guard !messageText.trimmingCharacters(in: .whitespaces).isEmpty else { return }
+                    onSendMessage?(messageText)
+                    messageText = ""
+                } label: {
+                    Image(systemName: "paperplane.fill")
+                        .font(.system(size: 14))
+                        .foregroundStyle(messageText.isEmpty ? MajorTomTheme.Colors.textTertiary : MajorTomTheme.Colors.accent)
+                }
+                .disabled(messageText.trimmingCharacters(in: .whitespaces).isEmpty)
+            }
         }
     }
 
@@ -160,4 +256,22 @@ struct AgentInspectorView: View {
             .tint(MajorTomTheme.Colors.textTertiary)
         }
     }
+}
+
+#Preview {
+    AgentInspectorView(
+        agent: AgentState(
+            id: "preview-1",
+            name: "Alice",
+            role: "frontend",
+            characterType: .dev,
+            status: .working,
+            currentTask: "Building the login page",
+            deskIndex: 0
+        ),
+        activityDescription: nil,
+        onRename: { _ in },
+        onSendMessage: { _ in },
+        onDismiss: {}
+    )
 }

--- a/ios/MajorTom/Features/Office/Views/CharacterGalleryView.swift
+++ b/ios/MajorTom/Features/Office/Views/CharacterGalleryView.swift
@@ -1,0 +1,219 @@
+import SwiftUI
+import SpriteKit
+
+// MARK: - Character Gallery View
+
+/// A swipeable horizontal carousel showing all 9 character types.
+/// Each card shows a large sprite preview, character name, and description.
+/// Idle animation plays on each preview card.
+struct CharacterGalleryView: View {
+    let onDismiss: () -> Void
+
+    @State private var selectedIndex: Int = 0
+
+    private let characters = CharacterCatalog.all
+
+    var body: some View {
+        VStack(spacing: 0) {
+            // Header
+            header
+
+            // Character carousel
+            TabView(selection: $selectedIndex) {
+                ForEach(Array(characters.enumerated()), id: \.offset) { index, config in
+                    characterCard(config: config)
+                        .tag(index)
+                }
+            }
+            .tabViewStyle(.page(indexDisplayMode: .always))
+            .frame(maxHeight: .infinity)
+
+            // Page indicator label
+            pageIndicator
+        }
+        .background(MajorTomTheme.Colors.background)
+    }
+
+    // MARK: - Header
+
+    private var header: some View {
+        HStack {
+            Text("Character Gallery")
+                .font(MajorTomTheme.Typography.title)
+                .foregroundStyle(MajorTomTheme.Colors.textPrimary)
+
+            Spacer()
+
+            Button {
+                onDismiss()
+            } label: {
+                Image(systemName: "xmark.circle.fill")
+                    .font(.title2)
+                    .foregroundStyle(MajorTomTheme.Colors.textTertiary)
+            }
+        }
+        .padding(.horizontal, MajorTomTheme.Spacing.lg)
+        .padding(.top, MajorTomTheme.Spacing.lg)
+        .padding(.bottom, MajorTomTheme.Spacing.md)
+    }
+
+    // MARK: - Character Card
+
+    private func characterCard(config: CharacterConfig) -> some View {
+        VStack(spacing: MajorTomTheme.Spacing.lg) {
+            // Sprite preview
+            spritePreview(config: config)
+
+            // Character info
+            VStack(spacing: MajorTomTheme.Spacing.sm) {
+                Text(config.displayName)
+                    .font(MajorTomTheme.Typography.headline)
+                    .foregroundStyle(MajorTomTheme.Colors.textPrimary)
+
+                Text(characterDescription(for: config.type))
+                    .font(MajorTomTheme.Typography.caption)
+                    .foregroundStyle(MajorTomTheme.Colors.textSecondary)
+                    .multilineTextAlignment(.center)
+                    .padding(.horizontal, MajorTomTheme.Spacing.xl)
+            }
+
+            // Traits
+            traitsView(config: config)
+
+            Spacer()
+        }
+        .padding(MajorTomTheme.Spacing.lg)
+    }
+
+    private func spritePreview(config: CharacterConfig) -> some View {
+        let scene = CharacterPreviewScene(characterType: config.type)
+
+        return SpriteView(scene: scene)
+            .frame(width: 120, height: 120)
+            .clipShape(RoundedRectangle(cornerRadius: MajorTomTheme.Radius.large))
+            .overlay(
+                RoundedRectangle(cornerRadius: MajorTomTheme.Radius.large)
+                    .stroke(config.spriteColor.opacity(0.5), lineWidth: 2)
+            )
+            .shadow(color: config.spriteColor.opacity(0.3), radius: 8, y: 4)
+    }
+
+    private func traitsView(config: CharacterConfig) -> some View {
+        HStack(spacing: MajorTomTheme.Spacing.sm) {
+            // Type badge
+            let isDog = [CharacterType.dachshund, .cattleDog, .schnauzerBlack, .schnauzerPepper].contains(config.type)
+            traitBadge(
+                icon: isDog ? "pawprint.fill" : "person.fill",
+                text: isDog ? "Dog" : "Human",
+                color: config.spriteColor
+            )
+
+            // Break behavior count
+            traitBadge(
+                icon: "cup.and.saucer.fill",
+                text: "\(config.breakBehaviors.count) hangouts",
+                color: MajorTomTheme.Colors.accent
+            )
+
+            // Special trait
+            if config.needsBlanket {
+                traitBadge(
+                    icon: "bed.double.fill",
+                    text: "Needs blanket",
+                    color: MajorTomTheme.Colors.warning
+                )
+            }
+        }
+    }
+
+    private func traitBadge(icon: String, text: String, color: Color) -> some View {
+        HStack(spacing: 4) {
+            Image(systemName: icon)
+                .font(.system(size: 10))
+            Text(text)
+                .font(.system(.caption2, design: .monospaced))
+        }
+        .foregroundStyle(color)
+        .padding(.horizontal, MajorTomTheme.Spacing.sm)
+        .padding(.vertical, MajorTomTheme.Spacing.xs)
+        .background(color.opacity(0.15))
+        .clipShape(Capsule())
+    }
+
+    // MARK: - Page Indicator
+
+    private var pageIndicator: some View {
+        Text("\(selectedIndex + 1) / \(characters.count)")
+            .font(MajorTomTheme.Typography.codeFontSmall)
+            .foregroundStyle(MajorTomTheme.Colors.textTertiary)
+            .padding(.bottom, MajorTomTheme.Spacing.lg)
+    }
+
+    // MARK: - Character Descriptions
+
+    private func characterDescription(for type: CharacterType) -> String {
+        switch type {
+        case .dev:
+            return "The classic coder. Lives on caffeine, thrives under pressure, and always has headphones on."
+        case .officeWorker:
+            return "Keeps the wheels turning. Organized, reliable, and always has a spreadsheet ready."
+        case .pm:
+            return "Herds cats for a living. Loves standup meetings and Gantt charts."
+        case .clown:
+            return "Office morale officer. Brings joy, chaos, and occasional whoopee cushions."
+        case .frankenstein:
+            return "The office wildcard. Bolts included. Surprisingly good at pair programming."
+        case .dachshund:
+            return "Long boi. Requires a blanket at all times. Expert at fitting under desks."
+        case .cattleDog:
+            return "High energy herder. Will round up the team for meetings whether you like it or not."
+        case .schnauzerBlack:
+            return "Distinguished and dignified. The office elder. Judges silently from their corner."
+        case .schnauzerPepper:
+            return "Salt and pepper wisdom. Best beard in the office, no contest."
+        }
+    }
+}
+
+// MARK: - Character Preview Scene
+
+/// A small SpriteKit scene that shows a single character with idle animation.
+final class CharacterPreviewScene: SKScene {
+    private let characterType: CharacterType
+
+    init(characterType: CharacterType) {
+        self.characterType = characterType
+        super.init(size: CGSize(width: 120, height: 120))
+        scaleMode = .aspectFit
+        backgroundColor = SKColor(red: 0.12, green: 0.12, blue: 0.15, alpha: 1.0)
+        anchorPoint = CGPoint(x: 0.5, y: 0.5)
+    }
+
+    @available(*, unavailable)
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func didMove(to view: SKView) {
+        super.didMove(to: view)
+
+        // Build and add a scaled-up version of the pixel art
+        let pixelArt = PixelArtBuilder.build(for: characterType)
+        pixelArt.setScale(3.0) // 3x scale for preview
+        pixelArt.position = CGPoint(x: 0, y: 0)
+        addChild(pixelArt)
+
+        // Add idle bobbing animation
+        let bob = SKAction.sequence([
+            SKAction.moveBy(x: 0, y: 4, duration: 0.8),
+            SKAction.moveBy(x: 0, y: -4, duration: 0.8),
+        ])
+        pixelArt.run(SKAction.repeatForever(bob))
+    }
+}
+
+// MARK: - Preview
+
+#Preview {
+    CharacterGalleryView(onDismiss: {})
+}

--- a/ios/MajorTom/Features/Office/Views/OfficeView.swift
+++ b/ios/MajorTom/Features/Office/Views/OfficeView.swift
@@ -7,6 +7,7 @@ import SpriteKit
 /// Manages the bridge between OfficeViewModel state changes and the SKScene.
 struct OfficeView: View {
     @Bindable var viewModel: OfficeViewModel
+    var relay: RelayService?
     @State private var scene: OfficeScene = {
         let scene = OfficeScene()
         scene.size = CGSize(width: OfficeLayout.sceneWidth, height: OfficeLayout.sceneHeight)
@@ -27,16 +28,37 @@ struct OfficeView: View {
                     syncScene(with: newAgents)
                 }
 
-            // Top overlay: agent count + mini-map placeholder
+            // Top overlay: agent count + controls
             VStack {
                 topBar
                 Spacer()
+
+                // Demo mode indicator
+                if viewModel.isDemoMode {
+                    demoModeBanner
+                }
             }
         }
         .onAppear {
             scene.onAgentTapped = { agentId in
                 if let agent = viewModel.agents.first(where: { $0.id == agentId }) {
                     viewModel.selectAgent(agent)
+                }
+            }
+
+            // Start activity cycling
+            viewModel.activityManager.startCycling { [weak scene] agentId, station in
+                if let station {
+                    scene?.moveAgentToStation(id: agentId, stationType: station.type)
+                }
+            }
+
+            // Auto-detect demo mode if no active agents and not connected
+            if viewModel.agents.isEmpty {
+                if let relay, relay.connectionState == .disconnected {
+                    viewModel.startDemoMode()
+                } else if relay == nil {
+                    viewModel.startDemoMode()
                 }
             }
         }
@@ -47,15 +69,30 @@ struct OfficeView: View {
             if let agent = viewModel.selectedAgent {
                 AgentInspectorView(
                     agent: agent,
+                    activityDescription: viewModel.activityManager.activityDescription(for: agent.id),
                     onRename: { newName in
                         viewModel.renameAgent(id: agent.id, newName: newName)
                         scene.updateAgentName(id: agent.id, name: newName)
                     },
+                    onSendMessage: relay != nil ? { message in
+                        Task {
+                            try? await relay?.sendAgentMessage(
+                                sessionId: relay?.currentSession?.id ?? "",
+                                agentId: agent.id,
+                                text: message
+                            )
+                        }
+                    } : nil,
                     onDismiss: {
                         viewModel.dismissInspector()
                     }
                 )
             }
+        }
+        .sheet(isPresented: $viewModel.showCharacterGallery) {
+            CharacterGalleryView(onDismiss: {
+                viewModel.showCharacterGallery = false
+            })
         }
     }
 
@@ -64,19 +101,66 @@ struct OfficeView: View {
     private var topBar: some View {
         HStack {
             // Agent count
-            Label("\(viewModel.agents.count) agents", systemImage: "person.2.fill")
-                .font(MajorTomTheme.Typography.caption)
-                .foregroundStyle(MajorTomTheme.Colors.textSecondary)
-                .padding(.horizontal, MajorTomTheme.Spacing.md)
-                .padding(.vertical, MajorTomTheme.Spacing.sm)
-                .glassBackground()
+            Label(
+                "\(viewModel.agents.count) agent\(viewModel.agents.count == 1 ? "" : "s")",
+                systemImage: "person.2.fill"
+            )
+            .font(MajorTomTheme.Typography.caption)
+            .foregroundStyle(MajorTomTheme.Colors.textSecondary)
+            .padding(.horizontal, MajorTomTheme.Spacing.md)
+            .padding(.vertical, MajorTomTheme.Spacing.sm)
+            .glassBackground()
 
             Spacer()
+
+            // Character gallery button
+            Button {
+                viewModel.showCharacterGallery = true
+            } label: {
+                Image(systemName: "person.crop.rectangle.stack")
+                    .font(.system(size: 16))
+                    .foregroundStyle(MajorTomTheme.Colors.textSecondary)
+                    .padding(MajorTomTheme.Spacing.sm)
+                    .glassBackground()
+            }
+
+            // Demo mode toggle
+            Button {
+                viewModel.toggleDemoMode()
+            } label: {
+                Image(systemName: viewModel.isDemoMode ? "play.slash.fill" : "play.fill")
+                    .font(.system(size: 14))
+                    .foregroundStyle(
+                        viewModel.isDemoMode
+                            ? MajorTomTheme.Colors.accent
+                            : MajorTomTheme.Colors.textSecondary
+                    )
+                    .padding(MajorTomTheme.Spacing.sm)
+                    .glassBackground()
+            }
 
             // Mini-map placeholder
             miniMapPlaceholder
         }
         .padding(MajorTomTheme.Spacing.md)
+    }
+
+    /// Demo mode banner at bottom of screen.
+    private var demoModeBanner: some View {
+        HStack(spacing: MajorTomTheme.Spacing.sm) {
+            Image(systemName: "theatermasks.fill")
+                .font(.system(size: 12))
+            Text("DEMO MODE")
+                .font(.system(.caption2, design: .monospaced, weight: .bold))
+            Text("Tap play to stop")
+                .font(.system(.caption2, design: .monospaced))
+                .foregroundStyle(MajorTomTheme.Colors.textTertiary)
+        }
+        .foregroundStyle(MajorTomTheme.Colors.accent)
+        .padding(.horizontal, MajorTomTheme.Spacing.md)
+        .padding(.vertical, MajorTomTheme.Spacing.sm)
+        .glassBackground()
+        .padding(.bottom, MajorTomTheme.Spacing.md)
     }
 
     /// Placeholder for the mini-map concept.
@@ -157,13 +241,18 @@ struct OfficeView: View {
             }
 
         case .idle:
-            // Pick a random break area based on character config
-            let config = CharacterCatalog.config(for: agent.characterType)
-            if let destination = config.breakBehaviors.randomElement() {
-                let areaType = breakDestinationToArea(destination)
-                scene.moveAgentToBreakArea(id: agent.id, areaType: areaType)
+            // Try to assign to an activity station first
+            if let station = viewModel.activityManager.assignStation(for: agent.id) {
+                scene.moveAgentToStation(id: agent.id, stationType: station.type)
             } else {
-                scene.updateAgentStatus(id: agent.id, status: .idle)
+                // Fall back to break area behavior
+                let config = CharacterCatalog.config(for: agent.characterType)
+                if let destination = config.breakBehaviors.randomElement() {
+                    let areaType = breakDestinationToArea(destination)
+                    scene.moveAgentToBreakArea(id: agent.id, areaType: areaType)
+                } else {
+                    scene.updateAgentStatus(id: agent.id, status: .idle)
+                }
             }
 
         case .celebrating:
@@ -190,3 +279,6 @@ struct OfficeView: View {
     }
 }
 
+#Preview {
+    OfficeView(viewModel: OfficeViewModel())
+}


### PR DESCRIPTION
## Summary
- **Demo mode** — 14 fake agents cycling through states when no active session
- **Idle activities** — 7 station types (ping pong, coffee, yoga, etc.) with unique animations
- **Activity manager** — assigns idle agents to stations, cycles every 5-15s
- **Character gallery** — swipeable carousel of all 9 character types with previews
- **Agent inspector enhancement** — text input for sending messages to specific agents
- **Station sprites** — colored areas with labels, ambient animations (coffee steam, ball bounce)

## Test plan
- [ ] Launch app without session → verify demo mode with 14 agents
- [ ] Observe idle agents → verify they move to activity stations
- [ ] Tap character gallery button → verify carousel with all 9 characters
- [ ] Tap agent → verify inspector shows activity + message input
- [ ] Connect to session → verify demo mode stops, real agents take over

🤖 Generated with [Claude Code](https://claude.com/claude-code)