### PR TITLE
feat(macos): Ground Control Wave 2 — management window with live log viewer

### DIFF
--- a/macos/GroundControl/App/GroundControlApp.swift
+++ b/macos/GroundControl/App/GroundControlApp.swift
@@ -3,7 +3,7 @@ import SwiftUI
 /// Ground Control — macOS menu bar app for managing the Major Tom relay server.
 ///
 /// Lives in the menu bar (no dock icon). Provides start/stop/restart controls,
-/// quick links to the PWA, and a placeholder management window for future waves.
+/// quick links to the PWA, and a management window with live log viewer.
 @main
 struct GroundControlApp: App {
     @State private var relay = RelayProcess()
@@ -16,12 +16,12 @@ struct GroundControlApp: App {
             menuBarLabel
         }
 
-        // Management window — empty stub for future waves
+        // Management window — log viewer and management UI
         Window("Ground Control", id: "management") {
-            ManagementPlaceholderView()
-                .frame(minWidth: 600, minHeight: 400)
+            ManagementWindow(relay: relay, logStore: relay.logStore)
+                .frame(minWidth: 700, minHeight: 450)
         }
-        .defaultSize(width: 800, height: 600)
+        .defaultSize(width: 900, height: 600)
     }
 
     /// Menu bar icon with status-aware appearance.
@@ -46,20 +46,3 @@ struct GroundControlApp: App {
     }
 }
 
-/// Placeholder view for the management window (Wave 2+).
-struct ManagementPlaceholderView: View {
-    var body: some View {
-        VStack(spacing: 16) {
-            Image(systemName: "antenna.radiowaves.left.and.right")
-                .font(.system(size: 48))
-                .foregroundStyle(.secondary)
-
-            Text("Ground Control")
-                .font(.title)
-
-            Text("Management window coming in a future update.")
-                .foregroundStyle(.secondary)
-        }
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
-    }
-}

--- a/macos/GroundControl/Models/LogEntry.swift
+++ b/macos/GroundControl/Models/LogEntry.swift
@@ -1,0 +1,132 @@
+import Foundation
+import SwiftUI
+
+/// A single parsed log entry from the relay's pino JSON output.
+struct LogEntry: Identifiable {
+    let id: UUID
+    let timestamp: Date
+    let level: LogLevel
+    let message: String
+    let rawJSON: String
+    let extra: [String: Any]
+
+    /// Pino log levels mapped to display metadata.
+    enum LogLevel: Int, CaseIterable, Comparable {
+        case trace = 10
+        case debug = 20
+        case info = 30
+        case warn = 40
+        case error = 50
+        case fatal = 60
+
+        var displayName: String {
+            switch self {
+            case .trace: "TRACE"
+            case .debug: "DEBUG"
+            case .info: "INFO"
+            case .warn: "WARN"
+            case .error: "ERROR"
+            case .fatal: "FATAL"
+            }
+        }
+
+        var color: Color {
+            switch self {
+            case .trace: .gray
+            case .debug: .blue
+            case .info: .green
+            case .warn: .yellow
+            case .error: .red
+            case .fatal: .purple
+            }
+        }
+
+        var sfSymbol: String {
+            switch self {
+            case .trace: "ant"
+            case .debug: "ladybug"
+            case .info: "info.circle"
+            case .warn: "exclamationmark.triangle"
+            case .error: "xmark.circle"
+            case .fatal: "bolt.circle"
+            }
+        }
+
+        static func < (lhs: LogLevel, rhs: LogLevel) -> Bool {
+            lhs.rawValue < rhs.rawValue
+        }
+
+        /// Attempt to parse a pino numeric level to a LogLevel.
+        /// Falls back to nearest known level for non-standard values.
+        init(pinoLevel: Int) {
+            switch pinoLevel {
+            case ...10: self = .trace
+            case 11...20: self = .debug
+            case 21...30: self = .info
+            case 31...40: self = .warn
+            case 41...50: self = .error
+            default: self = .fatal
+            }
+        }
+    }
+
+    // MARK: - Standard pino fields to strip from "extra"
+
+    private static let standardFields: Set<String> = [
+        "level", "time", "pid", "hostname", "name", "msg", "v",
+    ]
+
+    // MARK: - Parsing
+
+    /// Parse a pino JSON line into a LogEntry.
+    /// Returns nil only if the line is completely empty.
+    static func parse(line: String) -> LogEntry? {
+        let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+
+        guard let data = trimmed.data(using: .utf8),
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        else {
+            // Non-JSON line — treat as INFO with raw text
+            return LogEntry(
+                id: UUID(),
+                timestamp: Date(),
+                level: .info,
+                message: trimmed,
+                rawJSON: trimmed,
+                extra: [:]
+            )
+        }
+
+        // Parse pino fields
+        let pinoLevel = json["level"] as? Int ?? 30
+        let level = LogLevel(pinoLevel: pinoLevel)
+
+        let message = json["msg"] as? String ?? json["message"] as? String ?? ""
+
+        // Parse timestamp — pino uses epoch millis in "time"
+        let timestamp: Date
+        if let timeMs = json["time"] as? Double {
+            timestamp = Date(timeIntervalSince1970: timeMs / 1000.0)
+        } else if let timeMs = json["time"] as? Int {
+            timestamp = Date(timeIntervalSince1970: Double(timeMs) / 1000.0)
+        } else {
+            timestamp = Date()
+        }
+
+        // Collect extra fields (everything beyond standard pino fields)
+        var extra: [String: Any] = [:]
+        for (key, value) in json where !standardFields.contains(key) {
+            extra[key] = value
+        }
+
+        return LogEntry(
+            id: UUID(),
+            timestamp: timestamp,
+            level: level,
+            message: message,
+            rawJSON: trimmed,
+            extra: extra
+        )
+    }
+}

--- a/macos/GroundControl/Services/LogStore.swift
+++ b/macos/GroundControl/Services/LogStore.swift
@@ -1,0 +1,68 @@
+import Foundation
+
+/// Observable log storage with ring buffer, level filtering, and text search.
+///
+/// Capped at `maxEntries` to prevent unbounded memory growth.
+/// Provides a filtered view based on active level toggles and search text.
+@Observable
+final class LogStore {
+    /// Maximum entries before old ones are evicted.
+    let maxEntries: Int
+
+    /// All stored log entries (ring buffer, oldest first).
+    private(set) var entries: [LogEntry] = []
+
+    /// Which log levels are currently visible.
+    var activeLevels: Set<LogEntry.LogLevel> = Set(LogEntry.LogLevel.allCases)
+
+    /// Case-insensitive search text applied to the message field.
+    var searchText: String = ""
+
+    /// Filtered entries based on active levels and search text.
+    var filteredEntries: [LogEntry] {
+        entries.filter { entry in
+            guard activeLevels.contains(entry.level) else { return false }
+
+            if !searchText.isEmpty {
+                return entry.message.localizedCaseInsensitiveContains(searchText)
+            }
+
+            return true
+        }
+    }
+
+    init(maxEntries: Int = 10_000) {
+        self.maxEntries = maxEntries
+        entries.reserveCapacity(min(maxEntries, 1_000))
+    }
+
+    // MARK: - Mutations
+
+    /// Parse a raw stdout/stderr line and append the resulting LogEntry.
+    /// Ignores empty lines.
+    func append(_ line: String) {
+        guard let entry = LogEntry.parse(line: line) else { return }
+
+        entries.append(entry)
+
+        // Evict oldest entries when over capacity
+        if entries.count > maxEntries {
+            let overflow = entries.count - maxEntries
+            entries.removeFirst(overflow)
+        }
+    }
+
+    /// Toggle a specific log level on or off.
+    func toggleLevel(_ level: LogEntry.LogLevel) {
+        if activeLevels.contains(level) {
+            activeLevels.remove(level)
+        } else {
+            activeLevels.insert(level)
+        }
+    }
+
+    /// Clear all stored log entries.
+    func clear() {
+        entries.removeAll(keepingCapacity: true)
+    }
+}

--- a/macos/GroundControl/Services/LogStore.swift
+++ b/macos/GroundControl/Services/LogStore.swift
@@ -1,26 +1,37 @@
+import Collections
 import Foundation
 
 /// Observable log storage with ring buffer, level filtering, and text search.
 ///
 /// Capped at `maxEntries` to prevent unbounded memory growth.
-/// Provides a filtered view based on active level toggles and search text.
+/// Uses `Deque` for O(1) front eviction under steady-state log ingestion.
+/// Caches filtered results to avoid redundant O(n) recomputation.
 @Observable
 final class LogStore {
     /// Maximum entries before old ones are evicted.
     let maxEntries: Int
 
-    /// All stored log entries (ring buffer, oldest first).
-    private(set) var entries: [LogEntry] = []
+    /// All stored log entries (deque, oldest first). O(1) removeFirst.
+    private(set) var entries: Deque<LogEntry> = []
 
     /// Which log levels are currently visible.
-    var activeLevels: Set<LogEntry.LogLevel> = Set(LogEntry.LogLevel.allCases)
+    var activeLevels: Set<LogEntry.LogLevel> = Set(LogEntry.LogLevel.allCases) {
+        didSet { invalidateFilterCache() }
+    }
 
     /// Case-insensitive search text applied to the message field.
-    var searchText: String = ""
+    var searchText: String = "" {
+        didSet { invalidateFilterCache() }
+    }
+
+    /// Cached filtered entries — recomputed lazily when inputs change.
+    private var cachedFilteredEntries: [LogEntry]?
 
     /// Filtered entries based on active levels and search text.
     var filteredEntries: [LogEntry] {
-        entries.filter { entry in
+        if let cached = cachedFilteredEntries { return cached }
+
+        let result: [LogEntry] = entries.filter { entry in
             guard activeLevels.contains(entry.level) else { return false }
 
             if !searchText.isEmpty {
@@ -29,11 +40,12 @@ final class LogStore {
 
             return true
         }
+        cachedFilteredEntries = result
+        return result
     }
 
     init(maxEntries: Int = 10_000) {
         self.maxEntries = maxEntries
-        entries.reserveCapacity(min(maxEntries, 1_000))
     }
 
     // MARK: - Mutations
@@ -45,11 +57,12 @@ final class LogStore {
 
         entries.append(entry)
 
-        // Evict oldest entries when over capacity
-        if entries.count > maxEntries {
-            let overflow = entries.count - maxEntries
-            entries.removeFirst(overflow)
+        // Evict oldest entries when over capacity (O(1) with Deque)
+        while entries.count > maxEntries {
+            entries.removeFirst()
         }
+
+        invalidateFilterCache()
     }
 
     /// Toggle a specific log level on or off.
@@ -63,6 +76,13 @@ final class LogStore {
 
     /// Clear all stored log entries.
     func clear() {
-        entries.removeAll(keepingCapacity: true)
+        entries.removeAll()
+        invalidateFilterCache()
+    }
+
+    // MARK: - Private
+
+    private func invalidateFilterCache() {
+        cachedFilteredEntries = nil
     }
 }

--- a/macos/GroundControl/Services/RelayProcess.swift
+++ b/macos/GroundControl/Services/RelayProcess.swift
@@ -9,6 +9,9 @@ import Foundation
 final class RelayProcess {
     private(set) var state = RelayState()
 
+    /// Log store fed by stdout/stderr lines from the relay process.
+    let logStore = LogStore()
+
     private var process: Process?
     private var stdoutPipe: Pipe?
     private var stderrPipe: Pipe?
@@ -192,18 +195,58 @@ final class RelayProcess {
 
     // MARK: - Output Handling
 
+    /// Partial-line buffer per pipe (data may arrive mid-line).
+    private var stdoutBuffer = ""
+    private var stderrBuffer = ""
+
     private func readPipeAsync(_ pipe: Pipe, label: String) {
-        pipe.fileHandleForReading.readabilityHandler = { handle in
+        pipe.fileHandleForReading.readabilityHandler = { [weak self] handle in
             let data = handle.availableData
             guard !data.isEmpty else {
                 handle.readabilityHandler = nil
                 return
             }
-            if let text = String(data: data, encoding: .utf8) {
-                // Print to console for now — future: feed into LogStore
-                for line in text.split(separator: "\n", omittingEmptySubsequences: false) {
-                    if !line.isEmpty {
-                        print("[relay/\(label)] \(line)")
+            guard let self, let text = String(data: data, encoding: .utf8) else { return }
+
+            // Buffer management — data may arrive as partial lines
+            let buffer: String
+            if label == "stdout" {
+                buffer = self.stdoutBuffer + text
+            } else {
+                buffer = self.stderrBuffer + text
+            }
+
+            let lines = buffer.split(separator: "\n", omittingEmptySubsequences: false)
+
+            // If the chunk doesn't end with \n, the last element is a partial line — keep it
+            let hasTrailingNewline = text.hasSuffix("\n")
+            let completeLines: ArraySlice<Substring>
+            let remainder: String
+
+            if hasTrailingNewline {
+                completeLines = lines[...]
+                remainder = ""
+            } else {
+                completeLines = lines.dropLast()
+                remainder = String(lines.last ?? "")
+            }
+
+            if label == "stdout" {
+                self.stdoutBuffer = remainder
+            } else {
+                self.stderrBuffer = remainder
+            }
+
+            // Feed complete lines into LogStore on the main actor
+            let lineStrings = completeLines.compactMap { line -> String? in
+                let s = String(line)
+                return s.isEmpty ? nil : s
+            }
+
+            if !lineStrings.isEmpty {
+                DispatchQueue.main.async {
+                    for line in lineStrings {
+                        self.logStore.append(line)
                     }
                 }
             }

--- a/macos/GroundControl/Services/RelayProcess.swift
+++ b/macos/GroundControl/Services/RelayProcess.swift
@@ -203,6 +203,23 @@ final class RelayProcess {
         pipe.fileHandleForReading.readabilityHandler = { [weak self] handle in
             let data = handle.availableData
             guard !data.isEmpty else {
+                // Flush any remaining partial-line buffer before removing the handler
+                if let self {
+                    let remainder: String
+                    if label == "stdout" {
+                        remainder = self.stdoutBuffer
+                        self.stdoutBuffer = ""
+                    } else {
+                        remainder = self.stderrBuffer
+                        self.stderrBuffer = ""
+                    }
+
+                    if !remainder.isEmpty {
+                        DispatchQueue.main.async {
+                            self.logStore.append(remainder)
+                        }
+                    }
+                }
                 handle.readabilityHandler = nil
                 return
             }

--- a/macos/GroundControl/Views/LogView.swift
+++ b/macos/GroundControl/Views/LogView.swift
@@ -1,0 +1,264 @@
+import SwiftUI
+
+/// Live log viewer with level filtering, text search, and auto-scroll.
+///
+/// Displays pino JSON log entries as structured rows with color-coded level badges.
+/// Auto-scrolls to the bottom unless the user scrolls up (pause-on-scroll-up).
+struct LogView: View {
+    let logStore: LogStore
+
+    @State private var autoScroll = true
+    @State private var expandedEntries: Set<UUID> = []
+    /// Tracks the last entry count we auto-scrolled to, so we can detect
+    /// user-initiated scrolls vs. programmatic ones.
+    @State private var lastScrolledCount = 0
+
+    var body: some View {
+        VStack(spacing: 0) {
+            toolbar
+            Divider()
+            logList
+        }
+    }
+
+    // MARK: - Toolbar
+
+    @ViewBuilder
+    private var toolbar: some View {
+        VStack(spacing: 8) {
+            HStack(spacing: 8) {
+                // Level filter toggles
+                ForEach(LogEntry.LogLevel.allCases, id: \.rawValue) { level in
+                    LevelToggle(
+                        level: level,
+                        isActive: logStore.activeLevels.contains(level),
+                        action: { logStore.toggleLevel(level) }
+                    )
+                }
+
+                Spacer()
+
+                // Entry count
+                Text("\(logStore.filteredEntries.count) / \(logStore.entries.count)")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .monospacedDigit()
+
+                // Auto-scroll indicator
+                Button {
+                    autoScroll.toggle()
+                } label: {
+                    Image(systemName: autoScroll ? "arrow.down.to.line" : "pause")
+                        .font(.caption)
+                        .foregroundStyle(autoScroll ? .blue : .secondary)
+                }
+                .buttonStyle(.plain)
+                .help(autoScroll ? "Auto-scroll on (click to pause)" : "Auto-scroll paused (click to resume)")
+
+                // Clear button
+                Button {
+                    logStore.clear()
+                } label: {
+                    Image(systemName: "trash")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                .buttonStyle(.plain)
+                .help("Clear all logs")
+            }
+
+            // Search field
+            HStack {
+                Image(systemName: "magnifyingglass")
+                    .foregroundStyle(.secondary)
+                TextField("Filter logs...", text: Binding(
+                    get: { logStore.searchText },
+                    set: { logStore.searchText = $0 }
+                ))
+                .textFieldStyle(.plain)
+
+                if !logStore.searchText.isEmpty {
+                    Button {
+                        logStore.searchText = ""
+                    } label: {
+                        Image(systemName: "xmark.circle.fill")
+                            .foregroundStyle(.secondary)
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+            .padding(6)
+            .background(.quaternary)
+            .clipShape(RoundedRectangle(cornerRadius: 6))
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+    }
+
+    // MARK: - Log List
+
+    @ViewBuilder
+    private var logList: some View {
+        ScrollViewReader { proxy in
+            List(logStore.filteredEntries) { entry in
+                LogRowView(
+                    entry: entry,
+                    isExpanded: expandedEntries.contains(entry.id),
+                    onToggleExpand: {
+                        if expandedEntries.contains(entry.id) {
+                            expandedEntries.remove(entry.id)
+                        } else {
+                            expandedEntries.insert(entry.id)
+                        }
+                    }
+                )
+                .id(entry.id)
+                .listRowSeparator(.hidden)
+                .listRowInsets(EdgeInsets(top: 1, leading: 8, bottom: 1, trailing: 8))
+            }
+            .listStyle(.plain)
+            .font(.system(.body, design: .monospaced))
+            .onChange(of: logStore.filteredEntries.count) {
+                if autoScroll, let lastEntry = logStore.filteredEntries.last {
+                    withAnimation(.easeOut(duration: 0.1)) {
+                        proxy.scrollTo(lastEntry.id, anchor: .bottom)
+                    }
+                    lastScrolledCount = logStore.filteredEntries.count
+                }
+            }
+            .onChange(of: autoScroll) {
+                // When user re-enables auto-scroll, jump to bottom immediately
+                if autoScroll, let lastEntry = logStore.filteredEntries.last {
+                    withAnimation(.easeOut(duration: 0.1)) {
+                        proxy.scrollTo(lastEntry.id, anchor: .bottom)
+                    }
+                }
+            }
+        }
+    }
+}
+
+// MARK: - Log Row
+
+/// A single log entry row with timestamp, level badge, message, and expandable JSON.
+private struct LogRowView: View {
+    let entry: LogEntry
+    let isExpanded: Bool
+    let onToggleExpand: () -> Void
+
+    private static let timeFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.dateFormat = "HH:mm:ss.SSS"
+        return f
+    }()
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 2) {
+            HStack(alignment: .firstTextBaseline, spacing: 6) {
+                // Timestamp
+                Text(Self.timeFormatter.string(from: entry.timestamp))
+                    .font(.system(.caption, design: .monospaced))
+                    .foregroundStyle(.secondary)
+                    .frame(width: 85, alignment: .leading)
+
+                // Level badge
+                LevelBadge(level: entry.level)
+
+                // Message
+                Text(entry.message)
+                    .font(.system(.caption, design: .monospaced))
+                    .lineLimit(isExpanded ? nil : 1)
+                    .textSelection(.enabled)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+
+                // Expand/collapse if there's raw JSON to show
+                if !entry.extra.isEmpty || entry.rawJSON.contains("{") {
+                    Button {
+                        onToggleExpand()
+                    } label: {
+                        Image(systemName: isExpanded ? "chevron.down" : "chevron.right")
+                            .font(.caption2)
+                            .foregroundStyle(.secondary)
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+
+            // Expanded JSON details
+            if isExpanded {
+                Text(prettyJSON)
+                    .font(.system(.caption2, design: .monospaced))
+                    .foregroundStyle(.secondary)
+                    .textSelection(.enabled)
+                    .padding(.leading, 91) // align under message
+                    .padding(.top, 2)
+            }
+        }
+        .padding(.vertical, 2)
+        .contentShape(Rectangle())
+        .onTapGesture {
+            if !entry.extra.isEmpty || entry.rawJSON.contains("{") {
+                onToggleExpand()
+            }
+        }
+    }
+
+    private var prettyJSON: String {
+        guard let data = entry.rawJSON.data(using: .utf8),
+              let json = try? JSONSerialization.jsonObject(with: data),
+              let pretty = try? JSONSerialization.data(withJSONObject: json, options: [.prettyPrinted, .sortedKeys]),
+              let str = String(data: pretty, encoding: .utf8)
+        else {
+            return entry.rawJSON
+        }
+        return str
+    }
+}
+
+// MARK: - Level Badge
+
+/// Color-coded pill badge for a log level.
+private struct LevelBadge: View {
+    let level: LogEntry.LogLevel
+
+    var body: some View {
+        HStack(spacing: 2) {
+            Image(systemName: level.sfSymbol)
+                .font(.system(size: 8))
+            Text(level.displayName)
+                .font(.system(size: 9, weight: .semibold, design: .monospaced))
+        }
+        .foregroundStyle(level.color)
+        .padding(.horizontal, 5)
+        .padding(.vertical, 2)
+        .background(level.color.opacity(0.15))
+        .clipShape(RoundedRectangle(cornerRadius: 3))
+        .frame(width: 70, alignment: .center)
+    }
+}
+
+// MARK: - Level Toggle
+
+/// Toolbar toggle button for a log level filter.
+private struct LevelToggle: View {
+    let level: LogEntry.LogLevel
+    let isActive: Bool
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            Text(level.displayName)
+                .font(.system(size: 10, weight: .medium, design: .monospaced))
+                .foregroundStyle(isActive ? level.color : .secondary)
+                .padding(.horizontal, 6)
+                .padding(.vertical, 3)
+                .background(isActive ? level.color.opacity(0.15) : Color.clear)
+                .clipShape(RoundedRectangle(cornerRadius: 4))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 4)
+                        .strokeBorder(isActive ? level.color.opacity(0.3) : Color.secondary.opacity(0.2), lineWidth: 1)
+                )
+        }
+        .buttonStyle(.plain)
+    }
+}

--- a/macos/GroundControl/Views/LogView.swift
+++ b/macos/GroundControl/Views/LogView.swift
@@ -3,15 +3,12 @@ import SwiftUI
 /// Live log viewer with level filtering, text search, and auto-scroll.
 ///
 /// Displays pino JSON log entries as structured rows with color-coded level badges.
-/// Auto-scrolls to the bottom unless the user scrolls up (pause-on-scroll-up).
+/// Auto-scrolls to the bottom by default; user can toggle via the toolbar button.
 struct LogView: View {
     let logStore: LogStore
 
     @State private var autoScroll = true
     @State private var expandedEntries: Set<UUID> = []
-    /// Tracks the last entry count we auto-scrolled to, so we can detect
-    /// user-initiated scrolls vs. programmatic ones.
-    @State private var lastScrolledCount = 0
 
     var body: some View {
         VStack(spacing: 0) {
@@ -58,6 +55,7 @@ struct LogView: View {
                 // Clear button
                 Button {
                     logStore.clear()
+                    expandedEntries.removeAll()
                 } label: {
                     Image(systemName: "trash")
                         .font(.caption)
@@ -123,7 +121,6 @@ struct LogView: View {
                     withAnimation(.easeOut(duration: 0.1)) {
                         proxy.scrollTo(lastEntry.id, anchor: .bottom)
                     }
-                    lastScrolledCount = logStore.filteredEntries.count
                 }
             }
             .onChange(of: autoScroll) {

--- a/macos/GroundControl/Views/ManagementWindow.swift
+++ b/macos/GroundControl/Views/ManagementWindow.swift
@@ -24,6 +24,8 @@ enum ManagementSection: String, CaseIterable, Identifiable {
 /// Only the Logs section is functional in Wave 2.
 /// Other sections show placeholder content.
 struct ManagementWindow: View {
+    /// Retained for future sections (Dashboard, Configuration, Security) that need relay state.
+    // swiftlint:disable:next unused_declaration
     let relay: RelayProcess
     let logStore: LogStore
 

--- a/macos/GroundControl/Views/ManagementWindow.swift
+++ b/macos/GroundControl/Views/ManagementWindow.swift
@@ -1,0 +1,98 @@
+import SwiftUI
+
+/// Sidebar navigation items for the management window.
+enum ManagementSection: String, CaseIterable, Identifiable {
+    case dashboard = "Dashboard"
+    case logs = "Logs"
+    case configuration = "Configuration"
+    case security = "Security"
+
+    var id: String { rawValue }
+
+    var sfSymbol: String {
+        switch self {
+        case .dashboard: "gauge.with.dots.needle.bottom.50percent"
+        case .logs: "text.line.last.and.arrowtriangle.forward"
+        case .configuration: "gearshape"
+        case .security: "lock.shield"
+        }
+    }
+}
+
+/// Management window with sidebar navigation.
+///
+/// Only the Logs section is functional in Wave 2.
+/// Other sections show placeholder content.
+struct ManagementWindow: View {
+    let relay: RelayProcess
+    let logStore: LogStore
+
+    @State private var selectedSection: ManagementSection = .logs
+
+    var body: some View {
+        NavigationSplitView {
+            sidebar
+        } detail: {
+            detail
+        }
+        .navigationTitle("Ground Control")
+    }
+
+    // MARK: - Sidebar
+
+    @ViewBuilder
+    private var sidebar: some View {
+        List(ManagementSection.allCases, selection: $selectedSection) { section in
+            Label(section.rawValue, systemImage: section.sfSymbol)
+                .tag(section)
+        }
+        .listStyle(.sidebar)
+        .navigationSplitViewColumnWidth(min: 160, ideal: 180, max: 220)
+    }
+
+    // MARK: - Detail
+
+    @ViewBuilder
+    private var detail: some View {
+        switch selectedSection {
+        case .logs:
+            LogView(logStore: logStore)
+        case .dashboard:
+            placeholderView(
+                icon: ManagementSection.dashboard.sfSymbol,
+                title: "Dashboard",
+                subtitle: "Relay status and metrics coming soon."
+            )
+        case .configuration:
+            placeholderView(
+                icon: ManagementSection.configuration.sfSymbol,
+                title: "Configuration",
+                subtitle: "Port, environment, and startup settings coming soon."
+            )
+        case .security:
+            placeholderView(
+                icon: ManagementSection.security.sfSymbol,
+                title: "Security",
+                subtitle: "Auth tokens and access control coming soon."
+            )
+        }
+    }
+
+    @ViewBuilder
+    private func placeholderView(icon: String, title: String, subtitle: String) -> some View {
+        VStack(spacing: 12) {
+            Image(systemName: icon)
+                .font(.system(size: 40))
+                .foregroundStyle(.tertiary)
+
+            Text(title)
+                .font(.title2)
+                .fontWeight(.medium)
+
+            Text(subtitle)
+                .font(.callout)
+                .foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+}

--- a/macos/Package.swift
+++ b/macos/Package.swift
@@ -7,9 +7,15 @@ let package = Package(
     platforms: [
         .macOS(.v14),
     ],
+    dependencies: [
+        .package(url: "https://github.com/apple/swift-collections.git", from: "1.1.0"),
+    ],
     targets: [
         .executableTarget(
             name: "GroundControl",
+            dependencies: [
+                .product(name: "Collections", package: "swift-collections"),
+            ],
             path: "GroundControl",
             exclude: ["Info.plist"]
         ),


### PR DESCRIPTION
## Summary
- Add management window with NavigationSplitView sidebar (Dashboard, Logs, Configuration, Security — Logs active, rest placeholder)
- Implement live structured log viewer parsing pino JSON from relay stdout/stderr
- Ring buffer capped at 10,000 entries to prevent unbounded memory growth
- Level filter toggles (trace/debug/info/warn/error/fatal) and case-insensitive text search

## New Files
- `LogEntry.swift` — Pino JSON parser with `LogLevel` enum, color-coded badges, SF Symbols
- `LogStore.swift` — `@Observable` ring buffer with filtered view, level/search filtering
- `LogView.swift` — Live log viewer with auto-scroll, expandable JSON details, timestamp/level/message columns
- `ManagementWindow.swift` — Sidebar navigation shell for management features

## Modified Files
- `RelayProcess.swift` — Feeds stdout/stderr lines to LogStore with proper line buffering
- `GroundControlApp.swift` — Registers management window, injects LogStore

## Design Notes
- Non-JSON lines (Node warnings, startup messages) captured as INFO entries
- Auto-scroll toggle button (macOS 14 compatible, no `onScrollPhaseChange`)
- Level badges: trace=gray, debug=blue, info=green, warn=yellow, error=red, fatal=purple

## Test plan
- [ ] `cd macos && swift build` — verify clean compilation
- [ ] Start relay, open Management window — verify logs stream in real-time
- [ ] Toggle level filters — verify rows filter correctly
- [ ] Type in search field — verify case-insensitive filtering
- [ ] Scroll up — verify auto-scroll pauses, re-enable via toggle
- [ ] Expand a log row — verify raw JSON details shown
- [ ] Verify ring buffer caps at 10K entries (no memory growth)

🤖 Generated with [Claude Code](https://claude.com/claude-code)