### PR TITLE
feat(ios): Wave 4 — Keybar customization, themes & preference sync

### DIFF
--- a/ios/MajorTom.xcodeproj/project.pbxproj
+++ b/ios/MajorTom.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		00C9B06A8AC4D461EBF507D6 /* FleetSessionRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45C4E7F8614EBC3A8F2BB5C7 /* FleetSessionRow.swift */; };
 		00D5C37F9BC512C8E0290120 /* GitHubIssuesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4179D89400E69FF84FE744EA /* GitHubIssuesView.swift */; };
+		014B9A0D2E162DF44B93538F /* TerminalSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E330B7013F0151901B3BF271 /* TerminalSettingsView.swift */; };
 		01CF88DD53BD425A8BB52F59 /* OfficeLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2A5F6ECD6AEA9681C140DA3 /* OfficeLayout.swift */; };
 		05C0C742F30E2EDFA11347D0 /* FileContextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB6DBE8EE08D1C4498E7F3D4 /* FileContextView.swift */; };
 		07F6D478AD81C3549F81ECEB /* ModelDistributionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF0C705C7B75FC8AADBDC2F9 /* ModelDistributionView.swift */; };
@@ -24,6 +25,7 @@
 		1ECF57AD1993033DCCF73DB5 /* OfficeViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 794D98FF20DC91F49542FE7D /* OfficeViewModel.swift */; };
 		1FB9124E49F11A762382E6A9 /* SpecialtyKeyGrid.swift in Sources */ = {isa = PBXBuildFile; fileRef = 908E6CFCF4E1F5F05D0AE4C3 /* SpecialtyKeyGrid.swift */; };
 		2211645B8B3E1BF5093FE2CD /* MoodEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 579C4AF5EF7599467490F248 /* MoodEngine.swift */; };
+		22A50E5C5D84EFE896C415FF /* KeybarCustomizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D14F27776863DA81864B0F1 /* KeybarCustomizer.swift */; };
 		236F9F1B1379B823DB4FD5DB /* MajorTomWidgetsBundle.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCBDA7E064D0179C4FD35A17 /* MajorTomWidgetsBundle.swift */; };
 		241AFDC78C513CD9E223E14B /* PromptHistoryViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F01A77A2D40CD2418227CFFA /* PromptHistoryViewModel.swift */; };
 		26964C3030E1F083E2CD9348 /* CostChartView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDAE68402A08DCDB8ACF6CC6 /* CostChartView.swift */; };
@@ -67,6 +69,7 @@
 		682709FF9F9B3B74B4354939 /* ProgressRing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8656C4CC55FCA4FDE0434BE3 /* ProgressRing.swift */; };
 		6842CC155924DD2F8E828C18 /* WebSocketClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = C13191C0A248C84CA6959981 /* WebSocketClient.swift */; };
 		688A8874D97CF87B709FC013 /* CharacterGalleryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E176705EB6880868FE05573E /* CharacterGalleryView.swift */; };
+		6894059C83BB1BFF450749C2 /* KeybarViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C42B106DA406C73C9B93D02 /* KeybarViewModel.swift */; };
 		6B85090B7B87D7EDCACEFC85 /* WidgetColors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81DAC50CC5B48331EA08A225 /* WidgetColors.swift */; };
 		6BFB6FEFB30CCF68661CADA6 /* AchievementBadge.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0CCFCC6A1C6E9E8DE8AE5A2 /* AchievementBadge.swift */; };
 		6C1C58D6705B5201DC10755F /* ChatView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6657773292DC21D71241871E /* ChatView.swift */; };
@@ -114,6 +117,7 @@
 		B0C9D2C6266E89D3013542BB /* FleetWorkerCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27113A30A32A3F67614DC533 /* FleetWorkerCard.swift */; };
 		B13516C2AA172411121E901D /* ApprovalView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35C91B03433BBF7C8E5EEF21 /* ApprovalView.swift */; };
 		B15C42444B5CD22C9DC12CC6 /* ActiveSessionsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B0B76AD9D8C9446A7C7BA51 /* ActiveSessionsView.swift */; };
+		B20DCD81DEC28F837CDDCE18 /* TerminalTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14709F4508AF70E3A9411DC7 /* TerminalTheme.swift */; };
 		B384AD912E4F5F5AC8F5C0AE /* SpeechService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D7AADF76003BF7A6688FCD0 /* SpeechService.swift */; };
 		B3AFF958EA029C5CCBD0E16F /* ApprovalViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 880169FEDDBE6732F79039AC /* ApprovalViewModel.swift */; };
 		B7F0B7EF40820D1ACBD5720D /* Annotation.swift in Sources */ = {isa = PBXBuildFile; fileRef = A36A4C7C1708949F54A7FB29 /* Annotation.swift */; };
@@ -212,6 +216,7 @@
 		11221A86D528743D2A8857BE /* MajorTomDynamicIsland.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MajorTomDynamicIsland.swift; sourceTree = "<group>"; };
 		1214D167C32053AA742DF101 /* MajorTomWatchApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MajorTomWatchApp.swift; sourceTree = "<group>"; };
 		12F88005107C4A255AA3A9B4 /* NativeKeybar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativeKeybar.swift; sourceTree = "<group>"; };
+		14709F4508AF70E3A9411DC7 /* TerminalTheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalTheme.swift; sourceTree = "<group>"; };
 		1494C1C717DD39A7E7813BF7 /* PermissionViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionViewModel.swift; sourceTree = "<group>"; };
 		1681F6A43D64EB007106125F /* terminal.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = terminal.html; sourceTree = "<group>"; };
 		177E95044756377A532D2A5F /* AuditLogView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuditLogView.swift; sourceTree = "<group>"; };
@@ -235,6 +240,7 @@
 		3AC497E5E769C0087E856232 /* ApprovalCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApprovalCard.swift; sourceTree = "<group>"; };
 		3BF2DF38E87E425D2926A8FE /* GitPanelView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitPanelView.swift; sourceTree = "<group>"; };
 		3C243979CB87B28424C0EC73 /* FleetViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FleetViewModel.swift; sourceTree = "<group>"; };
+		3C42B106DA406C73C9B93D02 /* KeybarViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeybarViewModel.swift; sourceTree = "<group>"; };
 		3DE560D080ED5614FD0F6AFA /* xterm.min.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = xterm.min.js; sourceTree = "<group>"; };
 		3EFA6BF23E66D2305D236B9B /* TemplateListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TemplateListView.swift; sourceTree = "<group>"; };
 		4179D89400E69FF84FE744EA /* GitHubIssuesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitHubIssuesView.swift; sourceTree = "<group>"; };
@@ -268,6 +274,7 @@
 		696B3D1600947ADCE81C436C /* StatusGlanceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusGlanceView.swift; sourceTree = "<group>"; };
 		6A6B155FB1E10E586EFA12AC /* AgentInspectorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentInspectorView.swift; sourceTree = "<group>"; };
 		6C4FC6C7F8AA0ACAD27D5D54 /* DirectoryPermissionsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DirectoryPermissionsView.swift; sourceTree = "<group>"; };
+		6D14F27776863DA81864B0F1 /* KeybarCustomizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeybarCustomizer.swift; sourceTree = "<group>"; };
 		6DA07545B6E9F73EED9477FB /* SessionStatusWidget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionStatusWidget.swift; sourceTree = "<group>"; };
 		6E56BE06976EFB6DAC4215EE /* VoiceInputButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceInputButton.swift; sourceTree = "<group>"; };
 		6E652FADA594D09DB757B828 /* SessionCountView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionCountView.swift; sourceTree = "<group>"; };
@@ -349,6 +356,7 @@
 		E104B2CEBAA36B9B97E254AA /* CloseTabConfirm.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloseTabConfirm.swift; sourceTree = "<group>"; };
 		E12E82C2CDBC2751A59C34B6 /* GitStatusView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitStatusView.swift; sourceTree = "<group>"; };
 		E176705EB6880868FE05573E /* CharacterGalleryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CharacterGalleryView.swift; sourceTree = "<group>"; };
+		E330B7013F0151901B3BF271 /* TerminalSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalSettingsView.swift; sourceTree = "<group>"; };
 		E659E1885E32B1187E8C3703 /* MessageBubble.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageBubble.swift; sourceTree = "<group>"; };
 		E7FA07A9DCD7F42613309990 /* SessionTimelineProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionTimelineProvider.swift; sourceTree = "<group>"; };
 		E8A12203B4DD9D8C97600EC6 /* ContextChipView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextChipView.swift; sourceTree = "<group>"; };
@@ -451,6 +459,7 @@
 		0F5E1D6D2B523251B35E5320 /* ViewModels */ = {
 			isa = PBXGroup;
 			children = (
+				3C42B106DA406C73C9B93D02 /* KeybarViewModel.swift */,
 				689B672DDD255A39492A755E /* TerminalViewModel.swift */,
 			);
 			path = ViewModels;
@@ -737,8 +746,10 @@
 			isa = PBXGroup;
 			children = (
 				E104B2CEBAA36B9B97E254AA /* CloseTabConfirm.swift */,
+				6D14F27776863DA81864B0F1 /* KeybarCustomizer.swift */,
 				12F88005107C4A255AA3A9B4 /* NativeKeybar.swift */,
 				908E6CFCF4E1F5F05D0AE4C3 /* SpecialtyKeyGrid.swift */,
+				E330B7013F0151901B3BF271 /* TerminalSettingsView.swift */,
 				CEE5C5DC2463A313FEDD6406 /* TerminalTabBar.swift */,
 				08B5EA37D9C8CAB62E22FA9E /* TerminalView.swift */,
 				FB1670D9369405523BC6911E /* TerminalWebView.swift */,
@@ -911,6 +922,7 @@
 			children = (
 				44CC6040BB95650DF4152EE8 /* KeySpec.swift */,
 				98BCC0CB0F9FD6AB70872448 /* TerminalTab.swift */,
+				14709F4508AF70E3A9411DC7 /* TerminalTheme.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -1588,6 +1600,8 @@
 				C73A60CB24EFABD14D9C2A2F /* GodModeConfirmation.swift in Sources */,
 				8294293F9EF30CBEED38BFC6 /* HapticService.swift in Sources */,
 				8A47BE851B898A4D0899F183 /* KeySpec.swift in Sources */,
+				22A50E5C5D84EFE896C415FF /* KeybarCustomizer.swift in Sources */,
+				6894059C83BB1BFF450749C2 /* KeybarViewModel.swift in Sources */,
 				36B33910C927C9BBAC0813A7 /* KeychainService.swift in Sources */,
 				E8857FD8E62501F637B7EDA9 /* LiveActivityManager.swift in Sources */,
 				ECE7FC357B702CB405A5F331 /* MajorTomActivity.swift in Sources */,
@@ -1641,8 +1655,10 @@
 				9CD2E53B7E3E03544247C57C /* TemplateEditorView.swift in Sources */,
 				4F038F899716358276CDA57D /* TemplateListView.swift in Sources */,
 				8AF181059859C1E5F1FBEE38 /* TemplateViewModel.swift in Sources */,
+				014B9A0D2E162DF44B93538F /* TerminalSettingsView.swift in Sources */,
 				27B11F1CEE9D5951F2C500F0 /* TerminalTab.swift in Sources */,
 				E147B9996C907362442F395A /* TerminalTabBar.swift in Sources */,
+				B20DCD81DEC28F837CDDCE18 /* TerminalTheme.swift in Sources */,
 				FE62ADBFD8D61511DAA7AC76 /* TerminalView.swift in Sources */,
 				0F30CC544A16BDFDF67FCF16 /* TerminalViewModel.swift in Sources */,
 				D5F7ABD14733BA4E98FE10F9 /* TerminalWebView.swift in Sources */,

--- a/ios/MajorTom/Features/Terminal/Models/TerminalTheme.swift
+++ b/ios/MajorTom/Features/Terminal/Models/TerminalTheme.swift
@@ -1,0 +1,237 @@
+import Foundation
+
+/// Terminal color theme definition for xterm.js.
+///
+/// Each theme provides the full set of 19 xterm colors used by the JS bridge.
+/// Themes are injected into the WKWebView via `MajorTom.setTheme(theme)` and
+/// persisted by the `KeybarViewModel` preference sync system.
+struct TerminalTheme: Identifiable, Codable, Equatable, Sendable {
+    let id: String
+    let name: String
+
+    // Core colors
+    let background: String
+    let foreground: String
+    let cursor: String
+    let cursorAccent: String
+    let selectionBackground: String
+
+    // Standard ANSI colors
+    let black: String
+    let red: String
+    let green: String
+    let yellow: String
+    let blue: String
+    let magenta: String
+    let cyan: String
+    let white: String
+
+    // Bright ANSI colors
+    let brightBlack: String
+    let brightRed: String
+    let brightGreen: String
+    let brightYellow: String
+    let brightBlue: String
+    let brightMagenta: String
+    let brightCyan: String
+    let brightWhite: String
+
+    /// Dictionary representation for passing to the JS bridge's `MajorTom.setTheme()`.
+    var asDictionary: [String: String] {
+        [
+            "background": background,
+            "foreground": foreground,
+            "cursor": cursor,
+            "cursorAccent": cursorAccent,
+            "selectionBackground": selectionBackground,
+            "black": black,
+            "red": red,
+            "green": green,
+            "yellow": yellow,
+            "blue": blue,
+            "magenta": magenta,
+            "cyan": cyan,
+            "white": white,
+            "brightBlack": brightBlack,
+            "brightRed": brightRed,
+            "brightGreen": brightGreen,
+            "brightYellow": brightYellow,
+            "brightBlue": brightBlue,
+            "brightMagenta": brightMagenta,
+            "brightCyan": brightCyan,
+            "brightWhite": brightWhite,
+        ]
+    }
+}
+
+// MARK: - Preset Themes
+
+extension TerminalTheme {
+
+    /// All available themes for the picker UI.
+    static let all: [TerminalTheme] = [
+        .majorTom, .dracula, .solarizedDark, .solarizedLight, .monokai, .nord,
+    ]
+
+    /// Default Major Tom dark theme — matches the app's design system.
+    static let majorTom = TerminalTheme(
+        id: "major-tom",
+        name: "Major Tom",
+        background: "#0d0d12",
+        foreground: "#e8e8e8",
+        cursor: "#f2a641",
+        cursorAccent: "#0d0d12",
+        selectionBackground: "#f2a64140",
+        black: "#1a1a24",
+        red: "#f24d4d",
+        green: "#4dd97a",
+        yellow: "#f2cc33",
+        blue: "#4d8af2",
+        magenta: "#b84df2",
+        cyan: "#4dd9d9",
+        white: "#e8e8e8",
+        brightBlack: "#666680",
+        brightRed: "#f27a7a",
+        brightGreen: "#7ae89e",
+        brightYellow: "#f2d966",
+        brightBlue: "#7ab3f2",
+        brightMagenta: "#cc7af2",
+        brightCyan: "#7ae8e8",
+        brightWhite: "#ffffff"
+    )
+
+    /// Dracula — popular dark theme with purple accents.
+    static let dracula = TerminalTheme(
+        id: "dracula",
+        name: "Dracula",
+        background: "#282a36",
+        foreground: "#f8f8f2",
+        cursor: "#f8f8f2",
+        cursorAccent: "#282a36",
+        selectionBackground: "#44475a80",
+        black: "#21222c",
+        red: "#ff5555",
+        green: "#50fa7b",
+        yellow: "#f1fa8c",
+        blue: "#bd93f9",
+        magenta: "#ff79c6",
+        cyan: "#8be9fd",
+        white: "#f8f8f2",
+        brightBlack: "#6272a4",
+        brightRed: "#ff6e6e",
+        brightGreen: "#69ff94",
+        brightYellow: "#ffffa5",
+        brightBlue: "#d6acff",
+        brightMagenta: "#ff92df",
+        brightCyan: "#a4ffff",
+        brightWhite: "#ffffff"
+    )
+
+    /// Solarized Dark — Ethan Schoonover's warm dark palette.
+    static let solarizedDark = TerminalTheme(
+        id: "solarized-dark",
+        name: "Solarized Dark",
+        background: "#002b36",
+        foreground: "#839496",
+        cursor: "#93a1a1",
+        cursorAccent: "#002b36",
+        selectionBackground: "#073642",
+        black: "#073642",
+        red: "#dc322f",
+        green: "#859900",
+        yellow: "#b58900",
+        blue: "#268bd2",
+        magenta: "#d33682",
+        cyan: "#2aa198",
+        white: "#eee8d5",
+        brightBlack: "#586e75",
+        brightRed: "#cb4b16",
+        brightGreen: "#586e75",
+        brightYellow: "#657b83",
+        brightBlue: "#839496",
+        brightMagenta: "#6c71c4",
+        brightCyan: "#93a1a1",
+        brightWhite: "#fdf6e3"
+    )
+
+    /// Solarized Light — the light variant of Solarized.
+    static let solarizedLight = TerminalTheme(
+        id: "solarized-light",
+        name: "Solarized Light",
+        background: "#fdf6e3",
+        foreground: "#657b83",
+        cursor: "#586e75",
+        cursorAccent: "#fdf6e3",
+        selectionBackground: "#eee8d5",
+        black: "#073642",
+        red: "#dc322f",
+        green: "#859900",
+        yellow: "#b58900",
+        blue: "#268bd2",
+        magenta: "#d33682",
+        cyan: "#2aa198",
+        white: "#eee8d5",
+        brightBlack: "#002b36",
+        brightRed: "#cb4b16",
+        brightGreen: "#586e75",
+        brightYellow: "#657b83",
+        brightBlue: "#839496",
+        brightMagenta: "#6c71c4",
+        brightCyan: "#93a1a1",
+        brightWhite: "#fdf6e3"
+    )
+
+    /// Monokai — the classic Sublime Text / TextMate theme.
+    static let monokai = TerminalTheme(
+        id: "monokai",
+        name: "Monokai",
+        background: "#272822",
+        foreground: "#f8f8f2",
+        cursor: "#f8f8f0",
+        cursorAccent: "#272822",
+        selectionBackground: "#49483e80",
+        black: "#272822",
+        red: "#f92672",
+        green: "#a6e22e",
+        yellow: "#f4bf75",
+        blue: "#66d9ef",
+        magenta: "#ae81ff",
+        cyan: "#a1efe4",
+        white: "#f8f8f2",
+        brightBlack: "#75715e",
+        brightRed: "#f92672",
+        brightGreen: "#a6e22e",
+        brightYellow: "#f4bf75",
+        brightBlue: "#66d9ef",
+        brightMagenta: "#ae81ff",
+        brightCyan: "#a1efe4",
+        brightWhite: "#f9f8f5"
+    )
+
+    /// Nord — Arctic, north-bluish clean and elegant palette.
+    static let nord = TerminalTheme(
+        id: "nord",
+        name: "Nord",
+        background: "#2e3440",
+        foreground: "#d8dee9",
+        cursor: "#d8dee9",
+        cursorAccent: "#2e3440",
+        selectionBackground: "#434c5e80",
+        black: "#3b4252",
+        red: "#bf616a",
+        green: "#a3be8c",
+        yellow: "#ebcb8b",
+        blue: "#81a1c1",
+        magenta: "#b48ead",
+        cyan: "#88c0d0",
+        white: "#e5e9f0",
+        brightBlack: "#4c566a",
+        brightRed: "#bf616a",
+        brightGreen: "#a3be8c",
+        brightYellow: "#ebcb8b",
+        brightBlue: "#81a1c1",
+        brightMagenta: "#b48ead",
+        brightCyan: "#8fbcbb",
+        brightWhite: "#eceff4"
+    )
+}

--- a/ios/MajorTom/Features/Terminal/Resources/terminal.html
+++ b/ios/MajorTom/Features/Terminal/Resources/terminal.html
@@ -101,9 +101,11 @@
   function initTerminal() {
     var theme = config.theme || {};
 
+    var initialFontSize = (config.fontSize && config.fontSize >= 8 && config.fontSize <= 32) ? config.fontSize : 14;
+
     term = new Terminal({
       fontFamily: 'SF Mono, ui-monospace, Menlo, monospace',
-      fontSize: 13,
+      fontSize: initialFontSize,
       cursorBlink: true,
       allowProposedApi: true,
       scrollback: 5000,
@@ -445,6 +447,19 @@
     setTheme: function(theme) {
       if (term) {
         term.options.theme = theme;
+      }
+    },
+
+    /**
+     * Update terminal font size and refit.
+     * @param {number} size - Font size in pixels (8-32)
+     */
+    setFontSize: function(size) {
+      if (term && size >= 8 && size <= 32) {
+        term.options.fontSize = size;
+        if (fitAddon) {
+          try { fitAddon.fit(); } catch (e) { /* ignore */ }
+        }
       }
     },
 

--- a/ios/MajorTom/Features/Terminal/ViewModels/KeybarViewModel.swift
+++ b/ios/MajorTom/Features/Terminal/ViewModels/KeybarViewModel.swift
@@ -1,0 +1,316 @@
+import Foundation
+
+/// Manages keybar layout customization, font size, and preference sync with the relay.
+///
+/// On init, loads from UserDefaults (device-local cache). Then async fetches
+/// from the relay's `/api/user/preferences` endpoint — server wins if it has
+/// a config. Local mutations save to UserDefaults immediately and debounce-sync
+/// to the relay (800ms). Network errors are silent; the UI never blocks on sync.
+///
+/// Mirrors the web PWA's `keybar.svelte.ts` + `shell.svelte.ts` sync patterns.
+@Observable
+@MainActor
+final class KeybarViewModel {
+
+    // MARK: - Published State
+
+    /// Active key IDs for the accessory row (above the iOS keyboard).
+    var accessoryIds: [String]
+
+    /// Active key IDs for the specialty grid.
+    var specialtyIds: [String]
+
+    /// Terminal font size in points (range 8-32).
+    var fontSize: Int
+
+    /// Selected terminal theme ID (persisted in UserDefaults).
+    var selectedThemeId: String
+
+    // MARK: - Computed
+
+    /// Resolved accessory row keys for the UI.
+    var accessoryKeys: [KeySpec] {
+        KeyLibrary.resolve(accessoryIds)
+    }
+
+    /// Resolved specialty grid keys for the UI.
+    var specialtyKeys: [KeySpec] {
+        KeyLibrary.resolve(specialtyIds)
+    }
+
+    /// The currently selected theme.
+    var selectedTheme: TerminalTheme {
+        TerminalTheme.all.first(where: { $0.id == selectedThemeId }) ?? .majorTom
+    }
+
+    // MARK: - Constants
+
+    private static let accessoryKey = "mt-keybar-accessory-v1"
+    private static let specialtyKey = "mt-keybar-specialty-v1"
+    private static let fontSizeKey = "mt-font-size"
+    private static let themeKey = "mt-terminal-theme"
+    private static let syncDebounceMs: UInt64 = 800
+
+    // MARK: - Private State
+
+    /// Reference to auth for building relay URLs.
+    private let auth: AuthService
+
+    /// Whether we've synced from the relay (prevents double-apply).
+    private var synced = false
+
+    /// Debounce task for relay sync.
+    private var syncTask: Task<Void, Never>?
+
+    // MARK: - Init
+
+    init(auth: AuthService) {
+        self.auth = auth
+
+        // Load from UserDefaults (device-local cache)
+        let defaults = UserDefaults.standard
+
+        if let savedAccessory = defaults.stringArray(forKey: Self.accessoryKey),
+           !savedAccessory.isEmpty {
+            self.accessoryIds = savedAccessory
+        } else {
+            self.accessoryIds = KeyLibrary.defaultBarIDs
+        }
+
+        if let savedSpecialty = defaults.stringArray(forKey: Self.specialtyKey),
+           !savedSpecialty.isEmpty {
+            self.specialtyIds = savedSpecialty
+        } else {
+            self.specialtyIds = KeyLibrary.defaultGridIDs
+        }
+
+        let savedFontSize = defaults.integer(forKey: Self.fontSizeKey)
+        if savedFontSize >= 8 && savedFontSize <= 32 {
+            self.fontSize = savedFontSize
+        } else {
+            self.fontSize = 14
+        }
+
+        self.selectedThemeId = defaults.string(forKey: Self.themeKey) ?? TerminalTheme.majorTom.id
+    }
+
+    // MARK: - Relay Sync
+
+    /// Pull preferences from the relay. Server wins if it has config.
+    /// Called once on app load after auth is established.
+    func syncFromRelay() async {
+        guard !synced else { return }
+
+        guard let url = buildPreferencesURL() else {
+            synced = true
+            return
+        }
+
+        do {
+            var request = URLRequest(url: url)
+            request.httpMethod = "GET"
+            applyAuth(to: &request)
+
+            let (data, response) = try await URLSession.shared.data(for: request)
+
+            guard let httpResponse = response as? HTTPURLResponse,
+                  httpResponse.statusCode == 200 else {
+                synced = true
+                return
+            }
+
+            guard let prefs = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+                synced = true
+                return
+            }
+
+            // Apply keybar config if server has one
+            if let keybarConfig = prefs["keybarConfig"] as? [String: Any],
+               let remoteAccessory = keybarConfig["accessory"] as? [String],
+               !remoteAccessory.isEmpty {
+                let sanitizedAccessory = sanitize(remoteAccessory)
+                let remoteSpecialty = keybarConfig["specialty"] as? [String] ?? []
+                let sanitizedSpecialty = sanitize(remoteSpecialty)
+
+                if !sanitizedAccessory.isEmpty {
+                    accessoryIds = sanitizedAccessory
+                    specialtyIds = sanitizedSpecialty.isEmpty ? KeyLibrary.defaultGridIDs : sanitizedSpecialty
+                    saveToDefaults()
+                }
+            } else if !isDefault() {
+                // Local is customized but server is empty -- push local up
+                pushToRelay()
+            }
+
+            // Apply font size if server has one
+            if let remoteFontSize = prefs["fontSize"] as? Int,
+               remoteFontSize >= 8 && remoteFontSize <= 32 {
+                fontSize = remoteFontSize
+                UserDefaults.standard.set(fontSize, forKey: Self.fontSizeKey)
+            }
+
+            synced = true
+        } catch {
+            // Network error -- stay with local config, allow retry
+            print("[KeybarViewModel] syncFromRelay failed: \(error.localizedDescription)")
+        }
+    }
+
+    // MARK: - Accessory Row Mutators
+
+    func addAccessoryKey(id: String) {
+        guard KeyLibrary.get(id) != nil else { return }
+        guard !accessoryIds.contains(id) else { return }
+        accessoryIds.append(id)
+        persist()
+    }
+
+    func removeAccessoryKey(id: String) {
+        guard accessoryIds.contains(id) else { return }
+        accessoryIds.removeAll { $0 == id }
+        persist()
+    }
+
+    func moveAccessoryKey(from source: IndexSet, to destination: Int) {
+        accessoryIds.move(fromOffsets: source, toOffset: destination)
+        persist()
+    }
+
+    // MARK: - Specialty Grid Mutators
+
+    func addSpecialtyKey(id: String) {
+        guard KeyLibrary.get(id) != nil else { return }
+        guard !specialtyIds.contains(id) else { return }
+        specialtyIds.append(id)
+        persist()
+    }
+
+    func removeSpecialtyKey(id: String) {
+        guard specialtyIds.contains(id) else { return }
+        specialtyIds.removeAll { $0 == id }
+        persist()
+    }
+
+    func moveSpecialtyKey(from source: IndexSet, to destination: Int) {
+        specialtyIds.move(fromOffsets: source, toOffset: destination)
+        persist()
+    }
+
+    // MARK: - Font Size
+
+    func setFontSize(_ size: Int) {
+        let clamped = max(8, min(32, size))
+        guard clamped != fontSize else { return }
+        fontSize = clamped
+        UserDefaults.standard.set(fontSize, forKey: Self.fontSizeKey)
+        scheduleSyncToRelay()
+    }
+
+    // MARK: - Theme
+
+    func setTheme(_ theme: TerminalTheme) {
+        guard theme.id != selectedThemeId else { return }
+        selectedThemeId = theme.id
+        UserDefaults.standard.set(selectedThemeId, forKey: Self.themeKey)
+    }
+
+    // MARK: - Reset
+
+    func resetToDefaults() {
+        accessoryIds = KeyLibrary.defaultBarIDs
+        specialtyIds = KeyLibrary.defaultGridIDs
+        fontSize = 14
+        selectedThemeId = TerminalTheme.majorTom.id
+        UserDefaults.standard.set(fontSize, forKey: Self.fontSizeKey)
+        UserDefaults.standard.set(selectedThemeId, forKey: Self.themeKey)
+        persist()
+    }
+
+    // MARK: - Private Helpers
+
+    private func isDefault() -> Bool {
+        accessoryIds == KeyLibrary.defaultBarIDs &&
+        specialtyIds == KeyLibrary.defaultGridIDs
+    }
+
+    /// Sanitize key IDs -- filter out unrecognized IDs and duplicates.
+    private func sanitize(_ ids: [String]) -> [String] {
+        var seen = Set<String>()
+        var result: [String] = []
+        for id in ids {
+            guard !seen.contains(id) else { continue }
+            guard KeyLibrary.get(id) != nil else { continue }
+            seen.insert(id)
+            result.append(id)
+        }
+        return result
+    }
+
+    private func saveToDefaults() {
+        let defaults = UserDefaults.standard
+        defaults.set(accessoryIds, forKey: Self.accessoryKey)
+        defaults.set(specialtyIds, forKey: Self.specialtyKey)
+    }
+
+    private func persist() {
+        saveToDefaults()
+        scheduleSyncToRelay()
+    }
+
+    private func scheduleSyncToRelay() {
+        syncTask?.cancel()
+        syncTask = Task { [weak self] in
+            try? await Task.sleep(nanoseconds: Self.syncDebounceMs * 1_000_000)
+            guard !Task.isCancelled else { return }
+            self?.pushToRelay()
+        }
+    }
+
+    /// Push current config to relay (fire-and-forget).
+    private func pushToRelay() {
+        guard let url = buildPreferencesURL() else { return }
+
+        let payload: [String: Any] = [
+            "keybarConfig": [
+                "version": 1,
+                "accessory": accessoryIds,
+                "specialty": specialtyIds,
+            ],
+            "fontSize": fontSize,
+        ]
+
+        guard let body = try? JSONSerialization.data(withJSONObject: payload) else { return }
+
+        Task {
+            do {
+                var request = URLRequest(url: url)
+                request.httpMethod = "PUT"
+                request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+                applyAuth(to: &request)
+                request.httpBody = body
+
+                let (_, response) = try await URLSession.shared.data(for: request)
+                if let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode != 200 {
+                    print("[KeybarViewModel] pushToRelay got \(httpResponse.statusCode)")
+                }
+            } catch {
+                // Network error -- local state is saved, will sync next time
+                print("[KeybarViewModel] pushToRelay failed: \(error.localizedDescription)")
+            }
+        }
+    }
+
+    private func buildPreferencesURL() -> URL? {
+        let base = auth.serverURL
+        let scheme = base.contains("://") ? "" : "http://"
+        let fullBase = "\(scheme)\(base)"
+        return URL(string: "\(fullBase)/api/user/preferences")
+    }
+
+    /// Apply auth cookie/token to the request.
+    private func applyAuth(to request: inout URLRequest) {
+        if let token = auth.sessionCookie {
+            request.setValue("mt-session=\(token)", forHTTPHeaderField: "Cookie")
+        }
+    }
+}

--- a/ios/MajorTom/Features/Terminal/ViewModels/TerminalViewModel.swift
+++ b/ios/MajorTom/Features/Terminal/ViewModels/TerminalViewModel.swift
@@ -113,11 +113,20 @@ final class TerminalViewModel {
         tabs.first(where: { $0.isActive })
     }
 
+    /// Keybar customization and preference sync.
+    var keybarViewModel: KeybarViewModel
+
+    /// The currently selected terminal theme.
+    var selectedTheme: TerminalTheme {
+        keybarViewModel.selectedTheme
+    }
+
     /// Reference to the auth service for relay URL and token.
     private let auth: AuthService
 
     init(auth: AuthService) {
         self.auth = auth
+        self.keybarViewModel = KeybarViewModel(auth: auth)
         // Create the initial default tab.
         let initialTab = TerminalTab(title: "Terminal", isActive: true)
         self.tabs = [initialTab]
@@ -244,6 +253,7 @@ final class TerminalViewModel {
             "relayURL": relayURL,
             "tabId": tabId,
             "theme": themeConfig,
+            "fontSize": keybarViewModel.fontSize,
         ]
         if let token = authToken {
             config["token"] = token
@@ -254,31 +264,9 @@ final class TerminalViewModel {
         return config
     }
 
-    /// Terminal theme matching MajorTom dark theme.
+    /// Terminal theme — driven by KeybarViewModel's selected theme.
     var themeConfig: [String: String] {
-        [
-            "background": "#0d0d12",
-            "foreground": "#e8e8e8",
-            "cursor": "#f2a641",
-            "cursorAccent": "#0d0d12",
-            "selectionBackground": "#f2a64140",
-            "black": "#1a1a24",
-            "red": "#f24d4d",
-            "green": "#4dd97a",
-            "yellow": "#f2cc33",
-            "blue": "#4d8af2",
-            "magenta": "#b84df2",
-            "cyan": "#4dd9d9",
-            "white": "#e8e8e8",
-            "brightBlack": "#666680",
-            "brightRed": "#f27a7a",
-            "brightGreen": "#7ae89e",
-            "brightYellow": "#f2d966",
-            "brightBlue": "#7ab3f2",
-            "brightMagenta": "#cc7af2",
-            "brightCyan": "#7ae8e8",
-            "brightWhite": "#ffffff",
-        ]
+        selectedTheme.asDictionary
     }
 
     // MARK: - Bridge Message Handling
@@ -323,6 +311,24 @@ final class TerminalViewModel {
             self.cols = cols
             self.rows = rows
         }
+    }
+
+    // MARK: - Theme & Font
+
+    /// Apply a theme to the live terminal by calling the JS bridge.
+    func applyTheme(_ theme: TerminalTheme) {
+        guard let webView else { return }
+        guard let data = try? JSONSerialization.data(withJSONObject: theme.asDictionary),
+              let json = String(data: data, encoding: .utf8) else { return }
+        let js = "if(window.MajorTom && window.MajorTom.setTheme){window.MajorTom.setTheme(\(json))}"
+        webView.evaluateJavaScript(js) { _, _ in }
+    }
+
+    /// Apply a font size to the live terminal by calling the JS bridge.
+    func applyFontSize(_ size: Int) {
+        guard let webView else { return }
+        let js = "if(window.MajorTom && window.MajorTom.setFontSize){window.MajorTom.setFontSize(\(size))}"
+        webView.evaluateJavaScript(js) { _, _ in }
     }
 
     // MARK: - Key Input

--- a/ios/MajorTom/Features/Terminal/Views/KeybarCustomizer.swift
+++ b/ios/MajorTom/Features/Terminal/Views/KeybarCustomizer.swift
@@ -1,0 +1,277 @@
+import SwiftUI
+
+/// Full-screen sheet for drag-to-reorder keybar customization.
+///
+/// Two segments: "Accessory Row" (above keyboard) and "Specialty Grid" (keyboard replacement).
+/// Active keys can be reordered via native drag, removed with the minus button.
+/// New keys can be added from the full library, filtered by search text.
+/// Mirrors the web PWA's `KeybarCustomizeSheet.svelte` with native SwiftUI controls.
+struct KeybarCustomizer: View {
+    let keybarViewModel: KeybarViewModel
+
+    @State private var activeTab: KeybarTab = .accessory
+    @State private var searchText = ""
+    @State private var showAddKeys = false
+    @State private var showResetAlert = false
+    @Environment(\.dismiss) private var dismiss
+
+    private enum KeybarTab: String, CaseIterable {
+        case accessory = "Accessory Row"
+        case specialty = "Specialty Grid"
+    }
+
+    /// Current active key IDs for the selected tab.
+    private var currentIds: [String] {
+        activeTab == .accessory ? keybarViewModel.accessoryIds : keybarViewModel.specialtyIds
+    }
+
+    /// Current active keys resolved for the selected tab.
+    private var currentKeys: [KeySpec] {
+        activeTab == .accessory ? keybarViewModel.accessoryKeys : keybarViewModel.specialtyKeys
+    }
+
+    /// Available keys not already in the active layout, filtered by search.
+    private var availableKeys: [KeySpec] {
+        let activeSet = Set(currentIds)
+        let query = searchText.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+
+        return KeyLibrary.all.filter { key in
+            guard !activeSet.contains(key.id) else { return false }
+            guard !query.isEmpty else { return true }
+            return key.id.lowercased().contains(query) ||
+                   key.label.lowercased().contains(query) ||
+                   (key.description ?? "").lowercased().contains(query)
+        }
+    }
+
+    /// Available keys grouped by KeyGroup for organized display.
+    private var groupedAvailableKeys: [(KeyGroup, [KeySpec])] {
+        let grouped = Dictionary(grouping: availableKeys) { $0.group }
+        return KeyGroup.allCases.compactMap { group in
+            guard let keys = grouped[group], !keys.isEmpty else { return nil }
+            return (group, keys)
+        }
+    }
+
+    var body: some View {
+        NavigationStack {
+            VStack(spacing: 0) {
+                // Segment picker
+                Picker("Layout", selection: $activeTab) {
+                    ForEach(KeybarTab.allCases, id: \.self) { tab in
+                        Text(tab.rawValue).tag(tab)
+                    }
+                }
+                .pickerStyle(.segmented)
+                .padding(.horizontal, MajorTomTheme.Spacing.md)
+                .padding(.vertical, MajorTomTheme.Spacing.sm)
+
+                // Active keys list
+                List {
+                    activeKeysSection
+                    addKeysSection
+                }
+                .listStyle(.insetGrouped)
+                .scrollContentBackground(.hidden)
+            }
+            .background(MajorTomTheme.Colors.background)
+            .navigationTitle("Customize Keys")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarLeading) {
+                    Button("Reset") {
+                        showResetAlert = true
+                    }
+                    .foregroundStyle(MajorTomTheme.Colors.deny)
+                }
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button("Done") {
+                        dismiss()
+                    }
+                    .foregroundStyle(MajorTomTheme.Colors.accent)
+                }
+            }
+            .alert("Reset to Defaults", isPresented: $showResetAlert) {
+                Button("Cancel", role: .cancel) { }
+                Button("Reset", role: .destructive) {
+                    HapticService.buttonTap()
+                    keybarViewModel.resetToDefaults()
+                }
+            } message: {
+                Text("This will reset both the accessory row and specialty grid to their default layouts.")
+            }
+        }
+    }
+
+    // MARK: - Active Keys Section
+
+    private var activeKeysSection: some View {
+        Section {
+            if currentKeys.isEmpty {
+                Text("No keys configured. Add some below.")
+                    .font(MajorTomTheme.Typography.caption)
+                    .foregroundStyle(MajorTomTheme.Colors.textTertiary)
+                    .frame(maxWidth: .infinity, alignment: .center)
+                    .padding(.vertical, MajorTomTheme.Spacing.md)
+            } else {
+                ForEach(currentKeys) { key in
+                    HStack(spacing: MajorTomTheme.Spacing.md) {
+                        // Key label
+                        Text(key.label)
+                            .font(.system(size: 14, weight: .bold, design: .monospaced))
+                            .foregroundStyle(MajorTomTheme.Colors.textPrimary)
+                            .frame(minWidth: 36, alignment: .center)
+
+                        // Description
+                        Text(key.description ?? key.id)
+                            .font(MajorTomTheme.Typography.caption)
+                            .foregroundStyle(MajorTomTheme.Colors.textSecondary)
+                            .lineLimit(1)
+
+                        Spacer()
+
+                        // Remove button
+                        Button {
+                            HapticService.buttonTap()
+                            removeKey(key.id)
+                        } label: {
+                            Image(systemName: "minus.circle.fill")
+                                .font(.system(size: 20))
+                                .foregroundStyle(MajorTomTheme.Colors.deny)
+                        }
+                        .buttonStyle(.plain)
+                    }
+                    .listRowBackground(MajorTomTheme.Colors.surface)
+                }
+                .onMove(perform: moveKeys)
+            }
+        } header: {
+            HStack {
+                Text("Active (\(currentKeys.count))")
+                Spacer()
+                Image(systemName: "line.3.horizontal")
+                    .font(.system(size: 10))
+                    .foregroundStyle(MajorTomTheme.Colors.textTertiary)
+                Text("Drag to reorder")
+                    .font(.system(size: 10))
+                    .foregroundStyle(MajorTomTheme.Colors.textTertiary)
+            }
+        }
+        .listRowBackground(MajorTomTheme.Colors.surface)
+    }
+
+    // MARK: - Add Keys Section
+
+    private var addKeysSection: some View {
+        Section {
+            DisclosureGroup(
+                isExpanded: $showAddKeys,
+                content: {
+                    // Search field
+                    TextField("Filter keys...", text: $searchText)
+                        .font(MajorTomTheme.Typography.caption)
+                        .textFieldStyle(.roundedBorder)
+                        .listRowBackground(MajorTomTheme.Colors.surface)
+
+                    if groupedAvailableKeys.isEmpty {
+                        Text("All library keys are already active.")
+                            .font(MajorTomTheme.Typography.caption)
+                            .foregroundStyle(MajorTomTheme.Colors.textTertiary)
+                            .frame(maxWidth: .infinity, alignment: .center)
+                            .padding(.vertical, MajorTomTheme.Spacing.sm)
+                    } else {
+                        ForEach(groupedAvailableKeys, id: \.0) { group, keys in
+                            GroupHeader(group: group)
+                                .listRowBackground(MajorTomTheme.Colors.surface)
+
+                            ForEach(keys) { key in
+                                HStack(spacing: MajorTomTheme.Spacing.md) {
+                                    Text(key.label)
+                                        .font(.system(size: 14, weight: .bold, design: .monospaced))
+                                        .foregroundStyle(MajorTomTheme.Colors.textPrimary)
+                                        .frame(minWidth: 36, alignment: .center)
+
+                                    Text(key.description ?? key.id)
+                                        .font(MajorTomTheme.Typography.caption)
+                                        .foregroundStyle(MajorTomTheme.Colors.textSecondary)
+                                        .lineLimit(1)
+
+                                    Spacer()
+
+                                    Button {
+                                        HapticService.buttonTap()
+                                        addKey(key.id)
+                                    } label: {
+                                        Image(systemName: "plus.circle.fill")
+                                            .font(.system(size: 20))
+                                            .foregroundStyle(MajorTomTheme.Colors.accent)
+                                    }
+                                    .buttonStyle(.plain)
+                                }
+                                .listRowBackground(MajorTomTheme.Colors.surface)
+                            }
+                        }
+                    }
+                },
+                label: {
+                    Label("Add a key", systemImage: "plus.square")
+                        .foregroundStyle(MajorTomTheme.Colors.accent)
+                }
+            )
+        }
+        .listRowBackground(MajorTomTheme.Colors.surface)
+    }
+
+    // MARK: - Actions
+
+    private func addKey(_ id: String) {
+        if activeTab == .accessory {
+            keybarViewModel.addAccessoryKey(id: id)
+        } else {
+            keybarViewModel.addSpecialtyKey(id: id)
+        }
+    }
+
+    private func removeKey(_ id: String) {
+        if activeTab == .accessory {
+            keybarViewModel.removeAccessoryKey(id: id)
+        } else {
+            keybarViewModel.removeSpecialtyKey(id: id)
+        }
+    }
+
+    private func moveKeys(from source: IndexSet, to destination: Int) {
+        HapticService.buttonTap()
+        if activeTab == .accessory {
+            keybarViewModel.moveAccessoryKey(from: source, to: destination)
+        } else {
+            keybarViewModel.moveSpecialtyKey(from: source, to: destination)
+        }
+    }
+}
+
+// MARK: - Group Header
+
+/// Display name for a KeyGroup in the "Add Key" picker.
+private struct GroupHeader: View {
+    let group: KeyGroup
+
+    var body: some View {
+        Text(groupName)
+            .font(.system(size: 10, weight: .semibold))
+            .foregroundStyle(MajorTomTheme.Colors.textTertiary)
+            .textCase(.uppercase)
+    }
+
+    private var groupName: String {
+        switch group {
+        case .modifier: "Modifiers"
+        case .edit: "Edit"
+        case .nav: "Navigation"
+        case .symbol: "Symbols"
+        case .ctrl: "Ctrl Combos"
+        case .tmux: "Tmux"
+        case .function: "Function Keys"
+        }
+    }
+}

--- a/ios/MajorTom/Features/Terminal/Views/TerminalSettingsView.swift
+++ b/ios/MajorTom/Features/Terminal/Views/TerminalSettingsView.swift
@@ -1,0 +1,258 @@
+import SwiftUI
+
+/// Terminal settings sheet — font size, theme picker, and keybar customization entry point.
+///
+/// Presented as a sheet from TerminalView (gear icon). Changes apply immediately
+/// so the user gets live preview in the terminal behind the sheet.
+struct TerminalSettingsView: View {
+    let keybarViewModel: KeybarViewModel
+    let onFontSizeChange: (Int) -> Void
+    let onThemeChange: (TerminalTheme) -> Void
+
+    @State private var showKeybarCustomizer = false
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        NavigationStack {
+            List {
+                fontSizeSection
+                themeSection
+                keybarSection
+            }
+            .listStyle(.insetGrouped)
+            .navigationTitle("Terminal Settings")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button("Done") {
+                        dismiss()
+                    }
+                    .foregroundStyle(MajorTomTheme.Colors.accent)
+                }
+            }
+            .scrollContentBackground(.hidden)
+            .background(MajorTomTheme.Colors.background)
+        }
+        .sheet(isPresented: $showKeybarCustomizer) {
+            KeybarCustomizer(keybarViewModel: keybarViewModel)
+        }
+    }
+
+    // MARK: - Font Size Section
+
+    private var fontSizeSection: some View {
+        Section {
+            VStack(spacing: MajorTomTheme.Spacing.md) {
+                HStack {
+                    Text("Font Size")
+                        .font(MajorTomTheme.Typography.body)
+                        .foregroundStyle(MajorTomTheme.Colors.textPrimary)
+
+                    Spacer()
+
+                    Text("\(keybarViewModel.fontSize)pt")
+                        .font(MajorTomTheme.Typography.codeFontSmall)
+                        .foregroundStyle(MajorTomTheme.Colors.accent)
+                        .padding(.horizontal, MajorTomTheme.Spacing.sm)
+                        .padding(.vertical, MajorTomTheme.Spacing.xs)
+                        .background(MajorTomTheme.Colors.surfaceElevated)
+                        .clipShape(RoundedRectangle(cornerRadius: MajorTomTheme.Radius.small))
+                }
+
+                HStack(spacing: MajorTomTheme.Spacing.md) {
+                    // Decrease button
+                    Button {
+                        HapticService.buttonTap()
+                        let newSize = keybarViewModel.fontSize - 1
+                        keybarViewModel.setFontSize(newSize)
+                        onFontSizeChange(keybarViewModel.fontSize)
+                    } label: {
+                        Image(systemName: "minus.circle.fill")
+                            .font(.system(size: 24))
+                            .foregroundStyle(keybarViewModel.fontSize <= 8 ? MajorTomTheme.Colors.textTertiary : MajorTomTheme.Colors.accent)
+                    }
+                    .disabled(keybarViewModel.fontSize <= 8)
+
+                    // Slider
+                    Slider(
+                        value: Binding(
+                            get: { Double(keybarViewModel.fontSize) },
+                            set: { newValue in
+                                let intValue = Int(newValue.rounded())
+                                keybarViewModel.setFontSize(intValue)
+                                onFontSizeChange(keybarViewModel.fontSize)
+                            }
+                        ),
+                        in: 8...32,
+                        step: 1
+                    )
+                    .tint(MajorTomTheme.Colors.accent)
+
+                    // Increase button
+                    Button {
+                        HapticService.buttonTap()
+                        let newSize = keybarViewModel.fontSize + 1
+                        keybarViewModel.setFontSize(newSize)
+                        onFontSizeChange(keybarViewModel.fontSize)
+                    } label: {
+                        Image(systemName: "plus.circle.fill")
+                            .font(.system(size: 24))
+                            .foregroundStyle(keybarViewModel.fontSize >= 32 ? MajorTomTheme.Colors.textTertiary : MajorTomTheme.Colors.accent)
+                    }
+                    .disabled(keybarViewModel.fontSize >= 32)
+                }
+
+                // Preview text
+                Text("AaBbCc 0123 ~/code $")
+                    .font(.system(size: CGFloat(keybarViewModel.fontSize), design: .monospaced))
+                    .foregroundStyle(MajorTomTheme.Colors.textPrimary)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(MajorTomTheme.Spacing.sm)
+                    .background(Color(hex: keybarViewModel.selectedTheme.background) ?? MajorTomTheme.Colors.background)
+                    .clipShape(RoundedRectangle(cornerRadius: MajorTomTheme.Radius.small))
+            }
+        } header: {
+            Text("Font")
+        }
+        .listRowBackground(MajorTomTheme.Colors.surface)
+    }
+
+    // MARK: - Theme Section
+
+    private var themeSection: some View {
+        Section {
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: MajorTomTheme.Spacing.md) {
+                    ForEach(TerminalTheme.all) { theme in
+                        ThemeCard(
+                            theme: theme,
+                            isSelected: theme.id == keybarViewModel.selectedThemeId,
+                            onSelect: {
+                                HapticService.buttonTap()
+                                keybarViewModel.setTheme(theme)
+                                onThemeChange(theme)
+                            }
+                        )
+                    }
+                }
+                .padding(.vertical, MajorTomTheme.Spacing.xs)
+            }
+        } header: {
+            Text("Theme")
+        }
+        .listRowBackground(MajorTomTheme.Colors.surface)
+    }
+
+    // MARK: - Keybar Section
+
+    private var keybarSection: some View {
+        Section {
+            Button {
+                HapticService.buttonTap()
+                showKeybarCustomizer = true
+            } label: {
+                HStack {
+                    Label("Customize Keybar", systemImage: "keyboard.badge.ellipsis")
+                        .foregroundStyle(MajorTomTheme.Colors.textPrimary)
+
+                    Spacer()
+
+                    Image(systemName: "chevron.right")
+                        .font(.system(size: 12, weight: .semibold))
+                        .foregroundStyle(MajorTomTheme.Colors.textTertiary)
+                }
+            }
+        } header: {
+            Text("Keybar")
+        } footer: {
+            Text("Reorder, add, or remove keys from the accessory row and specialty grid.")
+                .foregroundStyle(MajorTomTheme.Colors.textTertiary)
+        }
+        .listRowBackground(MajorTomTheme.Colors.surface)
+    }
+}
+
+// MARK: - Theme Card
+
+/// A small preview card showing a terminal theme's colors.
+private struct ThemeCard: View {
+    let theme: TerminalTheme
+    let isSelected: Bool
+    let onSelect: () -> Void
+
+    var body: some View {
+        Button(action: onSelect) {
+            VStack(spacing: MajorTomTheme.Spacing.xs) {
+                // Color preview swatch
+                VStack(spacing: 2) {
+                    // Background + foreground preview
+                    HStack(spacing: 2) {
+                        colorDot(theme.red)
+                        colorDot(theme.green)
+                        colorDot(theme.yellow)
+                        colorDot(theme.blue)
+                    }
+                    HStack(spacing: 2) {
+                        colorDot(theme.magenta)
+                        colorDot(theme.cyan)
+                        colorDot(theme.brightRed)
+                        colorDot(theme.brightGreen)
+                    }
+                }
+                .padding(MajorTomTheme.Spacing.sm)
+                .frame(width: 80, height: 50)
+                .background(Color(hex: theme.background) ?? Color.black)
+                .clipShape(RoundedRectangle(cornerRadius: MajorTomTheme.Radius.small))
+                .overlay(
+                    RoundedRectangle(cornerRadius: MajorTomTheme.Radius.small)
+                        .stroke(isSelected ? MajorTomTheme.Colors.accent : Color.clear, lineWidth: 2)
+                )
+
+                // Theme name
+                Text(theme.name)
+                    .font(.system(size: 10, weight: .medium))
+                    .foregroundStyle(isSelected ? MajorTomTheme.Colors.accent : MajorTomTheme.Colors.textSecondary)
+                    .lineLimit(1)
+            }
+        }
+        .buttonStyle(.plain)
+    }
+
+    private func colorDot(_ hex: String) -> some View {
+        Circle()
+            .fill(Color(hex: hex) ?? Color.gray)
+            .frame(width: 8, height: 8)
+    }
+}
+
+// MARK: - Color Hex Extension
+
+extension Color {
+    /// Create a Color from a hex string (e.g., "#ff5555" or "#ff555580").
+    init?(hex: String) {
+        var hexString = hex.trimmingCharacters(in: .whitespacesAndNewlines)
+        if hexString.hasPrefix("#") {
+            hexString = String(hexString.dropFirst())
+        }
+
+        // Handle 6-char (RGB) and 8-char (RGBA) hex strings
+        var rgbValue: UInt64 = 0
+        guard Scanner(string: hexString).scanHexInt64(&rgbValue) else { return nil }
+
+        switch hexString.count {
+        case 6:
+            let r = Double((rgbValue & 0xFF0000) >> 16) / 255.0
+            let g = Double((rgbValue & 0x00FF00) >> 8) / 255.0
+            let b = Double(rgbValue & 0x0000FF) / 255.0
+            self.init(red: r, green: g, blue: b)
+        case 8:
+            let r = Double((rgbValue & 0xFF000000) >> 24) / 255.0
+            let g = Double((rgbValue & 0x00FF0000) >> 16) / 255.0
+            let b = Double((rgbValue & 0x0000FF00) >> 8) / 255.0
+            let a = Double(rgbValue & 0x000000FF) / 255.0
+            self.init(red: r, green: g, blue: b, opacity: a)
+        default:
+            return nil
+        }
+    }
+}

--- a/ios/MajorTom/Features/Terminal/Views/TerminalView.swift
+++ b/ios/MajorTom/Features/Terminal/Views/TerminalView.swift
@@ -9,6 +9,9 @@ import SwiftUI
 ///
 /// Wave 3: Multi-tab support. The TerminalTabBar sits above the terminal area
 /// and lets users create, switch, and close tmux windows (tabs).
+///
+/// Wave 4: Settings sheet with theme picker, font size slider, and keybar
+/// customization. Gear icon in the status bar presents TerminalSettingsView.
 struct TerminalView: View {
     let auth: AuthService
 
@@ -16,6 +19,9 @@ struct TerminalView: View {
 
     /// Whether the specialty key grid is visible.
     @State private var showSpecialtyGrid = false
+
+    /// Whether the terminal settings sheet is presented.
+    @State private var showSettings = false
 
     init(auth: AuthService) {
         self.auth = auth
@@ -59,7 +65,8 @@ struct TerminalView: View {
                             withAnimation(.easeInOut(duration: 0.2)) {
                                 showSpecialtyGrid = false
                             }
-                        }
+                        },
+                        keys: viewModel.keybarViewModel.specialtyKeys
                     )
                 }
 
@@ -80,7 +87,8 @@ struct TerminalView: View {
                                 showSpecialtyGrid.toggle()
                             }
                         },
-                        specialtyGridVisible: showSpecialtyGrid
+                        specialtyGridVisible: showSpecialtyGrid,
+                        keys: viewModel.keybarViewModel.accessoryKeys
                     )
                 }
             }
@@ -92,6 +100,21 @@ struct TerminalView: View {
                 viewModel.confirmCloseTab()
             }
         )
+        .sheet(isPresented: $showSettings) {
+            TerminalSettingsView(
+                keybarViewModel: viewModel.keybarViewModel,
+                onFontSizeChange: { size in
+                    viewModel.applyFontSize(size)
+                },
+                onThemeChange: { theme in
+                    viewModel.applyTheme(theme)
+                }
+            )
+            .presentationDetents([.medium, .large])
+        }
+        .task {
+            await viewModel.keybarViewModel.syncFromRelay()
+        }
     }
 
     // MARK: - Status Bar
@@ -114,6 +137,18 @@ struct TerminalView: View {
                 Text("\(viewModel.cols)x\(viewModel.rows)")
                     .font(MajorTomTheme.Typography.codeFontSmall)
                     .foregroundStyle(MajorTomTheme.Colors.textTertiary)
+            }
+
+            // Settings gear
+            Button {
+                HapticService.buttonTap()
+                showSettings = true
+            } label: {
+                Image(systemName: "gearshape")
+                    .font(.system(size: 14, weight: .medium))
+                    .foregroundStyle(MajorTomTheme.Colors.textSecondary)
+                    .frame(width: 28, height: 28)
+                    .contentShape(Rectangle())
             }
         }
         .padding(.horizontal, MajorTomTheme.Spacing.md)


### PR DESCRIPTION
## Summary

- **Terminal themes**: 6 preset color schemes (Major Tom, Dracula, Solarized Dark/Light, Monokai, Nord) with live preview cards and instant application via the `MajorTom.setTheme()` JS bridge
- **Font size control**: slider 8-32pt with +/- stepper buttons, live preview label, and instant terminal update via new `MajorTom.setFontSize()` bridge function
- **Keybar customization**: full drag-to-reorder customizer for both accessory row and specialty grid, with add/remove from the 68-key library, search/filter, and reset to defaults
- **Cross-device preference sync**: KeybarViewModel mirrors the web PWA's sync pattern -- loads from UserDefaults on init, async fetches from relay `/api/user/preferences` (server wins), debounced PUT on local mutations (800ms)
- **Settings sheet**: gear icon in the terminal status bar presents TerminalSettingsView with font, theme, and keybar sections

### New files (4)
| File | Purpose |
|------|---------|
| `TerminalTheme.swift` | Codable theme model with 6 presets and `asDictionary` for JS bridge |
| `KeybarViewModel.swift` | `@Observable` keybar layout state, UserDefaults persistence, relay sync |
| `TerminalSettingsView.swift` | Settings sheet (font slider, theme picker, keybar entry) |
| `KeybarCustomizer.swift` | Drag-to-reorder key editor with add/remove and reset |

### Modified files (4)
| File | Change |
|------|--------|
| `TerminalViewModel.swift` | Replace hardcoded theme with `selectedTheme`, add `keybarViewModel`, `applyTheme`/`applyFontSize` methods, wire `fontSize` into `bridgeConfig` |
| `TerminalView.swift` | Add gear icon, settings sheet, pass custom keys to NativeKeybar/SpecialtyKeyGrid, sync prefs on load |
| `terminal.html` | Add `MajorTom.setFontSize()` bridge function, configurable initial fontSize |
| `project.pbxproj` | xcodegen regenerated to include new files |

## Test plan

- [ ] Open terminal, tap gear icon -- settings sheet appears
- [ ] Drag font size slider -- terminal font updates live behind the sheet
- [ ] Tap a theme card -- terminal colors change immediately
- [ ] Tap "Customize Keybar..." -- drag-to-reorder sheet opens
- [ ] Drag keys to reorder, verify new order persists on app relaunch
- [ ] Remove a key via minus button, verify it disappears from keybar
- [ ] Add a key from the library, verify it appears in the keybar
- [ ] Reset to defaults, verify both accessory and specialty layouts reset
- [ ] Kill and relaunch app -- keybar layout and font size persist (UserDefaults)
- [ ] With relay running, verify preferences sync (check relay's preferences.json
- [ ] Build succeeds with zero new errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)
EOF
)