### PR TITLE
feat(macos): Ground Control Wave 1 — menu bar app scaffold with relay process management

### DIFF
--- a/macos/.gitignore
+++ b/macos/.gitignore
@@ -1,0 +1,9 @@
+# SwiftPM build artifacts
+.build/
+.swiftpm/
+
+# Bundled binaries (built by scripts)
+build/
+
+# Cached downloads
+.cache/

--- a/macos/GroundControl/App/GroundControlApp.swift
+++ b/macos/GroundControl/App/GroundControlApp.swift
@@ -1,0 +1,65 @@
+import SwiftUI
+
+/// Ground Control — macOS menu bar app for managing the Major Tom relay server.
+///
+/// Lives in the menu bar (no dock icon). Provides start/stop/restart controls,
+/// quick links to the PWA, and a placeholder management window for future waves.
+@main
+struct GroundControlApp: App {
+    @State private var relay = RelayProcess()
+
+    var body: some Scene {
+        // Menu bar extra — the primary UI
+        MenuBarExtra {
+            MenuBarView(relay: relay)
+        } label: {
+            menuBarLabel
+        }
+
+        // Management window — empty stub for future waves
+        Window("Ground Control", id: "management") {
+            ManagementPlaceholderView()
+                .frame(minWidth: 600, minHeight: 400)
+        }
+        .defaultSize(width: 800, height: 600)
+    }
+
+    /// Menu bar icon with status-aware appearance.
+    @ViewBuilder
+    private var menuBarLabel: some View {
+        switch relay.state.processState {
+        case .running:
+            Image(systemName: "antenna.radiowaves.left.and.right")
+                .symbolRenderingMode(.palette)
+                .foregroundStyle(.green, .primary)
+        case .error:
+            Image(systemName: "antenna.radiowaves.left.and.right")
+                .symbolRenderingMode(.palette)
+                .foregroundStyle(.red, .primary)
+        case .starting, .stopping:
+            Image(systemName: "antenna.radiowaves.left.and.right")
+                .symbolRenderingMode(.palette)
+                .foregroundStyle(.yellow, .primary)
+        case .idle:
+            Image(systemName: "antenna.radiowaves.left.and.right")
+        }
+    }
+}
+
+/// Placeholder view for the management window (Wave 2+).
+struct ManagementPlaceholderView: View {
+    var body: some View {
+        VStack(spacing: 16) {
+            Image(systemName: "antenna.radiowaves.left.and.right")
+                .font(.system(size: 48))
+                .foregroundStyle(.secondary)
+
+            Text("Ground Control")
+                .font(.title)
+
+            Text("Management window coming in a future update.")
+                .foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+}

--- a/macos/GroundControl/Info.plist
+++ b/macos/GroundControl/Info.plist
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleName</key>
+    <string>Ground Control</string>
+    <key>CFBundleDisplayName</key>
+    <string>Ground Control</string>
+    <key>CFBundleIdentifier</key>
+    <string>com.majortom.groundcontrol</string>
+    <key>CFBundleVersion</key>
+    <string>1</string>
+    <key>CFBundleShortVersionString</key>
+    <string>0.1.0</string>
+    <key>CFBundlePackageType</key>
+    <string>APPL</string>
+    <key>CFBundleExecutable</key>
+    <string>GroundControl</string>
+    <key>LSMinimumSystemVersion</key>
+    <string>14.0</string>
+    <key>LSUIElement</key>
+    <true/>
+    <key>NSHumanReadableCopyright</key>
+    <string>Copyright 2026 Major Tom. All rights reserved.</string>
+</dict>
+</plist>

--- a/macos/GroundControl/Models/RelayState.swift
+++ b/macos/GroundControl/Models/RelayState.swift
@@ -1,0 +1,73 @@
+import Foundation
+
+/// Observable state for the relay server process.
+@Observable
+final class RelayState {
+    /// Process lifecycle states.
+    enum ProcessState: Equatable {
+        case idle
+        case starting
+        case running
+        case stopping
+        case error(String)
+    }
+
+    var processState: ProcessState = .idle
+    var port: Int = 9090
+    var hookPort: Int = 9091
+    var clientCount: Int = 0
+
+    // MARK: - Computed Properties
+
+    var isRunning: Bool {
+        processState == .running
+    }
+
+    var canStart: Bool {
+        switch processState {
+        case .idle, .error:
+            return true
+        default:
+            return false
+        }
+    }
+
+    var canStop: Bool {
+        processState == .running
+    }
+
+    var statusText: String {
+        switch processState {
+        case .idle:
+            return "Relay Stopped"
+        case .starting:
+            return "Relay Starting..."
+        case .running:
+            return "Relay Running"
+        case .stopping:
+            return "Relay Stopping..."
+        case .error(let message):
+            return "Error: \(message)"
+        }
+    }
+
+    var statusColor: String {
+        switch processState {
+        case .idle, .stopping:
+            return "gray"
+        case .starting:
+            return "yellow"
+        case .running:
+            return "green"
+        case .error:
+            return "red"
+        }
+    }
+
+    var errorMessage: String? {
+        if case .error(let message) = processState {
+            return message
+        }
+        return nil
+    }
+}

--- a/macos/GroundControl/Services/NodeBundleManager.swift
+++ b/macos/GroundControl/Services/NodeBundleManager.swift
@@ -1,0 +1,164 @@
+import Foundation
+
+/// Locates bundled Node.js binary and relay dist files.
+///
+/// In production, everything is inside the app bundle. In development,
+/// falls back to local paths (system `node`, local `relay/dist/`).
+struct NodeBundleManager {
+    struct BundlePaths {
+        let nodeBinary: URL
+        let relayEntry: URL
+        let relayDir: URL
+        let isDevelopment: Bool
+    }
+
+    enum BundleError: LocalizedError {
+        case nodeNotFound
+        case relayNotFound
+        case nodeNotExecutable
+
+        var errorDescription: String? {
+            switch self {
+            case .nodeNotFound:
+                return "Node.js binary not found in app bundle or system PATH"
+            case .relayNotFound:
+                return "Relay server files not found in app bundle or local relay/dist/"
+            case .nodeNotExecutable:
+                return "Node.js binary exists but is not executable"
+            }
+        }
+    }
+
+    /// Resolve paths to the Node binary and relay dist.
+    ///
+    /// Tries the app bundle first, then falls back to development paths.
+    static func resolve() throws -> BundlePaths {
+        // Try bundled paths first
+        if let bundled = tryBundledPaths() {
+            return bundled
+        }
+
+        // Fall back to development paths
+        if let dev = tryDevelopmentPaths() {
+            return dev
+        }
+
+        // Nothing found — figure out what's missing for a useful error
+        if findSystemNode() == nil {
+            throw BundleError.nodeNotFound
+        }
+        throw BundleError.relayNotFound
+    }
+
+    // MARK: - Bundled (production)
+
+    private static func tryBundledPaths() -> BundlePaths? {
+        guard let nodeURL = Bundle.main.url(forResource: "node", withExtension: nil, subdirectory: "node"),
+              let relayURL = Bundle.main.url(forResource: "server", withExtension: "js", subdirectory: "relay-dist")
+        else {
+            return nil
+        }
+
+        guard FileManager.default.isExecutableFile(atPath: nodeURL.path) else {
+            return nil
+        }
+
+        return BundlePaths(
+            nodeBinary: nodeURL,
+            relayEntry: relayURL,
+            relayDir: relayURL.deletingLastPathComponent(),
+            isDevelopment: false
+        )
+    }
+
+    // MARK: - Development fallback
+
+    private static func tryDevelopmentPaths() -> BundlePaths? {
+        guard let node = findSystemNode() else { return nil }
+
+        // Walk up from the executable or current working directory to find
+        // the project root containing relay/dist/server.js
+        let candidates = projectRootCandidates()
+
+        for root in candidates {
+            let relayEntry = root.appendingPathComponent("relay/dist/server.js")
+            if FileManager.default.fileExists(atPath: relayEntry.path) {
+                return BundlePaths(
+                    nodeBinary: node,
+                    relayEntry: relayEntry,
+                    relayDir: relayEntry.deletingLastPathComponent(),
+                    isDevelopment: true
+                )
+            }
+        }
+
+        return nil
+    }
+
+    /// Find `node` on the system PATH.
+    private static func findSystemNode() -> URL? {
+        let process = Process()
+        let pipe = Pipe()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/which")
+        process.arguments = ["node"]
+        process.standardOutput = pipe
+        process.standardError = FileHandle.nullDevice
+
+        do {
+            try process.run()
+            process.waitUntilExit()
+
+            guard process.terminationStatus == 0 else { return nil }
+
+            let data = pipe.fileHandleForReading.readDataToEndOfFile()
+            guard let path = String(data: data, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines),
+                  !path.isEmpty
+            else { return nil }
+
+            let url = URL(fileURLWithPath: path)
+            guard FileManager.default.isExecutableFile(atPath: url.path) else { return nil }
+            return url
+        } catch {
+            return nil
+        }
+    }
+
+    /// Candidate project root directories for development mode.
+    private static func projectRootCandidates() -> [URL] {
+        var candidates: [URL] = []
+
+        // 1. Working directory
+        let cwd = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+        candidates.append(cwd)
+
+        // 2. Walk up from the main bundle executable
+        if let execURL = Bundle.main.executableURL {
+            var dir = execURL.deletingLastPathComponent()
+            for _ in 0..<6 {
+                candidates.append(dir)
+                let parent = dir.deletingLastPathComponent()
+                if parent == dir { break }
+                dir = parent
+            }
+        }
+
+        return candidates
+    }
+
+    /// Validate that all required paths exist and are accessible.
+    static func validate(_ paths: BundlePaths) -> [String] {
+        var issues: [String] = []
+
+        if !FileManager.default.fileExists(atPath: paths.nodeBinary.path) {
+            issues.append("Node binary missing at \(paths.nodeBinary.path)")
+        } else if !FileManager.default.isExecutableFile(atPath: paths.nodeBinary.path) {
+            issues.append("Node binary not executable at \(paths.nodeBinary.path)")
+        }
+
+        if !FileManager.default.fileExists(atPath: paths.relayEntry.path) {
+            issues.append("Relay entry not found at \(paths.relayEntry.path)")
+        }
+
+        return issues
+    }
+}

--- a/macos/GroundControl/Services/RelayProcess.swift
+++ b/macos/GroundControl/Services/RelayProcess.swift
@@ -1,0 +1,228 @@
+@preconcurrency import Dispatch
+import Foundation
+
+/// Manages the relay server as a child process using Foundation.Process.
+///
+/// Spawns `node server.js` with the bundled (or system) Node binary,
+/// handles graceful shutdown via SIGTERM, and tracks process state.
+@Observable
+final class RelayProcess {
+    private(set) var state = RelayState()
+
+    private var process: Process?
+    private var stdoutPipe: Pipe?
+    private var stderrPipe: Pipe?
+    private var terminationObserver: NSObjectProtocol?
+
+    /// Grace period before SIGKILL after SIGTERM (seconds).
+    private let shutdownTimeout: TimeInterval = 5.0
+
+    // MARK: - Lifecycle
+
+    func start() async {
+        guard state.canStart else { return }
+
+        state.processState = .starting
+
+        do {
+            let paths = try NodeBundleManager.resolve()
+            let issues = NodeBundleManager.validate(paths)
+            if !issues.isEmpty {
+                state.processState = .error(issues.joined(separator: "; "))
+                return
+            }
+
+            // Check for tmux
+            if !tmuxAvailable() {
+                state.processState = .error("tmux not found — install with 'brew install tmux'")
+                return
+            }
+
+            try launchProcess(paths: paths)
+            state.processState = .running
+
+            if paths.isDevelopment {
+                print("[GroundControl] Running in DEVELOPMENT mode")
+                print("[GroundControl] Node: \(paths.nodeBinary.path)")
+                print("[GroundControl] Relay: \(paths.relayEntry.path)")
+            }
+        } catch {
+            state.processState = .error(error.localizedDescription)
+        }
+    }
+
+    func stop() async {
+        guard state.canStop, let proc = process else { return }
+
+        state.processState = .stopping
+
+        // Send SIGTERM for graceful shutdown
+        proc.interrupt() // sends SIGINT, but Node handles both
+        // Actually send SIGTERM which is what the relay expects
+        kill(proc.processIdentifier, SIGTERM)
+
+        // Wait for graceful exit with timeout
+        let terminated = await waitForTermination(timeout: shutdownTimeout)
+
+        if !terminated {
+            // Force kill after timeout
+            print("[GroundControl] Process did not exit in \(shutdownTimeout)s — sending SIGKILL")
+            proc.terminate() // SIGTERM again via Foundation
+            kill(proc.processIdentifier, SIGKILL)
+        }
+
+        cleanup()
+        state.processState = .idle
+    }
+
+    func restart() async {
+        await stop()
+        // Brief pause to let the port release
+        try? await Task.sleep(for: .milliseconds(500))
+        await start()
+    }
+
+    // MARK: - Process Management
+
+    private func launchProcess(paths: NodeBundleManager.BundlePaths) throws {
+        let proc = Process()
+        let stdout = Pipe()
+        let stderr = Pipe()
+
+        proc.executableURL = paths.nodeBinary
+        proc.arguments = [paths.relayEntry.path]
+        proc.currentDirectoryURL = paths.relayDir
+
+        // Environment
+        var env = ProcessInfo.processInfo.environment
+        env["NODE_ENV"] = paths.isDevelopment ? "development" : "production"
+        env["WS_PORT"] = String(state.port)
+        env["HOOK_PORT"] = String(state.hookPort)
+        env["LOG_LEVEL"] = "info"
+        // Inherit CLAUDE_WORK_DIR from parent env, or use home directory
+        if env["CLAUDE_WORK_DIR"] == nil {
+            env["CLAUDE_WORK_DIR"] = FileManager.default.homeDirectoryForCurrentUser.path
+        }
+        proc.environment = env
+
+        proc.standardOutput = stdout
+        proc.standardError = stderr
+
+        // Pipe output to console (future: LogStore)
+        readPipeAsync(stdout, label: "stdout")
+        readPipeAsync(stderr, label: "stderr")
+
+        // Watch for unexpected termination
+        terminationObserver = NotificationCenter.default.addObserver(
+            forName: Process.didTerminateNotification,
+            object: proc,
+            queue: .main
+        ) { [weak self] _ in
+            self?.handleTermination()
+        }
+
+        try proc.run()
+
+        self.process = proc
+        self.stdoutPipe = stdout
+        self.stderrPipe = stderr
+
+        print("[GroundControl] Relay started (PID: \(proc.processIdentifier)) on port \(state.port)")
+    }
+
+    private func handleTermination() {
+        guard let proc = process else { return }
+
+        let status = proc.terminationStatus
+
+        // If we're in .stopping state, this is expected — stop() handles the cleanup
+        if state.processState == .stopping { return }
+
+        // Unexpected termination
+        if status != 0 {
+            state.processState = .error("Process exited with code \(status)")
+            print("[GroundControl] Relay exited unexpectedly (code: \(status))")
+        } else {
+            state.processState = .idle
+            print("[GroundControl] Relay exited cleanly")
+        }
+
+        cleanup()
+    }
+
+    private func cleanup() {
+        if let observer = terminationObserver {
+            NotificationCenter.default.removeObserver(observer)
+            terminationObserver = nil
+        }
+        process = nil
+        stdoutPipe = nil
+        stderrPipe = nil
+    }
+
+    private func waitForTermination(timeout: TimeInterval) async -> Bool {
+        guard let proc = process else { return true }
+
+        return await withCheckedContinuation { continuation in
+            let workItem = DispatchWorkItem {
+                proc.waitUntilExit()
+                continuation.resume(returning: true)
+            }
+
+            DispatchQueue.global().async(execute: workItem)
+
+            DispatchQueue.global().asyncAfter(deadline: .now() + timeout) {
+                if !workItem.isCancelled {
+                    workItem.cancel()
+                    continuation.resume(returning: false)
+                }
+            }
+        }
+    }
+
+    // MARK: - Output Handling
+
+    private func readPipeAsync(_ pipe: Pipe, label: String) {
+        pipe.fileHandleForReading.readabilityHandler = { handle in
+            let data = handle.availableData
+            guard !data.isEmpty else {
+                handle.readabilityHandler = nil
+                return
+            }
+            if let text = String(data: data, encoding: .utf8) {
+                // Print to console for now — future: feed into LogStore
+                for line in text.split(separator: "\n", omittingEmptySubsequences: false) {
+                    if !line.isEmpty {
+                        print("[relay/\(label)] \(line)")
+                    }
+                }
+            }
+        }
+    }
+
+    // MARK: - Dependency Checks
+
+    private func tmuxAvailable() -> Bool {
+        let proc = Process()
+        proc.executableURL = URL(fileURLWithPath: "/usr/bin/which")
+        proc.arguments = ["tmux"]
+        proc.standardOutput = FileHandle.nullDevice
+        proc.standardError = FileHandle.nullDevice
+
+        do {
+            try proc.run()
+            proc.waitUntilExit()
+            return proc.terminationStatus == 0
+        } catch {
+            return false
+        }
+    }
+
+    deinit {
+        // Best-effort cleanup if the object is destroyed while running
+        if let proc = process, proc.isRunning {
+            kill(proc.processIdentifier, SIGTERM)
+        }
+        cleanup()
+    }
+}

--- a/macos/GroundControl/Services/RelayProcess.swift
+++ b/macos/GroundControl/Services/RelayProcess.swift
@@ -164,18 +164,28 @@ final class RelayProcess {
         guard let proc = process else { return true }
 
         return await withCheckedContinuation { continuation in
+            let resumeLock = NSLock()
+            var didResume = false
+
+            func resumeOnce(_ result: Bool) {
+                resumeLock.lock()
+                defer { resumeLock.unlock() }
+
+                guard !didResume else { return }
+                didResume = true
+                continuation.resume(returning: result)
+            }
+
             let workItem = DispatchWorkItem {
                 proc.waitUntilExit()
-                continuation.resume(returning: true)
+                resumeOnce(true)
             }
 
             DispatchQueue.global().async(execute: workItem)
 
             DispatchQueue.global().asyncAfter(deadline: .now() + timeout) {
-                if !workItem.isCancelled {
-                    workItem.cancel()
-                    continuation.resume(returning: false)
-                }
+                workItem.cancel()
+                resumeOnce(false)
             }
         }
     }
@@ -203,11 +213,33 @@ final class RelayProcess {
     // MARK: - Dependency Checks
 
     private func tmuxAvailable() -> Bool {
+        // Check common Homebrew and system paths first, since GUI-launched
+        // macOS apps often have a minimal PATH that excludes /opt/homebrew/bin
+        // and /usr/local/bin where Homebrew installs tmux.
+        let knownPaths = [
+            "/opt/homebrew/bin/tmux",   // Apple Silicon Homebrew
+            "/usr/local/bin/tmux",      // Intel Homebrew
+            "/usr/bin/tmux",            // System (unlikely but possible)
+        ]
+
+        for path in knownPaths {
+            if FileManager.default.isExecutableFile(atPath: path) {
+                return true
+            }
+        }
+
+        // Fall back to which(1) with an expanded PATH for any non-standard installs
         let proc = Process()
         proc.executableURL = URL(fileURLWithPath: "/usr/bin/which")
         proc.arguments = ["tmux"]
         proc.standardOutput = FileHandle.nullDevice
         proc.standardError = FileHandle.nullDevice
+
+        // Inject Homebrew paths into the probe's PATH so which can find them
+        var env = ProcessInfo.processInfo.environment
+        let extraPaths = "/opt/homebrew/bin:/usr/local/bin"
+        env["PATH"] = extraPaths + ":" + (env["PATH"] ?? "/usr/bin:/bin")
+        proc.environment = env
 
         do {
             try proc.run()

--- a/macos/GroundControl/Views/MenuBarView.swift
+++ b/macos/GroundControl/Views/MenuBarView.swift
@@ -1,0 +1,134 @@
+import SwiftUI
+
+/// Menu bar dropdown content for Ground Control.
+struct MenuBarView: View {
+    let relay: RelayProcess
+
+    @Environment(\.openURL) private var openURL
+    @Environment(\.openWindow) private var openWindow
+
+    var body: some View {
+        // Status line
+        statusSection
+
+        Divider()
+
+        // Actions
+        actionSection
+
+        Divider()
+
+        // Links
+        linkSection
+
+        Divider()
+
+        // Management & Quit
+        footerSection
+    }
+
+    // MARK: - Sections
+
+    @ViewBuilder
+    private var statusSection: some View {
+        HStack {
+            statusIndicator
+            Text(relay.state.statusText)
+        }
+
+        if relay.state.isRunning {
+            Text("Port \(relay.state.port)")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+
+        if let error = relay.state.errorMessage {
+            Text(error)
+                .font(.caption)
+                .foregroundStyle(.red)
+                .lineLimit(3)
+        }
+    }
+
+    @ViewBuilder
+    private var actionSection: some View {
+        if relay.state.canStart {
+            Button("Start Relay") {
+                Task { await relay.start() }
+            }
+            .keyboardShortcut("s", modifiers: [.command])
+        }
+
+        if relay.state.canStop {
+            Button("Stop Relay") {
+                Task { await relay.stop() }
+            }
+            .keyboardShortcut("x", modifiers: [.command])
+        }
+
+        if relay.state.isRunning {
+            Button("Restart Relay") {
+                Task { await relay.restart() }
+            }
+            .keyboardShortcut("r", modifiers: [.command])
+        }
+    }
+
+    @ViewBuilder
+    private var linkSection: some View {
+        Button("Open PWA in Browser...") {
+            let url = URL(string: "http://localhost:\(relay.state.port)")!
+            openURL(url)
+        }
+        .disabled(!relay.state.isRunning)
+
+        Button("Copy Tunnel URL...") {
+            // Placeholder for future Cloudflare tunnel integration
+        }
+        .disabled(true)
+    }
+
+    @ViewBuilder
+    private var footerSection: some View {
+        Button("Management...") {
+            openWindow(id: "management")
+        }
+
+        Divider()
+
+        Button("Quit Ground Control") {
+            // Stop the relay gracefully before quitting
+            Task {
+                if relay.state.isRunning {
+                    await relay.stop()
+                }
+                NSApplication.shared.terminate(nil)
+            }
+        }
+        .keyboardShortcut("q", modifiers: [.command])
+    }
+
+    // MARK: - Status Indicator
+
+    @ViewBuilder
+    private var statusIndicator: some View {
+        switch relay.state.processState {
+        case .running:
+            Image(systemName: "circle.fill")
+                .foregroundStyle(.green)
+                .font(.caption2)
+        case .starting, .stopping:
+            Image(systemName: "circle.fill")
+                .foregroundStyle(.yellow)
+                .font(.caption2)
+        case .error:
+            Image(systemName: "exclamationmark.triangle.fill")
+                .foregroundStyle(.red)
+                .font(.caption2)
+        case .idle:
+            Image(systemName: "circle")
+                .foregroundStyle(.secondary)
+                .font(.caption2)
+        }
+    }
+}

--- a/macos/GroundControl/Views/MenuBarView.swift
+++ b/macos/GroundControl/Views/MenuBarView.swift
@@ -1,3 +1,4 @@
+import AppKit
 import SwiftUI
 
 /// Menu bar dropdown content for Ground Control.

--- a/macos/Package.swift
+++ b/macos/Package.swift
@@ -1,0 +1,17 @@
+// swift-tools-version: 5.9
+
+import PackageDescription
+
+let package = Package(
+    name: "GroundControl",
+    platforms: [
+        .macOS(.v14),
+    ],
+    targets: [
+        .executableTarget(
+            name: "GroundControl",
+            path: "GroundControl",
+            exclude: ["Info.plist"]
+        ),
+    ]
+)

--- a/macos/scripts/bundle-node.sh
+++ b/macos/scripts/bundle-node.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+#
+# bundle-node.sh — Downloads Node.js v22 LTS binary for macOS arm64
+# and stages just the `node` executable for app bundle embedding.
+#
+# Usage: ./bundle-node.sh [output-dir]
+#   output-dir: where to place the node binary (default: ./build/node)
+#
+# Idempotent: skips download if the cached tarball already exists.
+
+set -euo pipefail
+
+NODE_VERSION="22.16.0"
+ARCH="arm64"
+PLATFORM="darwin"
+TARBALL="node-v${NODE_VERSION}-${PLATFORM}-${ARCH}.tar.gz"
+DOWNLOAD_URL="https://nodejs.org/dist/v${NODE_VERSION}/${TARBALL}"
+
+# Directories
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CACHE_DIR="${SCRIPT_DIR}/../.cache"
+OUTPUT_DIR="${1:-${SCRIPT_DIR}/../build/node}"
+
+mkdir -p "${CACHE_DIR}" "${OUTPUT_DIR}"
+
+CACHED_TARBALL="${CACHE_DIR}/${TARBALL}"
+EXTRACTED_DIR="${CACHE_DIR}/node-v${NODE_VERSION}-${PLATFORM}-${ARCH}"
+
+echo "=== Ground Control: Bundle Node.js v${NODE_VERSION} (${ARCH}) ==="
+
+# Download if not cached
+if [[ -f "${CACHED_TARBALL}" ]]; then
+    echo "Using cached tarball: ${CACHED_TARBALL}"
+else
+    echo "Downloading Node.js v${NODE_VERSION}..."
+    curl -fSL --progress-bar -o "${CACHED_TARBALL}" "${DOWNLOAD_URL}"
+    echo "Downloaded to ${CACHED_TARBALL}"
+fi
+
+# Extract if not already extracted
+if [[ ! -f "${EXTRACTED_DIR}/bin/node" ]]; then
+    echo "Extracting..."
+    tar -xzf "${CACHED_TARBALL}" -C "${CACHE_DIR}"
+fi
+
+# Copy just the node binary
+cp "${EXTRACTED_DIR}/bin/node" "${OUTPUT_DIR}/node"
+chmod +x "${OUTPUT_DIR}/node"
+
+# Verify
+NODE_BUNDLED_VERSION=$("${OUTPUT_DIR}/node" --version)
+echo "Bundled node binary: ${OUTPUT_DIR}/node (${NODE_BUNDLED_VERSION})"
+echo "=== Done ==="

--- a/macos/scripts/bundle-relay.sh
+++ b/macos/scripts/bundle-relay.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+#
+# bundle-relay.sh — Builds the relay server and stages its dist output
+# plus the node-pty native addon for app bundle embedding.
+#
+# Usage: ./bundle-relay.sh [output-dir]
+#   output-dir: where to place relay dist files (default: ./build/relay-dist)
+#
+# Requires: npm, node
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="${SCRIPT_DIR}/../.."
+RELAY_DIR="${PROJECT_ROOT}/relay"
+OUTPUT_DIR="${1:-${SCRIPT_DIR}/../build/relay-dist}"
+
+echo "=== Ground Control: Bundle Relay Server ==="
+
+# Verify relay source exists
+if [[ ! -f "${RELAY_DIR}/package.json" ]]; then
+    echo "ERROR: relay/package.json not found at ${RELAY_DIR}"
+    exit 1
+fi
+
+# Install dependencies if needed
+if [[ ! -d "${RELAY_DIR}/node_modules" ]]; then
+    echo "Installing relay dependencies..."
+    (cd "${RELAY_DIR}" && npm ci)
+fi
+
+# Build the relay (tsc + esbuild)
+echo "Building relay..."
+(cd "${RELAY_DIR}" && npm run build)
+
+# Verify build output
+if [[ ! -f "${RELAY_DIR}/dist/server.js" ]]; then
+    echo "ERROR: Build failed — relay/dist/server.js not found"
+    exit 1
+fi
+
+# Stage the dist output
+mkdir -p "${OUTPUT_DIR}"
+echo "Copying relay dist..."
+cp -R "${RELAY_DIR}/dist/"* "${OUTPUT_DIR}/"
+
+# Copy node-pty native addon
+# node-pty compiles a .node file that lives in node_modules
+echo "Locating node-pty native addon..."
+
+NODE_PTY_BINDING=""
+# Check common locations for the native addon
+for candidate in \
+    "${RELAY_DIR}/node_modules/node-pty/build/Release/pty.node" \
+    "${RELAY_DIR}/node_modules/node-pty/build/Debug/pty.node" \
+    ; do
+    if [[ -f "${candidate}" ]]; then
+        NODE_PTY_BINDING="${candidate}"
+        break
+    fi
+done
+
+if [[ -n "${NODE_PTY_BINDING}" ]]; then
+    echo "Found node-pty binding: ${NODE_PTY_BINDING}"
+    mkdir -p "${OUTPUT_DIR}/node-pty"
+    cp "${NODE_PTY_BINDING}" "${OUTPUT_DIR}/node-pty/pty.node"
+
+    # Also copy the JS shims node-pty needs
+    if [[ -d "${RELAY_DIR}/node_modules/node-pty/lib" ]]; then
+        cp -R "${RELAY_DIR}/node_modules/node-pty/lib" "${OUTPUT_DIR}/node-pty/"
+    fi
+    echo "node-pty addon staged"
+else
+    echo "WARNING: node-pty native addon not found — relay will not be able to spawn PTY sessions"
+    echo "         This is expected if node-pty is not yet installed. Run 'cd relay && npm install' first."
+fi
+
+# Copy package.json for Node module resolution (node needs it for ESM)
+cp "${RELAY_DIR}/package.json" "${OUTPUT_DIR}/package.json"
+
+# Also need the node_modules for external dependencies that esbuild didn't bundle
+# (esbuild uses --packages=external, so runtime deps must be present)
+echo "Copying node_modules (external dependencies)..."
+if [[ -d "${RELAY_DIR}/node_modules" ]]; then
+    cp -R "${RELAY_DIR}/node_modules" "${OUTPUT_DIR}/node_modules"
+fi
+
+echo ""
+echo "Relay dist staged at: ${OUTPUT_DIR}"
+ls -la "${OUTPUT_DIR}/server.js"
+echo "=== Done ==="

--- a/macos/scripts/bundle-relay.sh
+++ b/macos/scripts/bundle-relay.sh
@@ -44,6 +44,13 @@ mkdir -p "${OUTPUT_DIR}"
 echo "Copying relay dist..."
 cp -R "${RELAY_DIR}/dist/"* "${OUTPUT_DIR}/"
 
+# Stage runtime hook templates used by the relay's hook installer
+if [[ -d "${RELAY_DIR}/scripts/hook-templates" ]]; then
+    echo "Copying relay hook templates..."
+    mkdir -p "${OUTPUT_DIR}/scripts"
+    cp -R "${RELAY_DIR}/scripts/hook-templates" "${OUTPUT_DIR}/scripts/"
+fi
+
 # Copy node-pty native addon
 # node-pty compiles a .node file that lives in node_modules
 echo "Locating node-pty native addon..."
@@ -75,15 +82,12 @@ else
     echo "         This is expected if node-pty is not yet installed. Run 'cd relay && npm install' first."
 fi
 
-# Copy package.json for Node module resolution (node needs it for ESM)
+# Install production-only dependencies into the staged output so devDependencies
+# (test frameworks, linters, etc.) are excluded and the bundle stays lean.
+echo "Installing production node_modules (--omit=dev)..."
 cp "${RELAY_DIR}/package.json" "${OUTPUT_DIR}/package.json"
-
-# Also need the node_modules for external dependencies that esbuild didn't bundle
-# (esbuild uses --packages=external, so runtime deps must be present)
-echo "Copying node_modules (external dependencies)..."
-if [[ -d "${RELAY_DIR}/node_modules" ]]; then
-    cp -R "${RELAY_DIR}/node_modules" "${OUTPUT_DIR}/node_modules"
-fi
+cp "${RELAY_DIR}/package-lock.json" "${OUTPUT_DIR}/package-lock.json" 2>/dev/null || true
+(cd "${OUTPUT_DIR}" && npm ci --omit=dev --ignore-scripts 2>/dev/null || npm install --omit=dev --ignore-scripts)
 
 echo ""
 echo "Relay dist staged at: ${OUTPUT_DIR}"


### PR DESCRIPTION
## Summary
- New macOS menu bar app (`macos/GroundControl/`) built with SwiftPM for managing the Major Tom relay server
- Foundation.Process wrapper for spawning/stopping `node server.js` with graceful shutdown (SIGTERM then 5s then SIGKILL)
- Development mode auto-detection: falls back to system `node` + local `relay/dist/` when app bundle resources aren't present
- Build scripts for bundling Node.js v22 LTS binary and relay dist into the app

## Features
- Menu bar icon (antenna) with status-aware coloring (green=running, yellow=transitioning, red=error, gray=stopped)
- Start/Stop/Restart relay controls
- "Open PWA in Browser" link
- Graceful quit (stops relay before exit)
- tmux availability check on startup
- LSUIElement (no dock icon -- lives in menu bar only)

## Test plan
- [ ] `cd macos && swift build` -- verify clean compilation
- [ ] `swift run` -- verify menu bar icon appears
- [ ] Start relay via menu bar -- verify `node server.js` spawns
- [ ] Stop relay -- verify SIGTERM sent, process exits
- [ ] Quit app while relay running -- verify graceful shutdown
- [ ] Run without tmux installed -- verify friendly error message

Generated with [Claude Code](https://claude.com/claude-code)
