### PR TITLE
feat(ios): SwiftTerm Wave 3 — Multi-Tab Support

### DIFF
--- a/ios/MajorTom.xcodeproj/project.pbxproj
+++ b/ios/MajorTom.xcodeproj/project.pbxproj
@@ -27,6 +27,7 @@
 		236F9F1B1379B823DB4FD5DB /* MajorTomWidgetsBundle.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCBDA7E064D0179C4FD35A17 /* MajorTomWidgetsBundle.swift */; };
 		241AFDC78C513CD9E223E14B /* PromptHistoryViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F01A77A2D40CD2418227CFFA /* PromptHistoryViewModel.swift */; };
 		26964C3030E1F083E2CD9348 /* CostChartView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDAE68402A08DCDB8ACF6CC6 /* CostChartView.swift */; };
+		27B11F1CEE9D5951F2C500F0 /* TerminalTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98BCC0CB0F9FD6AB70872448 /* TerminalTab.swift */; };
 		288F12D3D96E0A65C44898AB /* ActivityKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 86E24365BDAFFF829D7D95B8 /* ActivityKit.framework */; };
 		2893EC2341883FD3CB72E6F5 /* MajorTomLiveActivityView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0656AE4C6DEE802350E31BF /* MajorTomLiveActivityView.swift */; };
 		2CD2BE4AF89623E36046AEF2 /* ApprovalRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CAFA24AC1299FAEA55E2C0B /* ApprovalRequest.swift */; };
@@ -76,6 +77,7 @@
 		73C3300EC83340590AE6DEEC /* WidgetKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 99396FACEBA85FA298D818E8 /* WidgetKit.framework */; };
 		74BC84A25FAE29C592011D14 /* VoiceInputButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E56BE06976EFB6DAC4215EE /* VoiceInputButton.swift */; };
 		7800B5EFB116E5708F3A6300 /* SessionCostRankingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CFE6DFB18C709862C80D1B4 /* SessionCostRankingView.swift */; };
+		7D680AE80F01D84BF6209698 /* CloseTabConfirm.swift in Sources */ = {isa = PBXBuildFile; fileRef = E104B2CEBAA36B9B97E254AA /* CloseTabConfirm.swift */; };
 		818FA51F81C18CFE08B3C097 /* PairingViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 526DF9EAD13F47F747C7ACC3 /* PairingViewModel.swift */; };
 		8294293F9EF30CBEED38BFC6 /* HapticService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7794C5813F5964F288D432AD /* HapticService.swift */; };
 		83C02DEBD2B6488A47A08A65 /* ModePickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66594811ED284A67510E10AE /* ModePickerView.swift */; };
@@ -146,6 +148,7 @@
 		DAF8846049213892ED759F17 /* WatchModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = AED0FBA701051A3E384D032F /* WatchModels.swift */; };
 		DCB6D7EDF870D5026A60DD40 /* WidgetDataProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C930886C2C3C06157C3BEAE /* WidgetDataProvider.swift */; };
 		DEC7A03BAD629CB026FDD77F /* DeviceManagementView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B2D2956D7BBBE520D548CED /* DeviceManagementView.swift */; };
+		E147B9996C907362442F395A /* TerminalTabBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEE5C5DC2463A313FEDD6406 /* TerminalTabBar.swift */; };
 		E33E3AB2F7B8D363195066CE /* Command.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85D1943B475C9654A302EA24 /* Command.swift */; };
 		E4C11D19C5CBC7B5653532FD /* Theme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 345B4AA475B96036D85853BA /* Theme.swift */; };
 		E8857FD8E62501F637B7EDA9 /* LiveActivityManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5795954485F00C86256F6533 /* LiveActivityManager.swift */; };
@@ -301,6 +304,7 @@
 		91CC00DFBC23B1D7A0EC631C /* WatchModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchModels.swift; sourceTree = "<group>"; };
 		944EEB19C6C12FD8F9F43846 /* STATUS.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = STATUS.md; sourceTree = "<group>"; };
 		96C1E3AF7CCC785A62706B1F /* MajorTomWidgets.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = MajorTomWidgets.entitlements; sourceTree = "<group>"; };
+		98BCC0CB0F9FD6AB70872448 /* TerminalTab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalTab.swift; sourceTree = "<group>"; };
 		99396FACEBA85FA298D818E8 /* WidgetKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WidgetKit.framework; path = System/Library/Frameworks/WidgetKit.framework; sourceTree = SDKROOT; };
 		9E41011D1A5C03C795509B68 /* MajorTomWatch.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = MajorTomWatch.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		A198759EB4EA086A9CBF595F /* AchievementsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AchievementsViewModel.swift; sourceTree = "<group>"; };
@@ -330,6 +334,7 @@
 		CC19E99FB3AAD181F192CD3B /* MessageCodec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageCodec.swift; sourceTree = "<group>"; };
 		CCBDA7E064D0179C4FD35A17 /* MajorTomWidgetsBundle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MajorTomWidgetsBundle.swift; sourceTree = "<group>"; };
 		CCDB924E236ABFE12B68C803 /* ActivityManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityManager.swift; sourceTree = "<group>"; };
+		CEE5C5DC2463A313FEDD6406 /* TerminalTabBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalTabBar.swift; sourceTree = "<group>"; };
 		CF16084D9274212487A6B7CC /* TokenBreakdownView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenBreakdownView.swift; sourceTree = "<group>"; };
 		D06F8E498C8D1F63A30D6A5F /* RateLimitSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RateLimitSettingsView.swift; sourceTree = "<group>"; };
 		D136B4051E73808BE748883D /* MajorTomWidgets.appex */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = "wrapper.app-extension"; path = MajorTomWidgets.appex; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -341,6 +346,7 @@
 		DDAE68402A08DCDB8ACF6CC6 /* CostChartView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CostChartView.swift; sourceTree = "<group>"; };
 		DEEC8301336B2489A2BD0E74 /* xterm.css */ = {isa = PBXFileReference; lastKnownFileType = text.css; path = xterm.css; sourceTree = "<group>"; };
 		E056D47F9B40C746E3CF4F0A /* NotificationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationService.swift; sourceTree = "<group>"; };
+		E104B2CEBAA36B9B97E254AA /* CloseTabConfirm.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloseTabConfirm.swift; sourceTree = "<group>"; };
 		E12E82C2CDBC2751A59C34B6 /* GitStatusView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitStatusView.swift; sourceTree = "<group>"; };
 		E176705EB6880868FE05573E /* CharacterGalleryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CharacterGalleryView.swift; sourceTree = "<group>"; };
 		E659E1885E32B1187E8C3703 /* MessageBubble.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageBubble.swift; sourceTree = "<group>"; };
@@ -730,8 +736,10 @@
 		3DE6E199560ED8BF5FFCE9F1 /* Views */ = {
 			isa = PBXGroup;
 			children = (
+				E104B2CEBAA36B9B97E254AA /* CloseTabConfirm.swift */,
 				12F88005107C4A255AA3A9B4 /* NativeKeybar.swift */,
 				908E6CFCF4E1F5F05D0AE4C3 /* SpecialtyKeyGrid.swift */,
+				CEE5C5DC2463A313FEDD6406 /* TerminalTabBar.swift */,
 				08B5EA37D9C8CAB62E22FA9E /* TerminalView.swift */,
 				FB1670D9369405523BC6911E /* TerminalWebView.swift */,
 			);
@@ -902,6 +910,7 @@
 			isa = PBXGroup;
 			children = (
 				44CC6040BB95650DF4152EE8 /* KeySpec.swift */,
+				98BCC0CB0F9FD6AB70872448 /* TerminalTab.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -1548,6 +1557,7 @@
 				688A8874D97CF87B709FC013 /* CharacterGalleryView.swift in Sources */,
 				6C1C58D6705B5201DC10755F /* ChatView.swift in Sources */,
 				CFCBB89895F30259222DD268 /* ChatViewModel.swift in Sources */,
+				7D680AE80F01D84BF6209698 /* CloseTabConfirm.swift in Sources */,
 				D919E02E075F0907DC4F66E0 /* CodeBlockView.swift in Sources */,
 				E33E3AB2F7B8D363195066CE /* Command.swift in Sources */,
 				8FB3EDDC5BF48B634AD7D376 /* CommandPaletteView.swift in Sources */,
@@ -1631,6 +1641,8 @@
 				9CD2E53B7E3E03544247C57C /* TemplateEditorView.swift in Sources */,
 				4F038F899716358276CDA57D /* TemplateListView.swift in Sources */,
 				8AF181059859C1E5F1FBEE38 /* TemplateViewModel.swift in Sources */,
+				27B11F1CEE9D5951F2C500F0 /* TerminalTab.swift in Sources */,
+				E147B9996C907362442F395A /* TerminalTabBar.swift in Sources */,
 				FE62ADBFD8D61511DAA7AC76 /* TerminalView.swift in Sources */,
 				0F30CC544A16BDFDF67FCF16 /* TerminalViewModel.swift in Sources */,
 				D5F7ABD14733BA4E98FE10F9 /* TerminalWebView.swift in Sources */,

--- a/ios/MajorTom/Features/Terminal/Models/TerminalTab.swift
+++ b/ios/MajorTom/Features/Terminal/Models/TerminalTab.swift
@@ -1,0 +1,39 @@
+import Foundation
+
+/// Represents a single terminal tab backed by a tmux window on the relay.
+///
+/// Each tab maps to a unique `/shell/:tabId` WebSocket endpoint. The relay
+/// creates (or re-attaches to) a tmux window keyed by `tabId`.
+struct TerminalTab: Identifiable, Equatable {
+    /// Unique identifier for SwiftUI list diffing.
+    let id: UUID
+
+    /// The tab ID used in the WebSocket path (`/shell/:tabId`).
+    /// Matches the regex `[a-zA-Z0-9._-]{1,64}` enforced by the relay.
+    let tabId: String
+
+    /// Display title — updated via xterm title escape sequence from the shell.
+    var title: String
+
+    /// Whether this tab is currently the active/visible one.
+    var isActive: Bool
+
+    /// Timestamp when this tab was created (for ordering).
+    let createdAt: Date
+
+    init(
+        id: UUID = UUID(),
+        tabId: String? = nil,
+        title: String = "Terminal",
+        isActive: Bool = false,
+        createdAt: Date = Date()
+    ) {
+        self.id = id
+        // Generate a relay-safe tabId from the UUID if none provided.
+        // Uses the first 8 chars of the UUID for brevity + readability.
+        self.tabId = tabId ?? "tab-\(id.uuidString.prefix(8).lowercased())"
+        self.title = title
+        self.isActive = isActive
+        self.createdAt = createdAt
+    }
+}

--- a/ios/MajorTom/Features/Terminal/ViewModels/TerminalViewModel.swift
+++ b/ios/MajorTom/Features/Terminal/ViewModels/TerminalViewModel.swift
@@ -68,10 +68,16 @@ final class TerminalViewModel {
     var connectionState: TerminalConnectionState = .disconnected
 
     /// The active tab ID for the tmux window.
-    var tabId: String = "default"
+    /// Derived from the active tab in the `tabs` array.
+    var tabId: String {
+        activeTab?.tabId ?? "default"
+    }
 
     /// Terminal title (set by xterm title escape sequence).
-    var terminalTitle: String = "Terminal"
+    /// Derived from the active tab's title.
+    var terminalTitle: String {
+        activeTab?.title ?? "Terminal"
+    }
 
     /// Current terminal dimensions.
     var cols: Int = 80
@@ -87,11 +93,106 @@ final class TerminalViewModel {
     /// Set by TerminalWebView's makeUIView; nilled automatically on dealloc.
     weak var webView: WKWebView?
 
+    // MARK: - Multi-Tab State
+
+    /// All open terminal tabs.
+    var tabs: [TerminalTab] = []
+
+    /// The ID of the tab pending close confirmation (when user taps close).
+    var pendingCloseTabId: UUID?
+
+    /// Whether the close-tab confirmation dialog is showing.
+    var showCloseConfirmation: Bool = false
+
+    /// Signals the web view to switch to a new tab (disconnect + reconnect).
+    /// Set by `switchTab(id:)`, consumed by TerminalWebView's `updateUIView`.
+    var pendingTabSwitch: String?
+
+    /// The currently active tab, if any.
+    var activeTab: TerminalTab? {
+        tabs.first(where: { $0.isActive })
+    }
+
     /// Reference to the auth service for relay URL and token.
     private let auth: AuthService
 
     init(auth: AuthService) {
         self.auth = auth
+        // Create the initial default tab.
+        let initialTab = TerminalTab(title: "Terminal", isActive: true)
+        self.tabs = [initialTab]
+    }
+
+    // MARK: - Tab Management
+
+    /// Create a new tab and switch to it.
+    func createTab() {
+        // Deactivate all existing tabs.
+        for i in tabs.indices {
+            tabs[i].isActive = false
+        }
+
+        let newTab = TerminalTab(title: "Terminal", isActive: true)
+        tabs.append(newTab)
+
+        // Signal the web view to connect to the new tab.
+        pendingTabSwitch = newTab.tabId
+    }
+
+    /// Close a tab by its ID.
+    ///
+    /// If the closed tab was active, switches to the nearest neighbor.
+    /// If it was the last tab, creates a fresh one (never zero tabs).
+    func closeTab(id: UUID) {
+        guard let index = tabs.firstIndex(where: { $0.id == id }) else { return }
+
+        let wasActive = tabs[index].isActive
+        tabs.remove(at: index)
+
+        // Never allow zero tabs — create a fresh one.
+        if tabs.isEmpty {
+            let newTab = TerminalTab(title: "Terminal", isActive: true)
+            tabs.append(newTab)
+            pendingTabSwitch = newTab.tabId
+            return
+        }
+
+        // If the closed tab was active, switch to a neighbor.
+        if wasActive {
+            let newIndex = min(index, tabs.count - 1)
+            tabs[newIndex].isActive = true
+            pendingTabSwitch = tabs[newIndex].tabId
+        }
+    }
+
+    /// Request to close a tab — shows confirmation dialog.
+    func requestCloseTab(id: UUID) {
+        pendingCloseTabId = id
+        showCloseConfirmation = true
+    }
+
+    /// Confirm and execute the pending tab close.
+    func confirmCloseTab() {
+        guard let tabId = pendingCloseTabId else { return }
+        pendingCloseTabId = nil
+        closeTab(id: tabId)
+    }
+
+    /// Switch to a different tab by its ID.
+    func switchTab(id: UUID) {
+        guard let targetIndex = tabs.firstIndex(where: { $0.id == id }) else { return }
+
+        // Already active — nothing to do.
+        if tabs[targetIndex].isActive { return }
+
+        // Deactivate all, activate target.
+        for i in tabs.indices {
+            tabs[i].isActive = false
+        }
+        tabs[targetIndex].isActive = true
+
+        // Signal the web view to disconnect current and connect to the new tab.
+        pendingTabSwitch = tabs[targetIndex].tabId
     }
 
     // MARK: - Relay Configuration
@@ -188,9 +289,16 @@ final class TerminalViewModel {
         case .ready:
             isReady = true
 
-        case .connected(let tabId):
-            self.tabId = tabId
+        case .connected(let connectedTabId):
+            // Update the active tab's tabId if the relay confirmed it.
             connectionState = .connected
+            // Mark the matching tab as connected (relay may echo back the tabId).
+            if let index = tabs.firstIndex(where: { $0.tabId == connectedTabId }) {
+                // Ensure only this tab is active.
+                for i in tabs.indices {
+                    tabs[i].isActive = (i == index)
+                }
+            }
 
         case .disconnected(let code, let reason):
             connectionState = .disconnected
@@ -202,7 +310,11 @@ final class TerminalViewModel {
             HapticService.impact(.light)
 
         case .title(let title):
-            terminalTitle = title.isEmpty ? "Terminal" : title
+            // Update the active tab's title from xterm title escape sequence.
+            let newTitle = title.isEmpty ? "Terminal" : title
+            if let index = tabs.firstIndex(where: { $0.isActive }) {
+                tabs[index].title = newTitle
+            }
 
         case .selection(let text):
             UIPasteboard.general.string = text

--- a/ios/MajorTom/Features/Terminal/ViewModels/TerminalViewModel.swift
+++ b/ios/MajorTom/Features/Terminal/ViewModels/TerminalViewModel.swift
@@ -290,11 +290,11 @@ final class TerminalViewModel {
             isReady = true
 
         case .connected(let connectedTabId):
-            // Update the active tab's tabId if the relay confirmed it.
             connectionState = .connected
-            // Mark the matching tab as connected (relay may echo back the tabId).
+            // Activate the tab whose tabId matches the relay-confirmed ID.
+            // The relay echoes back the tabId on successful connection, so
+            // we reconcile by toggling isActive to the matching tab.
             if let index = tabs.firstIndex(where: { $0.tabId == connectedTabId }) {
-                // Ensure only this tab is active.
                 for i in tabs.indices {
                     tabs[i].isActive = (i == index)
                 }

--- a/ios/MajorTom/Features/Terminal/Views/CloseTabConfirm.swift
+++ b/ios/MajorTom/Features/Terminal/Views/CloseTabConfirm.swift
@@ -1,0 +1,43 @@
+import SwiftUI
+
+/// View modifier that presents a confirmation dialog when closing a terminal tab.
+///
+/// Shown when the user taps the close button on a tab that may have an active
+/// process. Uses `.alert` for a clean modal experience on iOS.
+struct CloseTabConfirmModifier: ViewModifier {
+    /// Whether the confirmation dialog is showing.
+    @Binding var isPresented: Bool
+
+    /// The title of the tab being closed, for display in the dialog.
+    let tabTitle: String
+
+    /// Called when the user confirms the close action.
+    let onConfirm: () -> Void
+
+    func body(content: Content) -> some View {
+        content
+            .alert("Close Tab?", isPresented: $isPresented) {
+                Button("Cancel", role: .cancel) { }
+                Button("Close", role: .destructive) {
+                    onConfirm()
+                }
+            } message: {
+                Text("This tab may have a running process. Close \"\(tabTitle)\" anyway?")
+            }
+    }
+}
+
+extension View {
+    /// Attach a close-tab confirmation dialog to this view.
+    func closeTabConfirmation(
+        isPresented: Binding<Bool>,
+        tabTitle: String,
+        onConfirm: @escaping () -> Void
+    ) -> some View {
+        modifier(CloseTabConfirmModifier(
+            isPresented: isPresented,
+            tabTitle: tabTitle,
+            onConfirm: onConfirm
+        ))
+    }
+}

--- a/ios/MajorTom/Features/Terminal/Views/TerminalTabBar.swift
+++ b/ios/MajorTom/Features/Terminal/Views/TerminalTabBar.swift
@@ -38,40 +38,42 @@ struct TerminalTabBar: View {
     // MARK: - Tab Button
 
     private func tabButton(for tab: TerminalTab) -> some View {
-        Button {
-            onSelectTab(tab.id)
-        } label: {
-            HStack(spacing: MajorTomTheme.Spacing.xs) {
-                Text(tab.title)
-                    .font(.system(size: 12, weight: tab.isActive ? .semibold : .regular, design: .monospaced))
-                    .foregroundStyle(tab.isActive ? MajorTomTheme.Colors.accent : MajorTomTheme.Colors.textSecondary)
-                    .lineLimit(1)
+        HStack(spacing: MajorTomTheme.Spacing.xs) {
+            Text(tab.title)
+                .font(.system(size: 12, weight: tab.isActive ? .semibold : .regular, design: .monospaced))
+                .foregroundStyle(tab.isActive ? MajorTomTheme.Colors.accent : MajorTomTheme.Colors.textSecondary)
+                .lineLimit(1)
 
-                // Close button
-                Button {
-                    onCloseTab(tab.id)
-                } label: {
-                    Image(systemName: "xmark")
-                        .font(.system(size: 8, weight: .bold))
-                        .foregroundStyle(tab.isActive ? MajorTomTheme.Colors.textSecondary : MajorTomTheme.Colors.textTertiary)
-                        .frame(width: 16, height: 16)
-                        .contentShape(Rectangle())
-                }
-                .buttonStyle(.plain)
+            // Close button
+            Button {
+                onCloseTab(tab.id)
+            } label: {
+                Image(systemName: "xmark")
+                    .font(.system(size: 8, weight: .bold))
+                    .foregroundStyle(tab.isActive ? MajorTomTheme.Colors.textSecondary : MajorTomTheme.Colors.textTertiary)
+                    .frame(width: 16, height: 16)
+                    .contentShape(Rectangle())
             }
-            .padding(.horizontal, MajorTomTheme.Spacing.sm)
-            .padding(.vertical, MajorTomTheme.Spacing.xs)
-            .background(tabBackground(isActive: tab.isActive))
-            .clipShape(RoundedRectangle(cornerRadius: 6))
-            .overlay(
-                RoundedRectangle(cornerRadius: 6)
-                    .strokeBorder(
-                        tab.isActive ? MajorTomTheme.Colors.accent.opacity(0.4) : Color.clear,
-                        lineWidth: 1
-                    )
-            )
+            .buttonStyle(.plain)
+            .accessibilityLabel("Close \(tab.title)")
         }
-        .buttonStyle(.plain)
+        .padding(.horizontal, MajorTomTheme.Spacing.sm)
+        .padding(.vertical, MajorTomTheme.Spacing.xs)
+        .background(tabBackground(isActive: tab.isActive))
+        .clipShape(RoundedRectangle(cornerRadius: 6))
+        .contentShape(RoundedRectangle(cornerRadius: 6))
+        .overlay(
+            RoundedRectangle(cornerRadius: 6)
+                .strokeBorder(
+                    tab.isActive ? MajorTomTheme.Colors.accent.opacity(0.4) : Color.clear,
+                    lineWidth: 1
+                )
+        )
+        .onTapGesture {
+            onSelectTab(tab.id)
+        }
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel("\(tab.title), tab\(tab.isActive ? ", active" : "")")
     }
 
     // MARK: - New Tab Button
@@ -88,6 +90,8 @@ struct TerminalTabBar: View {
                 .clipShape(RoundedRectangle(cornerRadius: 6))
         }
         .buttonStyle(.plain)
+        .accessibilityLabel("New tab")
+        .accessibilityHint("Creates a new terminal tab")
     }
 
     // MARK: - Helpers

--- a/ios/MajorTom/Features/Terminal/Views/TerminalTabBar.swift
+++ b/ios/MajorTom/Features/Terminal/Views/TerminalTabBar.swift
@@ -1,0 +1,98 @@
+import SwiftUI
+
+/// Horizontal scrolling tab bar for terminal multi-tab support.
+///
+/// Sits above the WKWebView terminal area. Shows tabs with titles from
+/// xterm title sequences, highlights the active tab, and provides close
+/// buttons on each tab plus a "+" button to create new tabs.
+struct TerminalTabBar: View {
+    /// The list of open terminal tabs.
+    let tabs: [TerminalTab]
+
+    /// Callback when a tab is tapped to switch to it.
+    let onSelectTab: (UUID) -> Void
+
+    /// Callback when the close button on a tab is tapped.
+    let onCloseTab: (UUID) -> Void
+
+    /// Callback when the "+" button is tapped to create a new tab.
+    let onCreateTab: () -> Void
+
+    var body: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: MajorTomTheme.Spacing.xs) {
+                ForEach(tabs) { tab in
+                    tabButton(for: tab)
+                }
+
+                // New tab button
+                newTabButton
+            }
+            .padding(.horizontal, MajorTomTheme.Spacing.sm)
+            .padding(.vertical, MajorTomTheme.Spacing.xs)
+        }
+        .frame(height: 36)
+        .background(MajorTomTheme.Colors.surface)
+    }
+
+    // MARK: - Tab Button
+
+    private func tabButton(for tab: TerminalTab) -> some View {
+        Button {
+            onSelectTab(tab.id)
+        } label: {
+            HStack(spacing: MajorTomTheme.Spacing.xs) {
+                Text(tab.title)
+                    .font(.system(size: 12, weight: tab.isActive ? .semibold : .regular, design: .monospaced))
+                    .foregroundStyle(tab.isActive ? MajorTomTheme.Colors.accent : MajorTomTheme.Colors.textSecondary)
+                    .lineLimit(1)
+
+                // Close button
+                Button {
+                    onCloseTab(tab.id)
+                } label: {
+                    Image(systemName: "xmark")
+                        .font(.system(size: 8, weight: .bold))
+                        .foregroundStyle(tab.isActive ? MajorTomTheme.Colors.textSecondary : MajorTomTheme.Colors.textTertiary)
+                        .frame(width: 16, height: 16)
+                        .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+            }
+            .padding(.horizontal, MajorTomTheme.Spacing.sm)
+            .padding(.vertical, MajorTomTheme.Spacing.xs)
+            .background(tabBackground(isActive: tab.isActive))
+            .clipShape(RoundedRectangle(cornerRadius: 6))
+            .overlay(
+                RoundedRectangle(cornerRadius: 6)
+                    .strokeBorder(
+                        tab.isActive ? MajorTomTheme.Colors.accent.opacity(0.4) : Color.clear,
+                        lineWidth: 1
+                    )
+            )
+        }
+        .buttonStyle(.plain)
+    }
+
+    // MARK: - New Tab Button
+
+    private var newTabButton: some View {
+        Button {
+            onCreateTab()
+        } label: {
+            Image(systemName: "plus")
+                .font(.system(size: 12, weight: .semibold))
+                .foregroundStyle(MajorTomTheme.Colors.textSecondary)
+                .frame(width: 28, height: 28)
+                .background(MajorTomTheme.Colors.surfaceElevated)
+                .clipShape(RoundedRectangle(cornerRadius: 6))
+        }
+        .buttonStyle(.plain)
+    }
+
+    // MARK: - Helpers
+
+    private func tabBackground(isActive: Bool) -> Color {
+        isActive ? MajorTomTheme.Colors.surfaceElevated : MajorTomTheme.Colors.surface
+    }
+}

--- a/ios/MajorTom/Features/Terminal/Views/TerminalView.swift
+++ b/ios/MajorTom/Features/Terminal/Views/TerminalView.swift
@@ -6,6 +6,9 @@ import SwiftUI
 /// keyboard with specialty keys (Esc, Tab, Ctrl, arrows). The SpecialtyKeyGrid
 /// slides up as an alternative to the iOS keyboard with function keys, Ctrl
 /// combos, tmux shortcuts, and symbols.
+///
+/// Wave 3: Multi-tab support. The TerminalTabBar sits above the terminal area
+/// and lets users create, switch, and close tmux windows (tabs).
 struct TerminalView: View {
     let auth: AuthService
 
@@ -28,6 +31,20 @@ struct TerminalView: View {
             VStack(spacing: 0) {
                 // Status bar
                 statusBar
+
+                // Tab bar for multi-tab support
+                TerminalTabBar(
+                    tabs: viewModel.tabs,
+                    onSelectTab: { id in
+                        viewModel.switchTab(id: id)
+                    },
+                    onCloseTab: { id in
+                        viewModel.requestCloseTab(id: id)
+                    },
+                    onCreateTab: {
+                        viewModel.createTab()
+                    }
+                )
 
                 // Terminal web view (fills available space)
                 terminalContent
@@ -68,6 +85,13 @@ struct TerminalView: View {
                 }
             }
         }
+        .closeTabConfirmation(
+            isPresented: $viewModel.showCloseConfirmation,
+            tabTitle: viewModel.tabs.first(where: { $0.id == viewModel.pendingCloseTabId })?.title ?? "Terminal",
+            onConfirm: {
+                viewModel.confirmCloseTab()
+            }
+        )
     }
 
     // MARK: - Status Bar

--- a/ios/MajorTom/Features/Terminal/Views/TerminalWebView.swift
+++ b/ios/MajorTom/Features/Terminal/Views/TerminalWebView.swift
@@ -84,6 +84,26 @@ struct TerminalWebView: UIViewRepresentable {
         if viewModel.didTerminate {
             viewModel.resetAfterRecovery()
             loadTerminalPage(webView)
+            return
+        }
+
+        // Tab switch: disconnect current WS and connect to the new tabId.
+        if let newTabId = viewModel.pendingTabSwitch {
+            viewModel.pendingTabSwitch = nil
+            viewModel.connectionState = .connecting
+
+            let escaped = newTabId
+                .replacingOccurrences(of: "\\", with: "\\\\")
+                .replacingOccurrences(of: "'", with: "\\'")
+
+            // Disconnect current session, update config, reconnect.
+            let js = """
+            if(window.MajorTom){
+              window.MajorTom.disconnect();
+              window.MajorTom.connect({tabId:'\(escaped)'});
+            }
+            """
+            webView.evaluateJavaScript(js) { _, _ in }
         }
     }
 

--- a/ios/MajorTom/Features/Terminal/Views/TerminalWebView.swift
+++ b/ios/MajorTom/Features/Terminal/Views/TerminalWebView.swift
@@ -87,23 +87,36 @@ struct TerminalWebView: UIViewRepresentable {
             return
         }
 
-        // Tab switch: disconnect current WS and connect to the new tabId.
+        // Tab switch: connect to the new tabId (connect() already closes the
+        // existing WS internally, so we skip disconnect() to avoid poisoning
+        // the reconnect counter).
         if let newTabId = viewModel.pendingTabSwitch {
-            viewModel.pendingTabSwitch = nil
-            viewModel.connectionState = .connecting
-
             let escaped = newTabId
                 .replacingOccurrences(of: "\\", with: "\\\\")
                 .replacingOccurrences(of: "'", with: "\\'")
 
-            // Disconnect current session, update config, reconnect.
+            // Call connect() directly — it closes the old socket and resets
+            // reconnect state. Return true/false so we know if MajorTom was
+            // available; only consume the pending switch on success.
             let js = """
             if(window.MajorTom){
-              window.MajorTom.disconnect();
               window.MajorTom.connect({tabId:'\(escaped)'});
+              true;
+            } else {
+              false;
             }
             """
-            webView.evaluateJavaScript(js) { _, _ in }
+            webView.evaluateJavaScript(js) { result, error in
+                guard error == nil, let didSwitch = result as? Bool, didSwitch else {
+                    return
+                }
+                // Only clear the pending switch after the JS bridge confirmed
+                // the reconnect path was invoked.
+                if viewModel.pendingTabSwitch == newTabId {
+                    viewModel.pendingTabSwitch = nil
+                }
+                viewModel.connectionState = .connecting
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

- **TerminalTab model** — data model with UUID, relay-safe tabId (UUID prefix), title, active state, creation timestamp
- **TerminalTabBar** — horizontal scrolling tab bar with active tab accent highlight (border + semibold), close (×) buttons per tab, "+" button for new tabs
- **CloseTabConfirm** — `.alert`-based confirmation dialog as a view modifier, applied via `.closeTabConfirmation()` extension
- **TerminalViewModel multi-tab** — `tabs` array, `activeTab` computed property, `createTab()`/`closeTab(id:)`/`switchTab(id:)` methods, title sync from xterm bridge, edge case handling (closing active tab switches to neighbor, closing last tab creates fresh one)
- **TerminalWebView tab switching** — detects `pendingTabSwitch` signal, calls `MajorTom.disconnect()` then `MajorTom.connect()` via JS bridge to switch WS connection

## Test plan

- [ ] Launch app, verify single default tab appears in tab bar
- [ ] Tap "+" button, verify new tab created and switched to
- [ ] Tap between tabs, verify terminal switches WS connection
- [ ] Run a command in one tab, switch away and back, verify output persists
- [ ] Tap × on a tab, verify confirmation dialog appears
- [ ] Confirm close, verify tab removed and neighbor becomes active
- [ ] Close all tabs down to one, close it, verify fresh tab auto-created
- [ ] Verify tab titles update from xterm title sequence

🤖 Generated with [Claude Code](https://claude.com/claude-code)