### PR TITLE
feat(macos): Wave 4 — Configuration editor & Keychain secrets

### DIFF
--- a/macos/GroundControl/App/GroundControlApp.swift
+++ b/macos/GroundControl/App/GroundControlApp.swift
@@ -6,7 +6,14 @@ import SwiftUI
 /// quick links to the PWA, and a management window with live log viewer.
 @main
 struct GroundControlApp: App {
-    @State private var relay = RelayProcess()
+    @State private var configManager = ConfigManager()
+    @State private var relay: RelayProcess
+
+    init() {
+        let cm = ConfigManager()
+        _configManager = State(initialValue: cm)
+        _relay = State(initialValue: RelayProcess(configManager: cm))
+    }
 
     var body: some Scene {
         // Menu bar extra — the primary UI
@@ -16,9 +23,9 @@ struct GroundControlApp: App {
             menuBarLabel
         }
 
-        // Management window — log viewer and management UI
+        // Management window — log viewer, dashboard, and config UI
         Window("Ground Control", id: "management") {
-            ManagementWindow(relay: relay, logStore: relay.logStore)
+            ManagementWindow(relay: relay, logStore: relay.logStore, configManager: configManager)
                 .frame(minWidth: 700, minHeight: 450)
         }
         .defaultSize(width: 900, height: 600)

--- a/macos/GroundControl/Models/RelayConfig.swift
+++ b/macos/GroundControl/Models/RelayConfig.swift
@@ -1,0 +1,99 @@
+import Foundation
+
+/// Authentication mode for the relay server.
+enum AuthMode: String, Codable, CaseIterable, Identifiable {
+    case none
+    case pin
+    case google
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .none: "None"
+        case .pin: "PIN"
+        case .google: "Google OAuth"
+        }
+    }
+}
+
+/// Log level matching pino's levels.
+enum LogLevel: String, Codable, CaseIterable, Identifiable {
+    case trace
+    case debug
+    case info
+    case warn
+    case error
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        rawValue.capitalized
+    }
+}
+
+/// Typed configuration model for the relay server.
+///
+/// Persisted to `~/.major-tom/config.json`. Secrets (OAuth credentials,
+/// Cloudflare token) are NOT stored here — they live in macOS Keychain.
+struct RelayConfig: Codable, Equatable {
+    var port: Int
+    var hookPort: Int
+    var authMode: AuthMode
+    var multiUserEnabled: Bool
+    var claudeWorkDir: String
+    var logLevel: LogLevel
+    var cloudflareEnabled: Bool
+    var autoStart: Bool
+
+    /// Sensible defaults for a fresh install.
+    static let defaults = RelayConfig(
+        port: 9090,
+        hookPort: 9091,
+        authMode: .pin,
+        multiUserEnabled: false,
+        claudeWorkDir: "~",
+        logLevel: .info,
+        cloudflareEnabled: false,
+        autoStart: true
+    )
+
+    // MARK: - Validation
+
+    /// Validation errors for the current config state.
+    struct ValidationResult {
+        var portError: String?
+        var hookPortError: String?
+
+        var isValid: Bool {
+            portError == nil && hookPortError == nil
+        }
+    }
+
+    /// Validate the config and return any errors.
+    func validate() -> ValidationResult {
+        var result = ValidationResult()
+
+        if port < 1024 || port > 65535 {
+            result.portError = "Port must be between 1024 and 65535"
+        }
+
+        if hookPort < 1024 || hookPort > 65535 {
+            result.hookPortError = "Hook port must be between 1024 and 65535"
+        }
+
+        if result.portError == nil && result.hookPortError == nil && port == hookPort {
+            result.hookPortError = "Hook port must differ from relay port"
+        }
+
+        return result
+    }
+
+    /// Expand `~` in claudeWorkDir to the full home directory path.
+    var expandedClaudeWorkDir: String {
+        if claudeWorkDir.hasPrefix("~") {
+            return (claudeWorkDir as NSString).expandingTildeInPath
+        }
+        return claudeWorkDir
+    }
+}

--- a/macos/GroundControl/Services/ConfigManager.swift
+++ b/macos/GroundControl/Services/ConfigManager.swift
@@ -1,0 +1,184 @@
+import Foundation
+import Security
+
+/// Manages relay configuration persistence and Keychain secret storage.
+///
+/// Config is stored in `~/.major-tom/config.json` (non-secret fields).
+/// Secrets (OAuth credentials, Cloudflare token) are stored in macOS Keychain.
+@Observable
+final class ConfigManager {
+    /// Current in-memory config. Update this then call `save()`.
+    var config: RelayConfig
+
+    /// Whether the config has unsaved changes compared to the on-disk version.
+    var hasUnsavedChanges: Bool {
+        config != lastSavedConfig
+    }
+
+    private var lastSavedConfig: RelayConfig
+
+    // MARK: - Constants
+
+    private static let configDirName = ".major-tom"
+    private static let configFileName = "config.json"
+    private static let keychainService = "com.majortom.groundcontrol"
+
+    /// Well-known Keychain keys for secrets.
+    enum SecretKey {
+        static let googleClientId = "google-client-id"
+        static let googleClientSecret = "google-client-secret"
+        static let cloudflareToken = "cloudflare-token"
+    }
+
+    // MARK: - Init
+
+    init() {
+        let loaded = ConfigManager.loadFromDisk()
+        self.config = loaded
+        self.lastSavedConfig = loaded
+    }
+
+    // MARK: - Config File I/O
+
+    /// Path to `~/.major-tom/config.json`.
+    static var configFileURL: URL {
+        let home = FileManager.default.homeDirectoryForCurrentUser
+        return home
+            .appendingPathComponent(configDirName)
+            .appendingPathComponent(configFileName)
+    }
+
+    /// Path to `~/.major-tom/`.
+    static var configDirURL: URL {
+        let home = FileManager.default.homeDirectoryForCurrentUser
+        return home.appendingPathComponent(configDirName)
+    }
+
+    /// Load config from disk, returning defaults if the file doesn't exist or is malformed.
+    static func loadFromDisk() -> RelayConfig {
+        let url = configFileURL
+
+        guard FileManager.default.fileExists(atPath: url.path) else {
+            return RelayConfig.defaults
+        }
+
+        do {
+            let data = try Data(contentsOf: url)
+            let decoder = JSONDecoder()
+            return try decoder.decode(RelayConfig.self, from: data)
+        } catch {
+            print("[ConfigManager] Failed to decode config.json, using defaults: \(error)")
+            return RelayConfig.defaults
+        }
+    }
+
+    /// Reload config from disk.
+    func reload() {
+        let loaded = ConfigManager.loadFromDisk()
+        config = loaded
+        lastSavedConfig = loaded
+    }
+
+    /// Save current config to `~/.major-tom/config.json` atomically.
+    ///
+    /// Creates the `~/.major-tom/` directory if it doesn't exist.
+    func save() throws {
+        let dirURL = ConfigManager.configDirURL
+        let fileURL = ConfigManager.configFileURL
+
+        // Ensure directory exists
+        try FileManager.default.createDirectory(
+            at: dirURL,
+            withIntermediateDirectories: true
+        )
+
+        // Encode to JSON
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        let data = try encoder.encode(config)
+
+        // Atomic write: write to temp file, then rename
+        let tempURL = dirURL.appendingPathComponent("config.json.tmp")
+        try data.write(to: tempURL, options: .atomic)
+
+        // Replace existing file atomically
+        if FileManager.default.fileExists(atPath: fileURL.path) {
+            _ = try FileManager.default.replaceItemAt(fileURL, withItemAt: tempURL)
+        } else {
+            try FileManager.default.moveItem(at: tempURL, to: fileURL)
+        }
+
+        lastSavedConfig = config
+    }
+
+    /// Reset config to defaults (does not save — call `save()` after).
+    func resetToDefaults() {
+        config = RelayConfig.defaults
+    }
+
+    // MARK: - Keychain CRUD
+
+    /// Store a secret in the macOS Keychain.
+    func setSecret(_ key: String, value: String) {
+        guard let data = value.data(using: .utf8) else { return }
+
+        // Try to update first
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: ConfigManager.keychainService,
+            kSecAttrAccount as String: key,
+        ]
+
+        let updateAttrs: [String: Any] = [
+            kSecValueData as String: data,
+        ]
+
+        let updateStatus = SecItemUpdate(query as CFDictionary, updateAttrs as CFDictionary)
+
+        if updateStatus == errSecItemNotFound {
+            // Item doesn't exist yet — add it
+            var addQuery = query
+            addQuery[kSecValueData as String] = data
+            let addStatus = SecItemAdd(addQuery as CFDictionary, nil)
+            if addStatus != errSecSuccess {
+                print("[ConfigManager] Keychain add failed for '\(key)': \(addStatus)")
+            }
+        } else if updateStatus != errSecSuccess {
+            print("[ConfigManager] Keychain update failed for '\(key)': \(updateStatus)")
+        }
+    }
+
+    /// Retrieve a secret from the macOS Keychain.
+    func getSecret(_ key: String) -> String? {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: ConfigManager.keychainService,
+            kSecAttrAccount as String: key,
+            kSecReturnData as String: true,
+            kSecMatchLimit as String: kSecMatchLimitOne,
+        ]
+
+        var result: AnyObject?
+        let status = SecItemCopyMatching(query as CFDictionary, &result)
+
+        guard status == errSecSuccess, let data = result as? Data else {
+            return nil
+        }
+
+        return String(data: data, encoding: .utf8)
+    }
+
+    /// Delete a secret from the macOS Keychain.
+    func deleteSecret(_ key: String) {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: ConfigManager.keychainService,
+            kSecAttrAccount as String: key,
+        ]
+
+        let status = SecItemDelete(query as CFDictionary)
+        if status != errSecSuccess && status != errSecItemNotFound {
+            print("[ConfigManager] Keychain delete failed for '\(key)': \(status)")
+        }
+    }
+}

--- a/macos/GroundControl/Services/RelayProcess.swift
+++ b/macos/GroundControl/Services/RelayProcess.swift
@@ -12,6 +12,9 @@ final class RelayProcess {
     /// Log store fed by stdout/stderr lines from the relay process.
     let logStore = LogStore()
 
+    /// Config manager providing relay settings and Keychain secrets.
+    let configManager: ConfigManager
+
     private var process: Process?
     private var stdoutPipe: Pipe?
     private var stderrPipe: Pipe?
@@ -19,6 +22,15 @@ final class RelayProcess {
 
     /// Grace period before SIGKILL after SIGTERM (seconds).
     private let shutdownTimeout: TimeInterval = 5.0
+
+    // MARK: - Init
+
+    init(configManager: ConfigManager = ConfigManager()) {
+        self.configManager = configManager
+        // Sync RelayState ports from config
+        self.state.port = configManager.config.port
+        self.state.hookPort = configManager.config.hookPort
+    }
 
     // MARK: - Lifecycle
 
@@ -96,16 +108,39 @@ final class RelayProcess {
         proc.arguments = [paths.relayEntry.path]
         proc.currentDirectoryURL = paths.relayDir
 
-        // Environment
+        // Environment — derived from ConfigManager
+        let config = configManager.config
         var env = ProcessInfo.processInfo.environment
         env["NODE_ENV"] = paths.isDevelopment ? "development" : "production"
-        env["WS_PORT"] = String(state.port)
-        env["HOOK_PORT"] = String(state.hookPort)
-        env["LOG_LEVEL"] = "info"
-        // Inherit CLAUDE_WORK_DIR from parent env, or use home directory
-        if env["CLAUDE_WORK_DIR"] == nil {
-            env["CLAUDE_WORK_DIR"] = FileManager.default.homeDirectoryForCurrentUser.path
+        env["WS_PORT"] = String(config.port)
+        env["HOOK_PORT"] = String(config.hookPort)
+        env["LOG_LEVEL"] = config.logLevel.rawValue
+        env["CLAUDE_WORK_DIR"] = config.expandedClaudeWorkDir
+        env["MULTI_USER_ENABLED"] = config.multiUserEnabled ? "true" : "false"
+
+        // Auth mode → relay env vars
+        switch config.authMode {
+        case .none:
+            env["AUTH_PIN_ENABLED"] = "false"
+            env["AUTH_GOOGLE_ENABLED"] = "false"
+        case .pin:
+            env["AUTH_PIN_ENABLED"] = "true"
+            env["AUTH_GOOGLE_ENABLED"] = "false"
+        case .google:
+            env["AUTH_PIN_ENABLED"] = "false"
+            env["AUTH_GOOGLE_ENABLED"] = "true"
+            if let clientId = configManager.getSecret(ConfigManager.SecretKey.googleClientId) {
+                env["GOOGLE_CLIENT_ID"] = clientId
+            }
+            if let clientSecret = configManager.getSecret(ConfigManager.SecretKey.googleClientSecret) {
+                env["GOOGLE_CLIENT_SECRET"] = clientSecret
+            }
         }
+
+        // Sync RelayState ports so the UI reflects current config
+        state.port = config.port
+        state.hookPort = config.hookPort
+
         proc.environment = env
 
         proc.standardOutput = stdout

--- a/macos/GroundControl/Views/CloudflareTunnelView.swift
+++ b/macos/GroundControl/Views/CloudflareTunnelView.swift
@@ -1,0 +1,92 @@
+import SwiftUI
+
+/// Cloudflare Tunnel configuration section.
+///
+/// Toggle to enable/disable, token stored in Keychain (masked by default),
+/// and a status indicator.
+struct CloudflareTunnelView: View {
+    @Bindable var configManager: ConfigManager
+
+    @State private var tunnelToken = ""
+    @State private var showToken = false
+
+    /// Derived status label for the tunnel.
+    private var statusText: String {
+        if !configManager.config.cloudflareEnabled {
+            return "Disabled"
+        }
+        let hasToken = !(configManager.getSecret(ConfigManager.SecretKey.cloudflareToken) ?? "").isEmpty
+            || !tunnelToken.isEmpty
+        return hasToken ? "Token saved" : "Not configured"
+    }
+
+    private var statusColor: Color {
+        if !configManager.config.cloudflareEnabled { return .secondary }
+        let hasToken = !(configManager.getSecret(ConfigManager.SecretKey.cloudflareToken) ?? "").isEmpty
+            || !tunnelToken.isEmpty
+        return hasToken ? .green : .orange
+    }
+
+    var body: some View {
+        GroupBox("Cloudflare Tunnel") {
+            VStack(alignment: .leading, spacing: 12) {
+                HStack {
+                    Toggle("Enable Cloudflare Tunnel", isOn: $configManager.config.cloudflareEnabled)
+
+                    Spacer()
+
+                    HStack(spacing: 4) {
+                        Circle()
+                            .fill(statusColor)
+                            .frame(width: 8, height: 8)
+                        Text(statusText)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+
+                if configManager.config.cloudflareEnabled {
+                    Divider()
+
+                    LabeledContent("Tunnel Token") {
+                        HStack(spacing: 4) {
+                            Group {
+                                if showToken {
+                                    TextField("Cloudflare Tunnel Token", text: $tunnelToken)
+                                } else {
+                                    SecureField("Cloudflare Tunnel Token", text: $tunnelToken)
+                                }
+                            }
+                            .textFieldStyle(.roundedBorder)
+                            .frame(width: 300)
+
+                            Button {
+                                showToken.toggle()
+                            } label: {
+                                Image(systemName: showToken ? "eye.slash" : "eye")
+                            }
+                            .buttonStyle(.borderless)
+                            .help(showToken ? "Hide" : "Reveal")
+                        }
+                    }
+
+                    Text("Get a tunnel token from the [Cloudflare Zero Trust dashboard](https://one.dash.cloudflare.com)")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+            .padding(8)
+        }
+        .onAppear {
+            tunnelToken = configManager.getSecret(ConfigManager.SecretKey.cloudflareToken) ?? ""
+        }
+        .onChange(of: tunnelToken) {
+            // Persist token changes to Keychain immediately
+            if tunnelToken.isEmpty {
+                configManager.deleteSecret(ConfigManager.SecretKey.cloudflareToken)
+            } else {
+                configManager.setSecret(ConfigManager.SecretKey.cloudflareToken, value: tunnelToken)
+            }
+        }
+    }
+}

--- a/macos/GroundControl/Views/ConfigView.swift
+++ b/macos/GroundControl/Views/ConfigView.swift
@@ -1,0 +1,312 @@
+import SwiftUI
+
+/// Form-based configuration editor for the relay server.
+///
+/// Sections: Server, Authentication, Directories, Features, Startup, Cloudflare.
+/// Secrets are stored in macOS Keychain, non-secret config in ~/.major-tom/config.json.
+struct ConfigView: View {
+    let relay: RelayProcess
+    @Bindable var configManager: ConfigManager
+
+    @State private var showResetConfirmation = false
+    @State private var saveError: String?
+    @State private var showSaveSuccess = false
+
+    // Keychain-backed secret fields (loaded on appear)
+    @State private var googleClientId = ""
+    @State private var googleClientSecret = ""
+    @State private var showGoogleClientId = false
+    @State private var showGoogleClientSecret = false
+
+    private var validation: RelayConfig.ValidationResult {
+        configManager.config.validate()
+    }
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 20) {
+                serverSection
+                authSection
+                directoriesSection
+                featuresSection
+                startupSection
+                CloudflareTunnelView(configManager: configManager)
+
+                Divider()
+                actionButtons
+            }
+            .padding(20)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        .onAppear(perform: loadSecrets)
+        .alert("Reset to Defaults", isPresented: $showResetConfirmation) {
+            Button("Reset", role: .destructive) {
+                resetToDefaults()
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text("This will reset all configuration to default values. Keychain secrets will not be affected.")
+        }
+    }
+
+    // MARK: - Server Section
+
+    @ViewBuilder
+    private var serverSection: some View {
+        GroupBox("Server") {
+            VStack(alignment: .leading, spacing: 12) {
+                LabeledContent("Relay Port") {
+                    VStack(alignment: .trailing, spacing: 2) {
+                        TextField("Port", value: $configManager.config.port, format: .number)
+                            .textFieldStyle(.roundedBorder)
+                            .frame(width: 100)
+                        if let error = validation.portError {
+                            Text(error)
+                                .font(.caption)
+                                .foregroundStyle(.red)
+                        }
+                    }
+                }
+
+                LabeledContent("Hook Port") {
+                    VStack(alignment: .trailing, spacing: 2) {
+                        TextField("Hook Port", value: $configManager.config.hookPort, format: .number)
+                            .textFieldStyle(.roundedBorder)
+                            .frame(width: 100)
+                        if let error = validation.hookPortError {
+                            Text(error)
+                                .font(.caption)
+                                .foregroundStyle(.red)
+                        }
+                    }
+                }
+
+                LabeledContent("Log Level") {
+                    Picker("", selection: $configManager.config.logLevel) {
+                        ForEach(LogLevel.allCases) { level in
+                            Text(level.displayName).tag(level)
+                        }
+                    }
+                    .labelsHidden()
+                    .frame(width: 120)
+                }
+            }
+            .padding(8)
+        }
+    }
+
+    // MARK: - Authentication Section
+
+    @ViewBuilder
+    private var authSection: some View {
+        GroupBox("Authentication") {
+            VStack(alignment: .leading, spacing: 12) {
+                LabeledContent("Auth Mode") {
+                    Picker("", selection: $configManager.config.authMode) {
+                        ForEach(AuthMode.allCases) { mode in
+                            Text(mode.displayName).tag(mode)
+                        }
+                    }
+                    .labelsHidden()
+                    .frame(width: 160)
+                }
+
+                if configManager.config.authMode == .google {
+                    googleOAuthFields
+                }
+            }
+            .padding(8)
+        }
+    }
+
+    @ViewBuilder
+    private var googleOAuthFields: some View {
+        Divider()
+
+        LabeledContent("Client ID") {
+            HStack(spacing: 4) {
+                Group {
+                    if showGoogleClientId {
+                        TextField("Google Client ID", text: $googleClientId)
+                    } else {
+                        SecureField("Google Client ID", text: $googleClientId)
+                    }
+                }
+                .textFieldStyle(.roundedBorder)
+                .frame(width: 300)
+
+                Button {
+                    showGoogleClientId.toggle()
+                } label: {
+                    Image(systemName: showGoogleClientId ? "eye.slash" : "eye")
+                }
+                .buttonStyle(.borderless)
+                .help(showGoogleClientId ? "Hide" : "Reveal")
+            }
+        }
+
+        LabeledContent("Client Secret") {
+            HStack(spacing: 4) {
+                Group {
+                    if showGoogleClientSecret {
+                        TextField("Google Client Secret", text: $googleClientSecret)
+                    } else {
+                        SecureField("Google Client Secret", text: $googleClientSecret)
+                    }
+                }
+                .textFieldStyle(.roundedBorder)
+                .frame(width: 300)
+
+                Button {
+                    showGoogleClientSecret.toggle()
+                } label: {
+                    Image(systemName: showGoogleClientSecret ? "eye.slash" : "eye")
+                }
+                .buttonStyle(.borderless)
+                .help(showGoogleClientSecret ? "Hide" : "Reveal")
+            }
+        }
+    }
+
+    // MARK: - Directories Section
+
+    @ViewBuilder
+    private var directoriesSection: some View {
+        GroupBox("Directories") {
+            VStack(alignment: .leading, spacing: 12) {
+                LabeledContent("Claude Work Dir") {
+                    HStack(spacing: 4) {
+                        TextField("~/path/to/dir", text: $configManager.config.claudeWorkDir)
+                            .textFieldStyle(.roundedBorder)
+                            .frame(width: 260)
+
+                        Button("Browse...") {
+                            chooseDirectory()
+                        }
+                    }
+                }
+            }
+            .padding(8)
+        }
+    }
+
+    // MARK: - Features Section
+
+    @ViewBuilder
+    private var featuresSection: some View {
+        GroupBox("Features") {
+            VStack(alignment: .leading, spacing: 12) {
+                Toggle("Multi-User Mode", isOn: $configManager.config.multiUserEnabled)
+                    .help("Enable multi-user features (per-user OS accounts)")
+            }
+            .padding(8)
+        }
+    }
+
+    // MARK: - Startup Section
+
+    @ViewBuilder
+    private var startupSection: some View {
+        GroupBox("Startup") {
+            VStack(alignment: .leading, spacing: 12) {
+                Toggle("Auto-start relay on app launch", isOn: $configManager.config.autoStart)
+                    .help("Automatically start the relay server when Ground Control launches")
+            }
+            .padding(8)
+        }
+    }
+
+    // MARK: - Action Buttons
+
+    @ViewBuilder
+    private var actionButtons: some View {
+        HStack {
+            Button("Reset to Defaults") {
+                showResetConfirmation = true
+            }
+
+            Spacer()
+
+            if let error = saveError {
+                Text(error)
+                    .font(.caption)
+                    .foregroundStyle(.red)
+            }
+
+            if showSaveSuccess {
+                Text("Saved")
+                    .font(.caption)
+                    .foregroundStyle(.green)
+            }
+
+            Button("Apply & Restart") {
+                applyAndRestart()
+            }
+            .buttonStyle(.borderedProminent)
+            .disabled(!validation.isValid)
+            .keyboardShortcut(.return, modifiers: .command)
+        }
+    }
+
+    // MARK: - Actions
+
+    private func loadSecrets() {
+        googleClientId = configManager.getSecret(ConfigManager.SecretKey.googleClientId) ?? ""
+        googleClientSecret = configManager.getSecret(ConfigManager.SecretKey.googleClientSecret) ?? ""
+    }
+
+    private func saveSecrets() {
+        if googleClientId.isEmpty {
+            configManager.deleteSecret(ConfigManager.SecretKey.googleClientId)
+        } else {
+            configManager.setSecret(ConfigManager.SecretKey.googleClientId, value: googleClientId)
+        }
+
+        if googleClientSecret.isEmpty {
+            configManager.deleteSecret(ConfigManager.SecretKey.googleClientSecret)
+        } else {
+            configManager.setSecret(ConfigManager.SecretKey.googleClientSecret, value: googleClientSecret)
+        }
+    }
+
+    private func applyAndRestart() {
+        saveError = nil
+        showSaveSuccess = false
+
+        do {
+            try configManager.save()
+            saveSecrets()
+            showSaveSuccess = true
+
+            // Hide success message after a moment
+            Task {
+                try? await Task.sleep(for: .seconds(2))
+                showSaveSuccess = false
+            }
+
+            // Restart relay to pick up new config
+            Task {
+                await relay.restart()
+            }
+        } catch {
+            saveError = "Save failed: \(error.localizedDescription)"
+        }
+    }
+
+    private func resetToDefaults() {
+        configManager.resetToDefaults()
+    }
+
+    private func chooseDirectory() {
+        let panel = NSOpenPanel()
+        panel.canChooseDirectories = true
+        panel.canChooseFiles = false
+        panel.allowsMultipleSelection = false
+        panel.message = "Select the default working directory for Claude"
+        panel.prompt = "Select"
+
+        if panel.runModal() == .OK, let url = panel.url {
+            configManager.config.claudeWorkDir = url.path
+        }
+    }
+}

--- a/macos/GroundControl/Views/ManagementWindow.swift
+++ b/macos/GroundControl/Views/ManagementWindow.swift
@@ -21,11 +21,12 @@ enum ManagementSection: String, CaseIterable, Identifiable {
 
 /// Management window with sidebar navigation.
 ///
-/// Dashboard (Wave 3) and Logs (Wave 2) are functional.
-/// Configuration and Security show placeholder content.
+/// Dashboard (Wave 3), Logs (Wave 2), and Configuration (Wave 4) are functional.
+/// Security shows placeholder content.
 struct ManagementWindow: View {
     let relay: RelayProcess
     let logStore: LogStore
+    let configManager: ConfigManager
 
     @State private var selectedSection: ManagementSection = .dashboard
 
@@ -60,11 +61,7 @@ struct ManagementWindow: View {
         case .logs:
             LogView(logStore: logStore)
         case .configuration:
-            placeholderView(
-                icon: ManagementSection.configuration.sfSymbol,
-                title: "Configuration",
-                subtitle: "Port, environment, and startup settings coming soon."
-            )
+            ConfigView(relay: relay, configManager: configManager)
         case .security:
             placeholderView(
                 icon: ManagementSection.security.sfSymbol,


### PR DESCRIPTION
## Summary

- **RelayConfig model** — Codable struct mapping to `~/.major-tom/config.json` with validation (port 1024-65535, no collision), sensible defaults, and tilde expansion for work dirs
- **ConfigManager** — Observable service for atomic config file I/O and macOS Keychain CRUD (Google OAuth client ID/secret, Cloudflare tunnel token). Service name: `com.majortom.groundcontrol`
- **ConfigView** — Form-based settings editor with sections: Server (ports, log level), Authentication (mode picker + masked secret fields with reveal toggle), Directories (claudeWorkDir + NSOpenPanel folder picker), Features (multi-user toggle), Startup (auto-start toggle)
- **CloudflareTunnelView** — Tunnel toggle, masked token input stored in Keychain, status indicator
- **RelayProcess** — Now reads ALL env vars from ConfigManager (WS_PORT, HOOK_PORT, LOG_LEVEL, CLAUDE_WORK_DIR, MULTI_USER_ENABLED, AUTH_PIN_ENABLED, AUTH_GOOGLE_ENABLED, GOOGLE_CLIENT_ID, GOOGLE_CLIENT_SECRET)
- **ManagementWindow** — Configuration sidebar item now shows real ConfigView instead of placeholder

## Test plan

- [ ] Build compiles clean (`swift build` in `macos/`)
- [ ] Config sidebar tab shows the form-based editor
- [ ] Changing port, log level, auth mode persists to `~/.major-tom/config.json`
- [ ] Google OAuth secrets stored in macOS Keychain, not in JSON file
- [ ] Cloudflare token stored in Keychain
- [ ] Reveal/hide toggle works for secret fields
- [ ] Port validation rejects <1024, >65535, and same-port collision
- [ ] "Apply & Restart" saves config and restarts relay with new env vars
- [ ] "Reset to Defaults" restores all non-secret fields
- [ ] Browse button opens NSOpenPanel for claudeWorkDir selection
- [ ] Config file created with defaults on first launch (no existing file)

🤖 Generated with [Claude Code](https://claude.com/claude-code)