### PR TITLE
fix(ios): address SwiftTerm Wave 4 review comments

### DIFF
--- a/ios/MajorTom/Features/Terminal/Models/TerminalTheme.swift
+++ b/ios/MajorTom/Features/Terminal/Models/TerminalTheme.swift
@@ -2,9 +2,10 @@ import Foundation
 
 /// Terminal color theme definition for xterm.js.
 ///
-/// Each theme provides the full set of 19 xterm colors used by the JS bridge.
+/// Each theme provides the full set of 21 xterm theme fields: 5 core colors and 16 ANSI colors.
 /// Themes are injected into the WKWebView via `MajorTom.setTheme(theme)` and
-/// persisted by the `KeybarViewModel` preference sync system.
+/// Theme selection is persisted locally via UserDefaults. Cross-device theme
+/// sync is not currently implemented — only keybar and font size sync to the relay.
 struct TerminalTheme: Identifiable, Codable, Equatable, Sendable {
     let id: String
     let name: String

--- a/ios/MajorTom/Features/Terminal/ViewModels/KeybarViewModel.swift
+++ b/ios/MajorTom/Features/Terminal/ViewModels/KeybarViewModel.swift
@@ -5,7 +5,8 @@ import Foundation
 /// On init, loads from UserDefaults (device-local cache). Then async fetches
 /// from the relay's `/api/user/preferences` endpoint — server wins if it has
 /// a config. Local mutations save to UserDefaults immediately and debounce-sync
-/// to the relay (800ms). Network errors are silent; the UI never blocks on sync.
+/// to the relay (800ms). Network errors never block the UI, though sync/push
+/// failures are logged to the console.
 ///
 /// Mirrors the web PWA's `keybar.svelte.ts` + `shell.svelte.ts` sync patterns.
 @Observable
@@ -208,6 +209,8 @@ final class KeybarViewModel {
 
     // MARK: - Theme
 
+    /// Set the active terminal theme. Theme selection is local-only (UserDefaults)
+    /// and not synced to the relay — only keybar layout and font size are synced.
     func setTheme(_ theme: TerminalTheme) {
         guard theme.id != selectedThemeId else { return }
         selectedThemeId = theme.id

--- a/ios/MajorTom/Features/Terminal/Views/KeybarCustomizer.swift
+++ b/ios/MajorTom/Features/Terminal/Views/KeybarCustomizer.swift
@@ -73,6 +73,7 @@ struct KeybarCustomizer: View {
                 }
                 .listStyle(.insetGrouped)
                 .scrollContentBackground(.hidden)
+                .environment(\.editMode, .constant(.active))
             }
             .background(MajorTomTheme.Colors.background)
             .navigationTitle("Customize Keys")

--- a/ios/MajorTom/Features/Terminal/Views/TerminalSettingsView.swift
+++ b/ios/MajorTom/Features/Terminal/Views/TerminalSettingsView.swift
@@ -105,7 +105,7 @@ struct TerminalSettingsView: View {
                 // Preview text
                 Text("AaBbCc 0123 ~/code $")
                     .font(.system(size: CGFloat(keybarViewModel.fontSize), design: .monospaced))
-                    .foregroundStyle(MajorTomTheme.Colors.textPrimary)
+                    .foregroundStyle(Color(hex: keybarViewModel.selectedTheme.foreground) ?? MajorTomTheme.Colors.textPrimary)
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .padding(MajorTomTheme.Spacing.sm)
                     .background(Color(hex: keybarViewModel.selectedTheme.background) ?? MajorTomTheme.Colors.background)

--- a/ios/MajorTom/Features/Terminal/Views/TerminalView.swift
+++ b/ios/MajorTom/Features/Terminal/Views/TerminalView.swift
@@ -114,6 +114,8 @@ struct TerminalView: View {
         }
         .task {
             await viewModel.keybarViewModel.syncFromRelay()
+            viewModel.applyFontSize(viewModel.keybarViewModel.fontSize)
+            viewModel.applyTheme(viewModel.keybarViewModel.selectedTheme)
         }
     }
 
@@ -150,6 +152,7 @@ struct TerminalView: View {
                     .frame(width: 28, height: 28)
                     .contentShape(Rectangle())
             }
+            .accessibilityLabel("Terminal settings")
         }
         .padding(.horizontal, MajorTomTheme.Spacing.md)
         .padding(.vertical, MajorTomTheme.Spacing.xs)


### PR DESCRIPTION
## Summary
Post-merge fixes for 8 Copilot review comments from PR #105 (SwiftTerm Wave 4).

### Fixes
1. **TerminalTheme.swift:5** — Doc comment said 19 colors, actually 21 (5 core + 16 ANSI)
2. **TerminalTheme.swift:7** — Doc falsely claimed relay sync; clarified theme is local-only (UserDefaults)
3. **TerminalView.swift:115-117** — After `syncFromRelay()`, apply fetched fontSize/theme to the WKWebView
4. **TerminalView.swift:152** — Added `.accessibilityLabel("Terminal settings")` to gear button
5. **KeybarCustomizer.swift:74** — Added `.environment(\.editMode, .constant(.active))` so drag handles show without manual edit mode
6. **TerminalSettingsView.swift:108** — Font preview now uses theme foreground color instead of hardcoded white (fixes unreadable text on light themes)
7. **KeybarViewModel.swift:8** — Doc said "silent" errors; clarified failures are logged to console
8. **KeybarViewModel.swift:210** — Documented `setTheme()` as local-only, not synced to relay

## Test plan
- [ ] Build succeeds (verified locally via `xcodebuild`)
- [ ] Font preview readable on both dark and light themes (Solarized Light)
- [ ] Keybar customizer shows drag handles without needing to tap Edit
- [ ] Settings gear has VoiceOver accessibility label
- [ ] Theme/font size from relay applied after sync on app launch

🤖 Generated with [Claude Code](https://claude.com/claude-code)