### PR TITLE
feat(relay,macos): Ground Control Wave 3 — Dashboard

### DIFF
--- a/macos/GroundControl/Models/HealthData.swift
+++ b/macos/GroundControl/Models/HealthData.swift
@@ -1,0 +1,113 @@
+import Foundation
+
+/// Parsed response from the relay's `/api/admin/status` endpoint.
+///
+/// Used by `RelayClient` to feed the Dashboard view with live server metrics.
+/// All properties are `Codable` for direct JSON decoding from the relay.
+struct HealthData: Codable, Equatable, Sendable {
+    let status: String
+    let uptime: Double
+    let clients: [ConnectedClient]
+    let sessions: [ActiveSession]
+    let memory: MemoryUsage
+    let tmuxWindowCount: Int
+
+    /// Fallback for when the relay is unreachable.
+    static let offline = HealthData(
+        status: "offline",
+        uptime: 0,
+        clients: [],
+        sessions: [],
+        memory: MemoryUsage(rss: 0, heapUsed: 0, heapTotal: 0, external: 0),
+        tmuxWindowCount: 0
+    )
+}
+
+// MARK: - Nested Types
+
+struct ConnectedClient: Codable, Equatable, Identifiable, Sendable {
+    let ip: String
+    let userAgent: String
+    let connectedAt: String
+
+    var id: String { "\(ip)-\(connectedAt)" }
+
+    /// Human-readable connection duration relative to now.
+    var connectionDuration: String {
+        guard let date = ISO8601DateFormatter().date(from: connectedAt) else {
+            return "unknown"
+        }
+        let interval = Date.now.timeIntervalSince(date)
+        return Self.formatDuration(interval)
+    }
+
+    /// Short device description parsed from user-agent.
+    var deviceSummary: String {
+        if userAgent.contains("iPhone") { return "iPhone" }
+        if userAgent.contains("iPad") { return "iPad" }
+        if userAgent.contains("Macintosh") || userAgent.contains("Mac OS") { return "Mac" }
+        if userAgent.contains("Android") { return "Android" }
+        if userAgent.contains("Windows") { return "Windows" }
+        if userAgent.contains("Linux") { return "Linux" }
+        if userAgent == "unknown" { return "Unknown Device" }
+        // Truncate long UAs
+        let trimmed = String(userAgent.prefix(40))
+        return trimmed.count < userAgent.count ? "\(trimmed)..." : trimmed
+    }
+
+    private static func formatDuration(_ seconds: TimeInterval) -> String {
+        if seconds < 60 { return "just now" }
+        let minutes = Int(seconds) / 60
+        if minutes < 60 { return "\(minutes)m" }
+        let hours = minutes / 60
+        let remainingMinutes = minutes % 60
+        if hours < 24 {
+            return remainingMinutes > 0 ? "\(hours)h \(remainingMinutes)m" : "\(hours)h"
+        }
+        let days = hours / 24
+        return "\(days)d \(hours % 24)h"
+    }
+}
+
+struct ActiveSession: Codable, Equatable, Identifiable, Sendable {
+    let sessionId: String
+    let workDir: String
+    let status: String
+    let startedAt: String
+
+    var id: String { sessionId }
+
+    /// Short display name from the working directory.
+    var workDirName: String {
+        (workDir as NSString).lastPathComponent
+    }
+}
+
+struct MemoryUsage: Codable, Equatable, Sendable {
+    let rss: Int
+    let heapUsed: Int
+    let heapTotal: Int
+    let external: Int
+
+    /// RSS formatted as human-readable string (e.g. "142 MB").
+    var rssFormatted: String { Self.formatBytes(rss) }
+    /// Heap used formatted.
+    var heapUsedFormatted: String { Self.formatBytes(heapUsed) }
+    /// Heap total formatted.
+    var heapTotalFormatted: String { Self.formatBytes(heapTotal) }
+    /// Heap utilization as a fraction (0..1).
+    var heapUtilization: Double {
+        guard heapTotal > 0 else { return 0 }
+        return Double(heapUsed) / Double(heapTotal)
+    }
+
+    private static func formatBytes(_ bytes: Int) -> String {
+        if bytes < 1024 { return "\(bytes) B" }
+        let kb = Double(bytes) / 1024
+        if kb < 1024 { return String(format: "%.0f KB", kb) }
+        let mb = kb / 1024
+        if mb < 1024 { return String(format: "%.1f MB", mb) }
+        let gb = mb / 1024
+        return String(format: "%.2f GB", gb)
+    }
+}

--- a/macos/GroundControl/Models/HealthData.swift
+++ b/macos/GroundControl/Models/HealthData.swift
@@ -34,7 +34,9 @@ struct ConnectedClient: Codable, Equatable, Identifiable, Sendable {
 
     /// Human-readable connection duration relative to now.
     var connectionDuration: String {
-        guard let date = ISO8601DateFormatter().date(from: connectedAt) else {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        guard let date = formatter.date(from: connectedAt) else {
             return "unknown"
         }
         let interval = Date.now.timeIntervalSince(date)

--- a/macos/GroundControl/Services/RelayClient.swift
+++ b/macos/GroundControl/Services/RelayClient.swift
@@ -53,6 +53,7 @@ final class RelayClient {
     func stopPolling() {
         pollingTask?.cancel()
         pollingTask = nil
+        markOffline(error: nil)
     }
 
     // MARK: - Fetch

--- a/macos/GroundControl/Services/RelayClient.swift
+++ b/macos/GroundControl/Services/RelayClient.swift
@@ -1,0 +1,95 @@
+import Foundation
+
+/// HTTP client that polls the relay's admin status endpoint and publishes
+/// parsed `HealthData` for the Dashboard view.
+///
+/// Uses `@Observable` (macOS 14+) and Swift Concurrency — no Combine.
+/// Auto-refreshes every 5 seconds while polling is active.
+@Observable
+final class RelayClient {
+    /// Latest health data from the relay. Defaults to `.offline`.
+    private(set) var healthData = HealthData.offline
+
+    /// Whether the relay is currently reachable.
+    private(set) var isConnected = false
+
+    /// Last error message (cleared on successful fetch).
+    private(set) var lastError: String?
+
+    /// The relay port to poll (matches RelayState.port).
+    var port: Int = 9090
+
+    /// Polling interval in seconds.
+    private let pollInterval: TimeInterval = 5.0
+
+    /// Active polling task — cancelled on `stopPolling()`.
+    private var pollingTask: Task<Void, Never>?
+
+    private let session: URLSession
+
+    init() {
+        // Short timeout so the dashboard doesn't hang when the relay is down
+        let config = URLSessionConfiguration.default
+        config.timeoutIntervalForRequest = 3
+        config.timeoutIntervalForResource = 5
+        self.session = URLSession(configuration: config)
+    }
+
+    // MARK: - Polling Lifecycle
+
+    /// Start periodic polling. Safe to call multiple times — restarts if already running.
+    func startPolling() {
+        stopPolling()
+        pollingTask = Task { [weak self] in
+            guard let self else { return }
+            while !Task.isCancelled {
+                await self.fetchStatus()
+                try? await Task.sleep(for: .seconds(self.pollInterval))
+            }
+        }
+    }
+
+    /// Stop periodic polling and mark as disconnected.
+    func stopPolling() {
+        pollingTask?.cancel()
+        pollingTask = nil
+    }
+
+    // MARK: - Fetch
+
+    /// Single fetch of the admin status endpoint.
+    @MainActor
+    func fetchStatus() async {
+        let url = URL(string: "http://127.0.0.1:\(port)/api/admin/status")!
+
+        do {
+            let (data, response) = try await session.data(from: url)
+
+            guard let httpResponse = response as? HTTPURLResponse,
+                  httpResponse.statusCode == 200 else {
+                let code = (response as? HTTPURLResponse)?.statusCode ?? 0
+                markOffline(error: "HTTP \(code)")
+                return
+            }
+
+            let decoded = try JSONDecoder().decode(HealthData.self, from: data)
+            healthData = decoded
+            isConnected = true
+            lastError = nil
+        } catch is CancellationError {
+            // Task cancelled — don't update state
+        } catch let error as URLError where error.code == .timedOut || error.code == .cannotConnectToHost {
+            markOffline(error: nil) // Expected when relay is stopped
+        } catch {
+            markOffline(error: error.localizedDescription)
+        }
+    }
+
+    // MARK: - Private
+
+    private func markOffline(error: String?) {
+        isConnected = false
+        healthData = HealthData.offline
+        lastError = error
+    }
+}

--- a/macos/GroundControl/Views/ClientListView.swift
+++ b/macos/GroundControl/Views/ClientListView.swift
@@ -1,0 +1,108 @@
+import SwiftUI
+
+/// Full-detail view of connected WebSocket clients.
+///
+/// Shows each client's IP, user agent, and connection duration.
+/// Designed as a standalone detail view or sheet for the Dashboard.
+struct ClientListView: View {
+    let clients: [ConnectedClient]
+
+    var body: some View {
+        Group {
+            if clients.isEmpty {
+                emptyState
+            } else {
+                clientList
+            }
+        }
+    }
+
+    // MARK: - Empty State
+
+    @ViewBuilder
+    private var emptyState: some View {
+        VStack(spacing: 12) {
+            Image(systemName: "person.2.slash")
+                .font(.system(size: 36))
+                .foregroundStyle(.tertiary)
+
+            Text("No Connected Clients")
+                .font(.title3)
+                .fontWeight(.medium)
+
+            Text("Clients will appear here when they connect to the relay.")
+                .font(.callout)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+                .frame(maxWidth: 280)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    // MARK: - Client List
+
+    @ViewBuilder
+    private var clientList: some View {
+        List {
+            Section {
+                ForEach(clients) { client in
+                    clientRow(client)
+                }
+            } header: {
+                Text("\(clients.count) Connected Client\(clients.count == 1 ? "" : "s")")
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func clientRow(_ client: ConnectedClient) -> some View {
+        HStack(spacing: 12) {
+            // Device icon
+            Image(systemName: deviceIcon(for: client))
+                .font(.title3)
+                .foregroundStyle(.secondary)
+                .frame(width: 28, alignment: .center)
+
+            // Client details
+            VStack(alignment: .leading, spacing: 3) {
+                Text(client.ip)
+                    .font(.body)
+                    .fontWeight(.medium)
+                    .monospaced()
+
+                Text(client.userAgent)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(2)
+                    .truncationMode(.middle)
+            }
+
+            Spacer()
+
+            // Connection duration
+            VStack(alignment: .trailing, spacing: 2) {
+                Text(client.connectionDuration)
+                    .font(.callout)
+                    .monospacedDigit()
+                    .foregroundStyle(.secondary)
+
+                Text("connected")
+                    .font(.caption2)
+                    .foregroundStyle(.tertiary)
+            }
+        }
+        .padding(.vertical, 4)
+    }
+
+    // MARK: - Helpers
+
+    private func deviceIcon(for client: ConnectedClient) -> String {
+        if client.userAgent.contains("iPhone") { return "iphone" }
+        if client.userAgent.contains("iPad") { return "ipad" }
+        if client.userAgent.contains("Macintosh") || client.userAgent.contains("Mac OS") {
+            return "desktopcomputer"
+        }
+        if client.userAgent.contains("Android") { return "candybarphone" }
+        return "display"
+    }
+}

--- a/macos/GroundControl/Views/DashboardView.swift
+++ b/macos/GroundControl/Views/DashboardView.swift
@@ -117,7 +117,7 @@ struct DashboardView: View {
                             .fontWeight(.semibold)
                             .monospacedDigit()
                             .contentTransition(.numericText())
-                        Text(clients.count == 1 ? "connected" : "connected")
+                        Text(clients.count == 1 ? "client connected" : "clients connected")
                             .foregroundStyle(.secondary)
                     }
 
@@ -174,7 +174,7 @@ struct DashboardView: View {
                             .fontWeight(.semibold)
                             .monospacedDigit()
                             .contentTransition(.numericText())
-                        Text(sessions.count == 1 ? "active" : "active")
+                        Text(sessions.count == 1 ? "active session" : "active sessions")
                             .foregroundStyle(.secondary)
                     }
 
@@ -190,7 +190,7 @@ struct DashboardView: View {
                                     Text(session.workDirName)
                                         .font(.callout)
                                         .lineLimit(1)
-                                    Text(session.sessionId.prefix(8) + "...")
+                                    Text(String(session.sessionId.prefix(8)) + "...")
                                         .font(.caption)
                                         .foregroundStyle(.secondary)
                                         .monospaced()

--- a/macos/GroundControl/Views/DashboardView.swift
+++ b/macos/GroundControl/Views/DashboardView.swift
@@ -1,0 +1,339 @@
+import SwiftUI
+
+/// Dashboard overview showing server status, clients, sessions, and resource usage.
+///
+/// Designed for the macOS management window sidebar detail area.
+/// Polls the relay's admin status endpoint via `RelayClient` and
+/// displays live metrics in a card-based layout.
+struct DashboardView: View {
+    let relay: RelayProcess
+    @State private var relayClient = RelayClient()
+
+    var body: some View {
+        ScrollView {
+            LazyVGrid(columns: [
+                GridItem(.flexible(), spacing: 16),
+                GridItem(.flexible(), spacing: 16),
+            ], spacing: 16) {
+                statusCard
+                resourcesCard
+                clientsCard
+                sessionsCard
+            }
+            .padding()
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(.background)
+        .onAppear {
+            relayClient.port = relay.state.port
+            relayClient.startPolling()
+        }
+        .onDisappear {
+            relayClient.stopPolling()
+        }
+        .onChange(of: relay.state.processState) {
+            relayClient.port = relay.state.port
+            // Trigger an immediate fetch when state changes
+            Task { await relayClient.fetchStatus() }
+        }
+    }
+
+    // MARK: - Status Card
+
+    @ViewBuilder
+    private var statusCard: some View {
+        DashboardCard(title: "Server Status", sfSymbol: "server.rack") {
+            VStack(alignment: .leading, spacing: 10) {
+                HStack(spacing: 8) {
+                    statusIndicator
+                    Text(statusLabel)
+                        .font(.headline)
+                }
+
+                if relayClient.isConnected {
+                    LabeledContent("Uptime") {
+                        Text(formatUptime(relayClient.healthData.uptime))
+                            .monospacedDigit()
+                    }
+
+                    LabeledContent("Port") {
+                        Text("\(relay.state.port)")
+                            .monospacedDigit()
+                    }
+
+                    LabeledContent("tmux Windows") {
+                        Text("\(relayClient.healthData.tmuxWindowCount)")
+                            .monospacedDigit()
+                    }
+                }
+            }
+        }
+    }
+
+    // MARK: - Resources Card
+
+    @ViewBuilder
+    private var resourcesCard: some View {
+        DashboardCard(title: "Memory", sfSymbol: "memorychip") {
+            if relayClient.isConnected {
+                let mem = relayClient.healthData.memory
+                VStack(alignment: .leading, spacing: 10) {
+                    LabeledContent("RSS") {
+                        Text(mem.rssFormatted)
+                            .monospacedDigit()
+                    }
+
+                    LabeledContent("Heap") {
+                        Text("\(mem.heapUsedFormatted) / \(mem.heapTotalFormatted)")
+                            .monospacedDigit()
+                    }
+
+                    ProgressView(value: mem.heapUtilization)
+                        .tint(heapColor(mem.heapUtilization))
+
+                    LabeledContent("External") {
+                        Text(formatBytesSimple(mem.external))
+                            .monospacedDigit()
+                    }
+                }
+            } else {
+                Text("No data")
+                    .foregroundStyle(.secondary)
+            }
+        }
+    }
+
+    // MARK: - Clients Card
+
+    @ViewBuilder
+    private var clientsCard: some View {
+        DashboardCard(title: "Clients", sfSymbol: "person.2") {
+            if relayClient.isConnected {
+                let clients = relayClient.healthData.clients
+                VStack(alignment: .leading, spacing: 10) {
+                    HStack {
+                        Text("\(clients.count)")
+                            .font(.title2)
+                            .fontWeight(.semibold)
+                            .monospacedDigit()
+                            .contentTransition(.numericText())
+                        Text(clients.count == 1 ? "connected" : "connected")
+                            .foregroundStyle(.secondary)
+                    }
+
+                    if clients.isEmpty {
+                        Text("No clients connected")
+                            .font(.callout)
+                            .foregroundStyle(.tertiary)
+                    } else {
+                        ForEach(clients.prefix(3)) { client in
+                            HStack(spacing: 6) {
+                                Image(systemName: deviceIcon(for: client))
+                                    .foregroundStyle(.secondary)
+                                    .frame(width: 16)
+                                VStack(alignment: .leading, spacing: 1) {
+                                    Text(client.deviceSummary)
+                                        .font(.callout)
+                                    Text(client.ip)
+                                        .font(.caption)
+                                        .foregroundStyle(.secondary)
+                                }
+                                Spacer()
+                                Text(client.connectionDuration)
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                                    .monospacedDigit()
+                            }
+                        }
+
+                        if clients.count > 3 {
+                            Text("+\(clients.count - 3) more")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                }
+            } else {
+                Text("No data")
+                    .foregroundStyle(.secondary)
+            }
+        }
+    }
+
+    // MARK: - Sessions Card
+
+    @ViewBuilder
+    private var sessionsCard: some View {
+        DashboardCard(title: "Sessions", sfSymbol: "terminal") {
+            if relayClient.isConnected {
+                let sessions = relayClient.healthData.sessions
+                VStack(alignment: .leading, spacing: 10) {
+                    HStack {
+                        Text("\(sessions.count)")
+                            .font(.title2)
+                            .fontWeight(.semibold)
+                            .monospacedDigit()
+                            .contentTransition(.numericText())
+                        Text(sessions.count == 1 ? "active" : "active")
+                            .foregroundStyle(.secondary)
+                    }
+
+                    if sessions.isEmpty {
+                        Text("No active sessions")
+                            .font(.callout)
+                            .foregroundStyle(.tertiary)
+                    } else {
+                        ForEach(sessions.prefix(4)) { session in
+                            HStack(spacing: 6) {
+                                statusDot(for: session.status)
+                                VStack(alignment: .leading, spacing: 1) {
+                                    Text(session.workDirName)
+                                        .font(.callout)
+                                        .lineLimit(1)
+                                    Text(session.sessionId.prefix(8) + "...")
+                                        .font(.caption)
+                                        .foregroundStyle(.secondary)
+                                        .monospaced()
+                                }
+                                Spacer()
+                                Text(session.status)
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                            }
+                        }
+
+                        if sessions.count > 4 {
+                            Text("+\(sessions.count - 4) more")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                }
+            } else {
+                Text("No data")
+                    .foregroundStyle(.secondary)
+            }
+        }
+    }
+
+    // MARK: - Helpers
+
+    private var statusLabel: String {
+        switch relay.state.processState {
+        case .running:
+            relayClient.isConnected ? "Running" : "Starting..."
+        case .starting:
+            "Starting..."
+        case .stopping:
+            "Stopping..."
+        case .idle:
+            "Stopped"
+        case .error(let msg):
+            "Error: \(msg)"
+        }
+    }
+
+    @ViewBuilder
+    private var statusIndicator: some View {
+        Circle()
+            .fill(statusColor)
+            .frame(width: 10, height: 10)
+            .shadow(color: statusColor.opacity(0.5), radius: 3)
+            .animation(.easeInOut(duration: 0.3), value: relay.state.processState)
+    }
+
+    private var statusColor: Color {
+        switch relay.state.processState {
+        case .running:
+            relayClient.isConnected ? .green : .yellow
+        case .starting, .stopping:
+            .yellow
+        case .idle:
+            .gray
+        case .error:
+            .red
+        }
+    }
+
+    private func formatUptime(_ seconds: Double) -> String {
+        let totalSeconds = Int(seconds)
+        let days = totalSeconds / 86400
+        let hours = (totalSeconds % 86400) / 3600
+        let minutes = (totalSeconds % 3600) / 60
+        let secs = totalSeconds % 60
+
+        if days > 0 {
+            return "\(days)d \(hours)h \(minutes)m"
+        } else if hours > 0 {
+            return "\(hours)h \(minutes)m \(secs)s"
+        } else if minutes > 0 {
+            return "\(minutes)m \(secs)s"
+        } else {
+            return "\(secs)s"
+        }
+    }
+
+    private func heapColor(_ utilization: Double) -> Color {
+        if utilization < 0.6 { return .green }
+        if utilization < 0.8 { return .yellow }
+        return .red
+    }
+
+    private func deviceIcon(for client: ConnectedClient) -> String {
+        if client.userAgent.contains("iPhone") { return "iphone" }
+        if client.userAgent.contains("iPad") { return "ipad" }
+        if client.userAgent.contains("Macintosh") || client.userAgent.contains("Mac OS") {
+            return "desktopcomputer"
+        }
+        if client.userAgent.contains("Android") { return "candybarphone" }
+        return "display"
+    }
+
+    private func formatBytesSimple(_ bytes: Int) -> String {
+        if bytes < 1024 { return "\(bytes) B" }
+        let kb = Double(bytes) / 1024
+        if kb < 1024 { return String(format: "%.0f KB", kb) }
+        let mb = kb / 1024
+        return String(format: "%.1f MB", mb)
+    }
+
+    @ViewBuilder
+    private func statusDot(for status: String) -> some View {
+        Circle()
+            .fill(sessionStatusColor(status))
+            .frame(width: 8, height: 8)
+    }
+
+    private func sessionStatusColor(_ status: String) -> Color {
+        switch status {
+        case "active": .green
+        case "idle": .yellow
+        case "closed": .gray
+        default: .gray
+        }
+    }
+}
+
+// MARK: - Dashboard Card
+
+/// Reusable card container for the dashboard grid.
+private struct DashboardCard<Content: View>: View {
+    let title: String
+    let sfSymbol: String
+    @ViewBuilder let content: () -> Content
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Label(title, systemImage: sfSymbol)
+                .font(.subheadline)
+                .fontWeight(.medium)
+                .foregroundStyle(.secondary)
+
+            content()
+        }
+        .padding()
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 10))
+        .animation(.easeInOut(duration: 0.25), value: title)
+    }
+}

--- a/macos/GroundControl/Views/ManagementWindow.swift
+++ b/macos/GroundControl/Views/ManagementWindow.swift
@@ -21,15 +21,13 @@ enum ManagementSection: String, CaseIterable, Identifiable {
 
 /// Management window with sidebar navigation.
 ///
-/// Only the Logs section is functional in Wave 2.
-/// Other sections show placeholder content.
+/// Dashboard (Wave 3) and Logs (Wave 2) are functional.
+/// Configuration and Security show placeholder content.
 struct ManagementWindow: View {
-    /// Retained for future sections (Dashboard, Configuration, Security) that need relay state.
-    // swiftlint:disable:next unused_declaration
     let relay: RelayProcess
     let logStore: LogStore
 
-    @State private var selectedSection: ManagementSection = .logs
+    @State private var selectedSection: ManagementSection = .dashboard
 
     var body: some View {
         NavigationSplitView {
@@ -57,14 +55,10 @@ struct ManagementWindow: View {
     @ViewBuilder
     private var detail: some View {
         switch selectedSection {
+        case .dashboard:
+            DashboardView(relay: relay)
         case .logs:
             LogView(logStore: logStore)
-        case .dashboard:
-            placeholderView(
-                icon: ManagementSection.dashboard.sfSymbol,
-                title: "Dashboard",
-                subtitle: "Relay status and metrics coming soon."
-            )
         case .configuration:
             placeholderView(
                 icon: ManagementSection.configuration.sfSymbol,

--- a/relay/src/routes/health.ts
+++ b/relay/src/routes/health.ts
@@ -3,6 +3,7 @@ import type { SessionManager } from '../sessions/session-manager.js';
 import type { FleetManager } from '../fleet/fleet-manager.js';
 import type { HealthMonitor } from '../health/health-monitor.js';
 import { listWindows } from '../utils/tmux-cli.js';
+import { logger } from '../utils/logger.js';
 
 interface HealthDeps {
   sessionManager: SessionManager;
@@ -61,7 +62,15 @@ export function createHealthRoutes(deps: HealthDeps): FastifyPluginAsync {
     // unnecessary. The endpoint is intentionally kept unauthenticated
     // to avoid coupling Ground Control to the relay's session cookie /
     // PIN flow — it's a management tool, not a user-facing client.
-    fastify.get('/api/admin/status', async (_request: FastifyRequest) => {
+    fastify.get('/api/admin/status', async (request: FastifyRequest, reply) => {
+      // Enforce loopback-only access — reject non-localhost requests
+      const clientIp = request.ip;
+      const isLoopback = clientIp === '127.0.0.1' || clientIp === '::1' || clientIp === '::ffff:127.0.0.1';
+      if (!isLoopback) {
+        logger.warn({ ip: clientIp }, 'Rejected non-loopback request to /api/admin/status');
+        return reply.code(403).send({ error: 'Forbidden — loopback only' });
+      }
+
       const sessions = deps.sessionManager.list();
       const mem = process.memoryUsage();
 

--- a/relay/src/routes/health.ts
+++ b/relay/src/routes/health.ts
@@ -1,7 +1,8 @@
-import type { FastifyPluginAsync } from 'fastify';
+import type { FastifyPluginAsync, FastifyRequest } from 'fastify';
 import type { SessionManager } from '../sessions/session-manager.js';
 import type { FleetManager } from '../fleet/fleet-manager.js';
 import type { HealthMonitor } from '../health/health-monitor.js';
+import { listWindows } from '../utils/tmux-cli.js';
 
 interface HealthDeps {
   sessionManager: SessionManager;
@@ -10,12 +11,36 @@ interface HealthDeps {
 }
 
 /**
+ * Connected WebSocket client info for the admin status endpoint.
+ * Populated by the WS route via `setClientTracker`.
+ */
+export interface AdminClientInfo {
+  ip: string;
+  userAgent: string;
+  connectedAt: string;
+}
+
+/** Callback type for the WS route to supply live client info. */
+export type ClientTrackerFn = () => AdminClientInfo[];
+
+/** Set by ws.ts so the admin endpoint can enumerate connected clients. */
+let clientTracker: ClientTrackerFn = () => [];
+
+export function setClientTracker(fn: ClientTrackerFn): void {
+  clientTracker = fn;
+}
+
+/**
  * Health check route — public, no auth.
  * Includes per-session process health status from HealthMonitor
  * and fleet worker status from FleetManager.
+ *
+ * Also provides `/api/admin/status` — a richer admin endpoint for
+ * Ground Control's dashboard (connected clients, memory, uptime, tmux).
  */
 export function createHealthRoutes(deps: HealthDeps): FastifyPluginAsync {
   return async (fastify) => {
+    // ── Lightweight health probe (public) ──────────────────
     fastify.get('/health', async () => {
       const fleetStatus = deps.fleetManager.getFleetStatus();
       return {
@@ -28,6 +53,44 @@ export function createHealthRoutes(deps: HealthDeps): FastifyPluginAsync {
           totalSessions: fleetStatus.totalSessions,
           workers: fleetStatus.workers,
         },
+      };
+    });
+
+    // ── Admin status endpoint (no auth — localhost only) ───
+    // Ground Control polls this from the same machine, so auth is
+    // unnecessary. The endpoint is intentionally kept unauthenticated
+    // to avoid coupling Ground Control to the relay's session cookie /
+    // PIN flow — it's a management tool, not a user-facing client.
+    fastify.get('/api/admin/status', async (_request: FastifyRequest) => {
+      const sessions = deps.sessionManager.list();
+      const mem = process.memoryUsage();
+
+      // tmux window count — best-effort, non-blocking
+      let tmuxWindowCount = 0;
+      try {
+        const windows = await listWindows();
+        tmuxWindowCount = windows.length;
+      } catch {
+        // tmux may not be running — that's fine
+      }
+
+      return {
+        status: 'ok',
+        uptime: process.uptime(),
+        clients: clientTracker(),
+        sessions: sessions.map((s) => ({
+          sessionId: s.id,
+          workDir: s.workingDir,
+          status: s.status,
+          startedAt: s.startedAt,
+        })),
+        memory: {
+          rss: mem.rss,
+          heapUsed: mem.heapUsed,
+          heapTotal: mem.heapTotal,
+          external: mem.external,
+        },
+        tmuxWindowCount,
       };
     });
   };

--- a/relay/src/routes/ws.ts
+++ b/relay/src/routes/ws.ts
@@ -92,6 +92,24 @@ export function createWsRoute(deps: WsDeps): FastifyPluginAsync {
   const clients = new Set<WebSocket>();
   const presenceManager = new PresenceManager();
 
+  // ── Per-client metadata for admin status endpoint ──────────
+  interface ClientMeta { ip: string; userAgent: string; connectedAt: string }
+  const clientMetas = new Map<WebSocket, ClientMeta>();
+
+  // Register the tracker so health.ts can enumerate connected clients
+  // without importing ws.ts (avoids circular deps).
+  import('../routes/health.js').then(({ setClientTracker }) => {
+    setClientTracker(() =>
+      [...clientMetas.values()].map((m) => ({
+        ip: m.ip,
+        userAgent: m.userAgent,
+        connectedAt: m.connectedAt,
+      })),
+    );
+  }).catch(() => {
+    // Defensive — should never happen in practice
+  });
+
   // ── Achievement event wiring ────────────────────────────────
   // When an achievement unlocks, broadcast to all connected clients + record in analytics
   achievementService.onUnlock((payload) => {
@@ -1759,12 +1777,13 @@ export function createWsRoute(deps: WsDeps): FastifyPluginAsync {
     wireAdapterEvents();
 
     // Shared socket setup — wires up event handlers after auth succeeds
-    function setupSocket(socket: WebSocket, ip: string, sessionPayload?: SessionPayload): void {
+    function setupSocket(socket: WebSocket, ip: string, userAgent: string, sessionPayload?: SessionPayload): void {
       (socket as WebSocket & { isAlive: boolean }).isAlive = true;
       socket.on('pong', () => {
         (socket as WebSocket & { isAlive: boolean }).isAlive = true;
       });
       clients.add(socket);
+      clientMetas.set(socket, { ip, userAgent, connectedAt: new Date().toISOString() });
 
       // Register presence if we have user identity
       if (sessionPayload) {
@@ -1778,6 +1797,7 @@ export function createWsRoute(deps: WsDeps): FastifyPluginAsync {
 
       socket.on('close', () => {
         clients.delete(socket);
+        clientMetas.delete(socket);
         // Disconnect from presence before untracking session
         const disconnectResult = presenceManager.disconnect(socket);
         untrackClientSession(socket);
@@ -1828,11 +1848,13 @@ export function createWsRoute(deps: WsDeps): FastifyPluginAsync {
       const legacyAuthToken = process.env['AUTH_TOKEN'];
       const isDevMode = process.env['NODE_ENV'] !== 'production';
 
+      const ua = (request.headers['user-agent'] as string | undefined) ?? 'unknown';
+
       // Legacy token auth: dev-only, if ?token= matches AUTH_TOKEN env var, skip OAuth
       if (isDevMode && queryToken && legacyAuthToken && queryToken === legacyAuthToken) {
         const ip = request.ip;
         logger.info({ ip }, 'Client connected via WebSocket (legacy token auth, dev mode)');
-        setupSocket(socket, ip);
+        setupSocket(socket, ip, ua);
         return;
       }
 
@@ -1861,7 +1883,7 @@ export function createWsRoute(deps: WsDeps): FastifyPluginAsync {
           // Authenticated — set up connection
           const ip = request.ip;
           logger.info({ ip, email: payload.email, userId: payload.userId }, 'Client connected via WebSocket');
-          setupSocket(socket, ip, payload);
+          setupSocket(socket, ip, ua, payload);
         })
         .catch(() => {
           socket.close(1008, 'Invalid session');
@@ -1876,6 +1898,7 @@ export function createWsRoute(deps: WsDeps): FastifyPluginAsync {
           logger.info('Terminating dead WebSocket connection');
           conn.terminate();
           clients.delete(client);
+          clientMetas.delete(client);
           continue;
         }
         conn.isAlive = false;
@@ -1900,6 +1923,7 @@ export function createWsRoute(deps: WsDeps): FastifyPluginAsync {
         client.close(1001, 'Server shutting down');
       }
       clients.clear();
+      clientMetas.clear();
     });
   };
 }

--- a/relay/src/routes/ws.ts
+++ b/relay/src/routes/ws.ts
@@ -106,8 +106,8 @@ export function createWsRoute(deps: WsDeps): FastifyPluginAsync {
         connectedAt: m.connectedAt,
       })),
     );
-  }).catch(() => {
-    // Defensive — should never happen in practice
+  }).catch((err: unknown) => {
+    logger.warn({ err }, 'Failed to register WebSocket client tracker with health route');
   });
 
   // ── Achievement event wiring ────────────────────────────────
@@ -1848,7 +1848,8 @@ export function createWsRoute(deps: WsDeps): FastifyPluginAsync {
       const legacyAuthToken = process.env['AUTH_TOKEN'];
       const isDevMode = process.env['NODE_ENV'] !== 'production';
 
-      const ua = (request.headers['user-agent'] as string | undefined) ?? 'unknown';
+      const rawUserAgent = request.headers['user-agent'];
+      const ua = (Array.isArray(rawUserAgent) ? rawUserAgent[0] : rawUserAgent) ?? 'unknown';
 
       // Legacy token auth: dev-only, if ?token= matches AUTH_TOKEN env var, skip OAuth
       if (isDevMode && queryToken && legacyAuthToken && queryToken === legacyAuthToken) {


### PR DESCRIPTION
## Summary

- **New `/api/admin/status` relay endpoint** — returns connected WS clients (IP, user agent, connected-at), active sessions (ID, working dir, status), Node.js memory usage (RSS, heap), process uptime, and tmux window count
- **Relay WS client tracking** — `ws.ts` now tracks per-client metadata (IP, user-agent, connected-at) in a Map, cleaned up on close/eviction
- **Dashboard view** — card-based `LazyVGrid` layout with status card (running indicator, uptime, port), memory card (RSS, heap with progress bar), clients card (count + device rows), sessions card (count + directory names)
- **RelayClient service** — `@Observable` HTTP poller hitting admin endpoint every 5s with 3s timeout, graceful error handling
- **ClientListView** — full-detail connected clients view with device icons, monospaced IPs, user agent strings, connection duration
- **ManagementWindow** — Dashboard now default sidebar tab (above Logs)

## Test plan

- [ ] Start relay, launch Ground Control, verify dashboard shows server status + uptime
- [ ] Connect PWA/iOS client, verify client appears in dashboard clients card
- [ ] Start a Claude session, verify it appears in sessions card
- [ ] Verify memory card shows heap usage with progress bar
- [ ] Stop relay, verify dashboard shows stopped state gracefully
- [ ] Verify auto-refresh every 5 seconds updates all cards
- [ ] Hit `/api/admin/status` directly, verify JSON response shape

🤖 Generated with [Claude Code](https://claude.com/claude-code)