### PR TITLE
fix(macos): address Wave 4 config review comments

### DIFF
--- a/macos/GroundControl/App/GroundControlApp.swift
+++ b/macos/GroundControl/App/GroundControlApp.swift
@@ -6,7 +6,7 @@ import SwiftUI
 /// quick links to the PWA, and a management window with live log viewer.
 @main
 struct GroundControlApp: App {
-    @State private var configManager = ConfigManager()
+    @State private var configManager: ConfigManager
     @State private var relay: RelayProcess
 
     init() {

--- a/macos/GroundControl/Services/ConfigManager.swift
+++ b/macos/GroundControl/Services/ConfigManager.swift
@@ -33,9 +33,15 @@ final class ConfigManager {
     // MARK: - Init
 
     init() {
+        let fileExisted = FileManager.default.fileExists(atPath: ConfigManager.configFileURL.path)
         let loaded = ConfigManager.loadFromDisk()
         self.config = loaded
         self.lastSavedConfig = loaded
+
+        // Write defaults on first launch so config.json exists on disk
+        if !fileExisted {
+            try? save()
+        }
     }
 
     // MARK: - Config File I/O

--- a/macos/GroundControl/Services/RelayProcess.swift
+++ b/macos/GroundControl/Services/RelayProcess.swift
@@ -117,6 +117,7 @@ final class RelayProcess {
         env["LOG_LEVEL"] = config.logLevel.rawValue
         env["CLAUDE_WORK_DIR"] = config.expandedClaudeWorkDir
         env["MULTI_USER_ENABLED"] = config.multiUserEnabled ? "true" : "false"
+        env["CLOUDFLARE_TUNNEL"] = config.cloudflareEnabled ? "true" : "false"
 
         // Auth mode → relay env vars
         switch config.authMode {
@@ -128,12 +129,16 @@ final class RelayProcess {
             env["AUTH_GOOGLE_ENABLED"] = "false"
         case .google:
             env["AUTH_PIN_ENABLED"] = "false"
-            env["AUTH_GOOGLE_ENABLED"] = "true"
-            if let clientId = configManager.getSecret(ConfigManager.SecretKey.googleClientId) {
-                env["GOOGLE_CLIENT_ID"] = clientId
-            }
-            if let clientSecret = configManager.getSecret(ConfigManager.SecretKey.googleClientSecret) {
-                env["GOOGLE_CLIENT_SECRET"] = clientSecret
+            let clientId = configManager.getSecret(ConfigManager.SecretKey.googleClientId)
+            let clientSecret = configManager.getSecret(ConfigManager.SecretKey.googleClientSecret)
+            let hasCredentials = !(clientId ?? "").isEmpty && !(clientSecret ?? "").isEmpty
+            if hasCredentials {
+                env["AUTH_GOOGLE_ENABLED"] = "true"
+                env["GOOGLE_CLIENT_ID"] = clientId!
+                env["GOOGLE_CLIENT_SECRET"] = clientSecret!
+            } else {
+                env["AUTH_GOOGLE_ENABLED"] = "false"
+                print("[GroundControl] WARNING: Google auth mode selected but client ID or secret is missing — disabling Google auth")
             }
         }
 

--- a/macos/GroundControl/Views/CloudflareTunnelView.swift
+++ b/macos/GroundControl/Views/CloudflareTunnelView.swift
@@ -9,22 +9,19 @@ struct CloudflareTunnelView: View {
 
     @State private var tunnelToken = ""
     @State private var showToken = false
+    @State private var tokenSaveTask: Task<Void, Never>?
 
-    /// Derived status label for the tunnel.
+    /// Derived status label for the tunnel (uses @State to avoid Keychain reads during recomputation).
     private var statusText: String {
         if !configManager.config.cloudflareEnabled {
             return "Disabled"
         }
-        let hasToken = !(configManager.getSecret(ConfigManager.SecretKey.cloudflareToken) ?? "").isEmpty
-            || !tunnelToken.isEmpty
-        return hasToken ? "Token saved" : "Not configured"
+        return !tunnelToken.isEmpty ? "Token saved" : "Not configured"
     }
 
     private var statusColor: Color {
         if !configManager.config.cloudflareEnabled { return .secondary }
-        let hasToken = !(configManager.getSecret(ConfigManager.SecretKey.cloudflareToken) ?? "").isEmpty
-            || !tunnelToken.isEmpty
-        return hasToken ? .green : .orange
+        return !tunnelToken.isEmpty ? .green : .orange
     }
 
     var body: some View {
@@ -81,11 +78,16 @@ struct CloudflareTunnelView: View {
             tunnelToken = configManager.getSecret(ConfigManager.SecretKey.cloudflareToken) ?? ""
         }
         .onChange(of: tunnelToken) {
-            // Persist token changes to Keychain immediately
-            if tunnelToken.isEmpty {
-                configManager.deleteSecret(ConfigManager.SecretKey.cloudflareToken)
-            } else {
-                configManager.setSecret(ConfigManager.SecretKey.cloudflareToken, value: tunnelToken)
+            // Debounce Keychain writes — only persist after 1s of inactivity
+            tokenSaveTask?.cancel()
+            tokenSaveTask = Task {
+                try? await Task.sleep(for: .seconds(1))
+                guard !Task.isCancelled else { return }
+                if tunnelToken.isEmpty {
+                    configManager.deleteSecret(ConfigManager.SecretKey.cloudflareToken)
+                } else {
+                    configManager.setSecret(ConfigManager.SecretKey.cloudflareToken, value: tunnelToken)
+                }
             }
         }
     }

--- a/macos/GroundControl/Views/ConfigView.swift
+++ b/macos/GroundControl/Views/ConfigView.swift
@@ -1,3 +1,4 @@
+import AppKit
 import SwiftUI
 
 /// Form-based configuration editor for the relay server.
@@ -279,7 +280,7 @@ struct ConfigView: View {
             showSaveSuccess = true
 
             // Hide success message after a moment
-            Task {
+            Task { @MainActor in
                 try? await Task.sleep(for: .seconds(2))
                 showSaveSuccess = false
             }


### PR DESCRIPTION
## Summary

Addresses all 8 Copilot review comments from PR #104 (Ground Control Wave 4).

1. **ConfigView.swift** — Add missing `import AppKit` (required by `NSOpenPanel`)
2. **ConfigView.swift** — Add `@MainActor` to Task that mutates `@State` (`showSaveSuccess`)
3. **CloudflareTunnelView.swift** — Derive `statusText`/`statusColor` from `@State tunnelToken` instead of hitting Keychain on every SwiftUI recomputation
4. **CloudflareTunnelView.swift** — Debounce Keychain writes (1s delay) instead of writing on every keystroke
5. **RelayProcess.swift** — Pass `CLOUDFLARE_TUNNEL` env var to relay process
6. **RelayProcess.swift** — Only set `AUTH_GOOGLE_ENABLED=true` when both Google client ID and secret are present; log warning if missing
7. **ConfigManager.swift** — Write defaults to `config.json` on first launch so the file exists on disk
8. **GroundControlApp.swift** — Remove double `ConfigManager()` initialization (was created once via `@State` default, then again in `init()`)

## Test plan
- [ ] Build compiles cleanly (`swift build` passes)
- [ ] Config file created on first launch at `~/.major-tom/config.json`
- [ ] Cloudflare token saved only after typing pause (no per-keystroke writes)
- [ ] Google auth gracefully disabled when credentials missing
- [ ] `CLOUDFLARE_TUNNEL` env var present in relay process environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)