### PR TITLE
fix(macos,ios): address Wave 4 review round 2 comments

### DIFF
--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -15,10 +15,10 @@ Spec: `docs/GROUND-CONTROL.md`
 | 1 — Scaffold & Process Management | DONE | #98 |
 | 2 — Log Viewer | DONE | #100 |
 | 3 — Dashboard | DONE | #102 |
-| **4 — Configuration** | **NEXT** | — |
-| 5 — Security & Polish | TODO | — |
+| 4 — Configuration | DONE | #104 |
+| **5 — Security & Polish** | **NEXT** | — |
 
-**Wave 4 scope:** GUI settings editor (ConfigView), Keychain secrets (OAuth creds, tunnel token), config.json read/write, CloudflareTunnelView, "Apply & Restart" flow.
+**Wave 5 scope:** Security panel (connected devices, session revocation), first-run onboarding, menu bar icon status colors, notarization prep.
 
 ### Phase 14 "SwiftTerm" (iOS native terminal)
 
@@ -29,10 +29,10 @@ Spec: `docs/PHASE-14-SWIFTTERM.md`
 | 1 — Basic Terminal Rendering | DONE | #97 |
 | 2 — Keyboard & Input | DONE | #99 |
 | 3 — Multi-Tab Support | DONE | #103 |
-| **4 — Customization & Sync** | **NEXT** | — |
-| 5 — Polish & Integration | TODO | — |
+| 4 — Customization & Sync | DONE | #105 |
+| **5 — Polish & Integration** | **NEXT** | — |
 
-**Wave 4 scope:** Keybar reorder/customize (KeybarCustomizer), theme picker (TerminalTheme, TerminalSettingsView), font size slider, relay preference sync via `/api/user/preferences`.
+**Wave 5 scope:** Terminal as default tab, Dynamic Island/Live Activity integration, Watch status, Siri shortcuts, copy/paste mode, orientation transitions, memory leak audit.
 
 ## Prior Phases (all complete)
 

--- a/ios/MajorTom/Features/Terminal/Models/TerminalTheme.swift
+++ b/ios/MajorTom/Features/Terminal/Models/TerminalTheme.swift
@@ -3,7 +3,7 @@ import Foundation
 /// Terminal color theme definition for xterm.js.
 ///
 /// Each theme provides the full set of 21 xterm theme fields: 5 core colors and 16 ANSI colors.
-/// Themes are injected into the WKWebView via `MajorTom.setTheme(theme)` and
+/// Themes are injected into the WKWebView via `MajorTom.setTheme(theme)`.
 /// Theme selection is persisted locally via UserDefaults. Cross-device theme
 /// sync is not currently implemented — only keybar and font size sync to the relay.
 struct TerminalTheme: Identifiable, Codable, Equatable, Sendable {

--- a/ios/MajorTom/Features/Terminal/Views/TerminalView.swift
+++ b/ios/MajorTom/Features/Terminal/Views/TerminalView.swift
@@ -114,6 +114,12 @@ struct TerminalView: View {
         }
         .task {
             await viewModel.keybarViewModel.syncFromRelay()
+            // Wait for the JS terminal to initialize before applying synced preferences,
+            // otherwise setFontSize/setTheme no-op because `term` is nil in the webview.
+            while !viewModel.isReady {
+                if Task.isCancelled { return }
+                try? await Task.sleep(for: .milliseconds(50))
+            }
             viewModel.applyFontSize(viewModel.keybarViewModel.fontSize)
             viewModel.applyTheme(viewModel.keybarViewModel.selectedTheme)
         }

--- a/macos/GroundControl/Services/ConfigManager.swift
+++ b/macos/GroundControl/Services/ConfigManager.swift
@@ -40,7 +40,11 @@ final class ConfigManager {
 
         // Write defaults on first launch so config.json exists on disk
         if !fileExisted {
-            try? save()
+            do {
+                try save()
+            } catch {
+                print("[ConfigManager] Failed to create initial config at \(ConfigManager.configFileURL.path): \(error)")
+            }
         }
     }
 

--- a/macos/GroundControl/Services/RelayProcess.swift
+++ b/macos/GroundControl/Services/RelayProcess.swift
@@ -117,7 +117,11 @@ final class RelayProcess {
         env["LOG_LEVEL"] = config.logLevel.rawValue
         env["CLAUDE_WORK_DIR"] = config.expandedClaudeWorkDir
         env["MULTI_USER_ENABLED"] = config.multiUserEnabled ? "true" : "false"
-        env["CLOUDFLARE_TUNNEL"] = config.cloudflareEnabled ? "true" : "false"
+        if config.cloudflareEnabled {
+            env["CLOUDFLARE_TUNNEL"] = "true"
+        } else {
+            env.removeValue(forKey: "CLOUDFLARE_TUNNEL")
+        }
 
         // Auth mode → relay env vars
         switch config.authMode {
@@ -131,11 +135,11 @@ final class RelayProcess {
             env["AUTH_PIN_ENABLED"] = "false"
             let clientId = configManager.getSecret(ConfigManager.SecretKey.googleClientId)
             let clientSecret = configManager.getSecret(ConfigManager.SecretKey.googleClientSecret)
-            let hasCredentials = !(clientId ?? "").isEmpty && !(clientSecret ?? "").isEmpty
-            if hasCredentials {
+            if let clientId, !clientId.isEmpty,
+               let clientSecret, !clientSecret.isEmpty {
                 env["AUTH_GOOGLE_ENABLED"] = "true"
-                env["GOOGLE_CLIENT_ID"] = clientId!
-                env["GOOGLE_CLIENT_SECRET"] = clientSecret!
+                env["GOOGLE_CLIENT_ID"] = clientId
+                env["GOOGLE_CLIENT_SECRET"] = clientSecret
             } else {
                 env["AUTH_GOOGLE_ENABLED"] = "false"
                 print("[GroundControl] WARNING: Google auth mode selected but client ID or secret is missing — disabling Google auth")


### PR DESCRIPTION
## Summary

Addresses 5 Copilot review comments from PRs #106 and #107 (Wave 4 fix PRs).

### Ground Control (3 fixes)
- **RelayProcess: CLOUDFLARE_TUNNEL env var** — Only set when enabled, remove entirely when disabled. Relay uses presence check (`!!process.env[...]`), so `"false"` was incorrectly treated as enabled.
- **RelayProcess: force unwrap removal** — Replace `clientId!`/`clientSecret!` with `if let` binding for Google OAuth credentials.
- **ConfigManager: log first-launch errors** — `try? save()` silently swallowed errors on initial config write. Now logs the failure.

### SwiftTerm (2 fixes)
- **TerminalView: gate apply on readiness** — `applyFontSize`/`applyTheme` after relay sync can fire before the JS terminal has initialized `term`, causing the calls to no-op. Now waits for `viewModel.isReady` before applying.
- **TerminalTheme: doc grammar** — Fix sentence continuation starting with capital letter.

## Test plan
- [ ] Ground Control builds clean (`swift build`)
- [ ] iOS builds clean (Xcode)
- [ ] Cloudflare tunnel toggle works correctly in both enabled/disabled states
- [ ] Terminal preferences sync applies theme/font after terminal loads

🤖 Generated with [Claude Code](https://claude.com/claude-code)