### PR TITLE
feat(ios): SwiftTerm Wave 5 — Polish & Integration

### DIFF
--- a/ios/MajorTom/App/MajorTomApp.swift
+++ b/ios/MajorTom/App/MajorTomApp.swift
@@ -5,12 +5,11 @@ struct MajorTomApp: App {
     @State private var relay = RelayService()
     @State private var officeViewModel = OfficeViewModel()
     @State private var auth = AuthService()
-    @State private var sessionStorage = SessionStorageService()
     @State private var notificationService = NotificationService()
     @State private var liveActivityManager = LiveActivityManager()
     @State private var watchConnectivity = PhoneWatchConnectivityService()
     @State private var achievementsViewModel: AchievementsViewModel?
-    @State private var selectedTab: AppTab = .control
+    @State private var selectedTab: AppTab = .terminal
     @Environment(\.scenePhase) private var scenePhase
 
     var body: some Scene {
@@ -96,6 +95,9 @@ struct MajorTomApp: App {
             .onReceive(NotificationCenter.default.publisher(for: .checkAchievementsFromShortcut)) { _ in
                 handleShortcutAction(.checkAchievements)
             }
+            .onReceive(NotificationCenter.default.publisher(for: .openTerminalFromShortcut)) { _ in
+                handleShortcutAction(.openTerminal)
+            }
             // Check for cross-process shortcut actions (Siri / Shortcuts app) on scene phase change
             .onChange(of: scenePhase) { _, newPhase in
                 if newPhase == .active {
@@ -109,15 +111,9 @@ struct MajorTomApp: App {
 
     private var mainTabView: some View {
         TabView(selection: $selectedTab) {
-            ChatView(relay: relay, storage: sessionStorage)
+            TerminalView(auth: auth, liveActivityManager: liveActivityManager, watchConnectivity: watchConnectivity)
                 .tabItem {
-                    Label("Control", systemImage: "terminal")
-                }
-                .tag(AppTab.control)
-
-            TerminalView(auth: auth)
-                .tabItem {
-                    Label("Shell", systemImage: "apple.terminal")
+                    Label("Terminal", systemImage: "apple.terminal")
                 }
                 .tag(AppTab.terminal)
 
@@ -180,7 +176,7 @@ struct MajorTomApp: App {
     private func handleShortcutAction(_ action: ShortcutActionKey.Action) {
         switch action {
         case .startSession:
-            selectedTab = .control
+            selectedTab = .terminal
             Task {
                 if relay.currentSession == nil {
                     try? await relay.startSession()
@@ -189,16 +185,16 @@ struct MajorTomApp: App {
         case .navigateToOffice:
             selectedTab = .office
         case .showCost:
-            selectedTab = .control
+            selectedTab = .terminal
         case .sendPrompt:
-            selectedTab = .control
+            selectedTab = .terminal
             Task {
                 if let text = WidgetDataProvider.consumePendingPrompt() {
                     try? await relay.sendPrompt(text)
                 }
             }
         case .quickApprove:
-            selectedTab = .control
+            selectedTab = .terminal
             Task {
                 // Prefer the approval that the widget/intent snapshot showed, with a safe fallback.
                 let snapshotApprovalId = WidgetDataProvider.consumePendingApprovalId()
@@ -217,6 +213,8 @@ struct MajorTomApp: App {
                     HapticService.approve()
                 }
             }
+        case .openTerminal:
+            selectedTab = .terminal
         case .toggleGodMode:
             Task {
                 guard WidgetDataProvider.consumeGodModeToggle() else { return }
@@ -241,11 +239,11 @@ struct MajorTomApp: App {
 
     private func handleDeepLink(_ deepLink: NotificationDeepLink) {
         if deepLink.isApproval {
-            selectedTab = .control
+            selectedTab = .terminal
         } else if deepLink.isOffice {
             selectedTab = .office
         } else if deepLink.isSession {
-            selectedTab = .control
+            selectedTab = .terminal
         }
         HapticService.impact(.light)
     }
@@ -272,14 +270,14 @@ struct MajorTomApp: App {
             let requestId = pathComponent ?? "latest"
             resolveApproval(requestId: requestId, approved: false)
         case "session":
-            // Navigate to the Control tab for the session.
+            // Navigate to the Terminal tab for the session.
             // If a specific sessionId is provided and differs from the current session,
             // attach to it so the user sees the right session context.
             if let sessionId = pathComponent,
                relay.currentSession?.id != sessionId {
                 Task { try? await relay.attachSession(id: sessionId) }
             }
-            selectedTab = .control
+            selectedTab = .terminal
             HapticService.impact(.light)
         default:
             break
@@ -301,7 +299,7 @@ struct MajorTomApp: App {
             targetId = requestId
         }
 
-        selectedTab = .control
+        selectedTab = .terminal
         Task {
             let decision: ApprovalDecision = approved ? .allow : .deny
             try? await relay.sendApproval(requestId: targetId, decision: decision)
@@ -336,7 +334,6 @@ struct MajorTomApp: App {
 // MARK: - Tab Enum
 
 enum AppTab: Hashable {
-    case control
     case terminal
     case office
     case connect

--- a/ios/MajorTom/Core/Models/WatchModels.swift
+++ b/ios/MajorTom/Core/Models/WatchModels.swift
@@ -115,4 +115,7 @@ enum WatchConnectivityKeys {
     static let totalCostToday = "totalCostToday"
     static let pendingApprovalCount = "pendingApprovalCount"
     static let activeSessionCount = "activeSessionCount"
+    static let terminalActive = "terminalActive"
+    static let terminalTabCount = "terminalTabCount"
+    static let terminalTitle = "terminalTitle"
 }

--- a/ios/MajorTom/Core/Services/PhoneWatchConnectivityService.swift
+++ b/ios/MajorTom/Core/Services/PhoneWatchConnectivityService.swift
@@ -73,6 +73,28 @@ final class PhoneWatchConnectivityService: NSObject {
         try? session.updateApplicationContext(context)
     }
 
+    /// Send terminal-specific context to the watch without overwriting relay data.
+    ///
+    /// Unlike `updateContext` (which replaces the entire `applicationContext`), this
+    /// uses `transferUserInfo` so it layers on top of whatever RelayService has set.
+    func updateTerminalContext(isActive: Bool, tabCount: Int, title: String) {
+        guard let session = wcSession, session.activationState == .activated else { return }
+
+        let payload: [String: Any] = [
+            WatchConnectivityKeys.terminalActive: isActive,
+            WatchConnectivityKeys.terminalTabCount: tabCount,
+            WatchConnectivityKeys.terminalTitle: title,
+        ]
+
+        if session.isReachable {
+            session.sendMessage(payload, replyHandler: nil) { _ in
+                session.transferUserInfo(payload)
+            }
+        } else {
+            session.transferUserInfo(payload)
+        }
+    }
+
     /// Forward approval requests to the watch (real-time when reachable).
     func sendApprovalRequests(_ requests: [WatchApprovalRequest]) {
         guard let session = wcSession, session.activationState == .activated else { return }

--- a/ios/MajorTom/Features/LiveActivity/LiveActivityManager.swift
+++ b/ios/MajorTom/Features/LiveActivity/LiveActivityManager.swift
@@ -101,6 +101,19 @@ final class LiveActivityManager {
         }
     }
 
+    // MARK: - Terminal Session Events
+
+    /// Update the Live Activity for an active terminal session.
+    /// Called from TerminalView when terminal state changes (title, tab switch, etc.).
+    func updateTerminalSession(sessionId: String, sessionName: String, tabCount: Int) {
+        guard snapshots[sessionId] != nil else { return }
+        snapshots[sessionId]!.sessionName = sessionName
+        snapshots[sessionId]!.status = "active"
+        snapshots[sessionId]!.activeAgents = tabCount
+        snapshots[sessionId]!.latestTool = "shell"
+        debouncedUpdate(for: sessionId)
+    }
+
     // MARK: - Event Handlers
 
     /// Called when an agent spawns in a session.

--- a/ios/MajorTom/Features/Shortcuts/MajorTomShortcuts.swift
+++ b/ios/MajorTom/Features/Shortcuts/MajorTomShortcuts.swift
@@ -23,6 +23,7 @@ enum ShortcutActionKey {
         case quickApprove
         case toggleGodMode
         case checkAchievements
+        case openTerminal
     }
 
     /// Returns the App Group `UserDefaults` used for cross-process shortcut communication.
@@ -257,6 +258,20 @@ struct CheckAchievementsIntent: AppIntent {
     }
 }
 
+// MARK: - Open Terminal Intent
+
+struct OpenTerminalIntent: AppIntent {
+    static var title: LocalizedStringResource = "Open Terminal"
+    static var description: IntentDescription = "Opens Major Tom directly to the terminal tab"
+    static var openAppWhenRun: Bool = true
+
+    func perform() async throws -> some IntentResult {
+        ShortcutActionKey.postAction(.openTerminal)
+        NotificationCenter.default.post(name: .openTerminalFromShortcut, object: nil)
+        return .result()
+    }
+}
+
 // MARK: - App Shortcuts Provider
 
 struct MajorTomShortcutsProvider: AppShortcutsProvider {
@@ -368,6 +383,18 @@ struct MajorTomShortcutsProvider: AppShortcutsProvider {
             shortTitle: "Check Achievements",
             systemImageName: "trophy"
         )
+
+        AppShortcut(
+            intent: OpenTerminalIntent(),
+            phrases: [
+                "Open \(.applicationName) terminal",
+                "Open terminal in \(.applicationName)",
+                "\(.applicationName) shell",
+                "Show terminal in \(.applicationName)"
+            ],
+            shortTitle: "Open Terminal",
+            systemImageName: "apple.terminal"
+        )
     }
 }
 
@@ -381,4 +408,5 @@ extension Notification.Name {
     static let quickApproveFromShortcut = Notification.Name("com.majortom.shortcut.quickApprove")
     static let toggleGodModeFromShortcut = Notification.Name("com.majortom.shortcut.toggleGodMode")
     static let checkAchievementsFromShortcut = Notification.Name("com.majortom.shortcut.checkAchievements")
+    static let openTerminalFromShortcut = Notification.Name("com.majortom.shortcut.openTerminal")
 }

--- a/ios/MajorTom/Features/Terminal/ViewModels/TerminalViewModel.swift
+++ b/ios/MajorTom/Features/Terminal/ViewModels/TerminalViewModel.swift
@@ -313,6 +313,44 @@ final class TerminalViewModel {
         }
     }
 
+    // MARK: - Copy/Paste
+
+    /// Paste text into the terminal via the JS bridge.
+    func pasteText(_ text: String) {
+        guard let webView else { return }
+        guard let data = try? JSONSerialization.data(withJSONObject: text),
+              let json = String(data: data, encoding: .utf8) else { return }
+        let js = "if(window.MajorTom && window.MajorTom.paste){window.MajorTom.paste(\(json))}"
+        webView.evaluateJavaScript(js) { _, _ in }
+    }
+
+    /// Enable or disable copy/select mode in the terminal.
+    /// When enabled, touch interactions in xterm select text instead of scrolling.
+    func setCopyMode(_ enabled: Bool) {
+        guard let webView else { return }
+        let js = """
+        if(window.MajorTom && window.MajorTom._term){
+          window.MajorTom._term.options.rightClickSelectsWord = \(enabled);
+          if(\(enabled)){
+            window.MajorTom._term.select(0, window.MajorTom._term.buffer.active.cursorY, window.MajorTom._term.cols);
+          } else {
+            window.MajorTom._term.clearSelection();
+          }
+        }
+        """
+        webView.evaluateJavaScript(js) { _, _ in }
+    }
+
+    // MARK: - Orientation / Resize
+
+    /// Trigger a terminal resize via the JS bridge (e.g. after orientation change).
+    /// The fit addon recalculates cols/rows based on the new container dimensions.
+    func triggerResize() {
+        guard let webView else { return }
+        let js = "if(window.MajorTom && window.MajorTom.resize){window.MajorTom.resize()}"
+        webView.evaluateJavaScript(js) { _, _ in }
+    }
+
     // MARK: - Theme & Font
 
     /// Apply a theme to the live terminal by calling the JS bridge.

--- a/ios/MajorTom/Features/Terminal/ViewModels/TerminalViewModel.swift
+++ b/ios/MajorTom/Features/Terminal/ViewModels/TerminalViewModel.swift
@@ -318,7 +318,7 @@ final class TerminalViewModel {
     /// Paste text into the terminal via the JS bridge.
     func pasteText(_ text: String) {
         guard let webView else { return }
-        guard let data = try? JSONSerialization.data(withJSONObject: text),
+        guard let data = try? JSONEncoder().encode(text),
               let json = String(data: data, encoding: .utf8) else { return }
         let js = "if(window.MajorTom && window.MajorTom.paste){window.MajorTom.paste(\(json))}"
         webView.evaluateJavaScript(js) { _, _ in }

--- a/ios/MajorTom/Features/Terminal/Views/TerminalView.swift
+++ b/ios/MajorTom/Features/Terminal/Views/TerminalView.swift
@@ -35,6 +35,9 @@ struct TerminalView: View {
     /// Toast message for copy/paste feedback.
     @State private var toastMessage: String?
 
+    /// Timestamp when the terminal first connected — set once, reused for Watch/Activity elapsed time.
+    @State private var terminalStartedAt: Date?
+
     /// Current device orientation — used to trigger resize on rotation.
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
 
@@ -163,6 +166,9 @@ struct TerminalView: View {
         .onChange(of: viewModel.terminalTitle) { _, _ in
             updateWatchTerminalState()
         }
+        .onChange(of: viewModel.tabs.count) { _, _ in
+            updateWatchTerminalState()
+        }
         .task {
             await viewModel.keybarViewModel.syncFromRelay()
             // Wait for the JS terminal to initialize before applying synced preferences,
@@ -196,7 +202,7 @@ struct TerminalView: View {
 
     private func showToast(_ message: String) {
         toastMessage = message
-        Task {
+        Task { @MainActor in
             try? await Task.sleep(for: .seconds(1.5))
             if toastMessage == message {
                 toastMessage = nil
@@ -214,7 +220,7 @@ struct TerminalView: View {
                 let sessionInfo = SessionInfo(
                     sessionId: "terminal-\(viewModel.tabId)",
                     sessionName: viewModel.terminalTitle,
-                    workingDir: viewModel.terminalTitle
+                    workingDir: "~"
                 )
                 await liveActivityManager.startActivity(for: sessionInfo)
             case .disconnected:
@@ -234,15 +240,22 @@ struct TerminalView: View {
         let isConnected = viewModel.connectionState == .connected
         let tabCount = viewModel.tabs.count
 
+        // Set startedAt once on connect, clear on disconnect.
+        if isConnected && terminalStartedAt == nil {
+            terminalStartedAt = Date()
+        } else if !isConnected {
+            terminalStartedAt = nil
+        }
+
         // Build a WatchSession representing the terminal
         let session = WatchSession(
             id: "terminal-\(viewModel.tabId)",
             name: viewModel.terminalTitle,
-            workingDir: viewModel.terminalTitle,
+            workingDir: "~",
             status: isConnected ? .active : .idle,
             agentCount: tabCount,
             cost: 0,
-            startedAt: isConnected ? Date() : nil
+            startedAt: isConnected ? terminalStartedAt : nil
         )
 
         watchConnectivity.updateContext(
@@ -252,6 +265,15 @@ struct TerminalView: View {
             latestToolName: isConnected ? "shell" : nil,
             latestToolStatus: isConnected ? "active" : nil
         )
+
+        // Keep the Live Activity in sync with title/tab changes.
+        if isConnected {
+            liveActivityManager.updateTerminalSession(
+                sessionId: "terminal-\(viewModel.tabId)",
+                sessionName: viewModel.terminalTitle,
+                tabCount: tabCount
+            )
+        }
     }
 
     // MARK: - Status Bar

--- a/ios/MajorTom/Features/Terminal/Views/TerminalView.swift
+++ b/ios/MajorTom/Features/Terminal/Views/TerminalView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import UIKit
 
 /// Main terminal view — hosts the WKWebView terminal and manages lifecycle.
 ///
@@ -12,8 +13,13 @@ import SwiftUI
 ///
 /// Wave 4: Settings sheet with theme picker, font size slider, and keybar
 /// customization. Gear icon in the status bar presents TerminalSettingsView.
+///
+/// Wave 5: Copy/paste mode, orientation transitions, Live Activity and Watch
+/// integration. Terminal is now the default tab on launch.
 struct TerminalView: View {
     let auth: AuthService
+    let liveActivityManager: LiveActivityManager
+    let watchConnectivity: PhoneWatchConnectivityService
 
     @State private var viewModel: TerminalViewModel
 
@@ -23,8 +29,19 @@ struct TerminalView: View {
     /// Whether the terminal settings sheet is presented.
     @State private var showSettings = false
 
-    init(auth: AuthService) {
+    /// Whether copy mode is active (long-press to select text).
+    @State private var copyModeActive = false
+
+    /// Toast message for copy/paste feedback.
+    @State private var toastMessage: String?
+
+    /// Current device orientation — used to trigger resize on rotation.
+    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
+
+    init(auth: AuthService, liveActivityManager: LiveActivityManager, watchConnectivity: PhoneWatchConnectivityService) {
         self.auth = auth
+        self.liveActivityManager = liveActivityManager
+        self.watchConnectivity = watchConnectivity
         self._viewModel = State(initialValue: TerminalViewModel(auth: auth))
     }
 
@@ -77,6 +94,8 @@ struct TerminalView: View {
                 // visible even when no iOS keyboard is showing (e.g., when the
                 // specialty grid replaces the keyboard). This matches the PWA's
                 // mobile-first layout where the keybar is always on screen.
+                //
+                // Long-press on the keybar area pastes clipboard content.
                 if viewModel.connectionState == .connected || viewModel.isReady {
                     NativeKeybar(
                         onSendBytes: { bytes in
@@ -90,6 +109,9 @@ struct TerminalView: View {
                         specialtyGridVisible: showSpecialtyGrid,
                         keys: viewModel.keybarViewModel.accessoryKeys
                     )
+                    .onLongPressGesture(minimumDuration: 0.5) {
+                        pasteFromClipboard()
+                    }
                 }
             }
         }
@@ -112,6 +134,35 @@ struct TerminalView: View {
             )
             .presentationDetents([.medium, .large])
         }
+        .overlay(alignment: .bottom) {
+            // Toast feedback for copy/paste actions
+            if let message = toastMessage {
+                Text(message)
+                    .font(MajorTomTheme.Typography.caption)
+                    .foregroundStyle(MajorTomTheme.Colors.textPrimary)
+                    .padding(.horizontal, MajorTomTheme.Spacing.md)
+                    .padding(.vertical, MajorTomTheme.Spacing.sm)
+                    .background(MajorTomTheme.Colors.surfaceElevated)
+                    .clipShape(Capsule())
+                    .shadow(color: .black.opacity(0.3), radius: 4, y: 2)
+                    .padding(.bottom, 80)
+                    .transition(.move(edge: .bottom).combined(with: .opacity))
+                    .allowsHitTesting(false)
+            }
+        }
+        .animation(.easeInOut(duration: 0.2), value: toastMessage)
+        // Trigger terminal resize on orientation change
+        .onChange(of: horizontalSizeClass) { _, _ in
+            viewModel.triggerResize()
+        }
+        // Wire terminal state into Live Activity on connection changes
+        .onChange(of: viewModel.connectionState) { _, newState in
+            updateLiveActivity(for: newState)
+            updateWatchTerminalState()
+        }
+        .onChange(of: viewModel.terminalTitle) { _, _ in
+            updateWatchTerminalState()
+        }
         .task {
             await viewModel.keybarViewModel.syncFromRelay()
             // Wait for the JS terminal to initialize before applying synced preferences,
@@ -123,6 +174,84 @@ struct TerminalView: View {
             viewModel.applyFontSize(viewModel.keybarViewModel.fontSize)
             viewModel.applyTheme(viewModel.keybarViewModel.selectedTheme)
         }
+    }
+
+    // MARK: - Copy/Paste
+
+    /// Paste clipboard content into the terminal.
+    private func pasteFromClipboard() {
+        guard let text = UIPasteboard.general.string, !text.isEmpty else { return }
+        viewModel.pasteText(text)
+        HapticService.impact(.light)
+        showToast("Pasted")
+    }
+
+    /// Toggle copy mode on the terminal web view.
+    private func toggleCopyMode() {
+        copyModeActive.toggle()
+        viewModel.setCopyMode(copyModeActive)
+        HapticService.impact(.medium)
+        showToast(copyModeActive ? "Copy mode ON" : "Copy mode OFF")
+    }
+
+    private func showToast(_ message: String) {
+        toastMessage = message
+        Task {
+            try? await Task.sleep(for: .seconds(1.5))
+            if toastMessage == message {
+                toastMessage = nil
+            }
+        }
+    }
+
+    // MARK: - Live Activity Integration
+
+    /// Start or end a Live Activity based on terminal connection state.
+    private func updateLiveActivity(for state: TerminalConnectionState) {
+        Task {
+            switch state {
+            case .connected:
+                let sessionInfo = SessionInfo(
+                    sessionId: "terminal-\(viewModel.tabId)",
+                    sessionName: viewModel.terminalTitle,
+                    workingDir: viewModel.terminalTitle
+                )
+                await liveActivityManager.startActivity(for: sessionInfo)
+            case .disconnected:
+                await liveActivityManager.endActivity(for: "terminal-\(viewModel.tabId)")
+            case .error:
+                await liveActivityManager.endActivity(for: "terminal-\(viewModel.tabId)")
+            case .connecting:
+                break
+            }
+        }
+    }
+
+    // MARK: - Watch Integration
+
+    /// Push terminal session state to the Apple Watch via WatchConnectivity.
+    private func updateWatchTerminalState() {
+        let isConnected = viewModel.connectionState == .connected
+        let tabCount = viewModel.tabs.count
+
+        // Build a WatchSession representing the terminal
+        let session = WatchSession(
+            id: "terminal-\(viewModel.tabId)",
+            name: viewModel.terminalTitle,
+            workingDir: viewModel.terminalTitle,
+            status: isConnected ? .active : .idle,
+            agentCount: tabCount,
+            cost: 0,
+            startedAt: isConnected ? Date() : nil
+        )
+
+        watchConnectivity.updateContext(
+            sessions: [session],
+            fleetSummary: nil,
+            isRelayConnected: isConnected,
+            latestToolName: isConnected ? "shell" : nil,
+            latestToolStatus: isConnected ? "active" : nil
+        )
     }
 
     // MARK: - Status Bar
@@ -146,6 +275,30 @@ struct TerminalView: View {
                     .font(MajorTomTheme.Typography.codeFontSmall)
                     .foregroundStyle(MajorTomTheme.Colors.textTertiary)
             }
+
+            // Copy mode toggle
+            Button {
+                toggleCopyMode()
+            } label: {
+                Image(systemName: copyModeActive ? "text.cursor" : "selection.pin.in.out")
+                    .font(.system(size: 14, weight: .medium))
+                    .foregroundStyle(copyModeActive ? MajorTomTheme.Colors.accent : MajorTomTheme.Colors.textSecondary)
+                    .frame(width: 28, height: 28)
+                    .contentShape(Rectangle())
+            }
+            .accessibilityLabel(copyModeActive ? "Disable copy mode" : "Enable copy mode")
+
+            // Paste button
+            Button {
+                pasteFromClipboard()
+            } label: {
+                Image(systemName: "doc.on.clipboard")
+                    .font(.system(size: 14, weight: .medium))
+                    .foregroundStyle(MajorTomTheme.Colors.textSecondary)
+                    .frame(width: 28, height: 28)
+                    .contentShape(Rectangle())
+            }
+            .accessibilityLabel("Paste from clipboard")
 
             // Settings gear
             Button {
@@ -175,6 +328,9 @@ struct TerminalView: View {
         default:
             ZStack {
                 TerminalWebView(viewModel: viewModel)
+                    .onLongPressGesture(minimumDuration: 0.5) {
+                        toggleCopyMode()
+                    }
 
                 if viewModel.didTerminate {
                     recoveryOverlay
@@ -182,6 +338,25 @@ struct TerminalView: View {
 
                 if !viewModel.isReady {
                     loadingOverlay
+                }
+
+                // Copy mode indicator overlay
+                if copyModeActive {
+                    VStack {
+                        HStack {
+                            Spacer()
+                            Text("COPY MODE")
+                                .font(.system(size: 10, weight: .bold, design: .monospaced))
+                                .foregroundStyle(MajorTomTheme.Colors.background)
+                                .padding(.horizontal, MajorTomTheme.Spacing.sm)
+                                .padding(.vertical, 2)
+                                .background(MajorTomTheme.Colors.accent)
+                                .clipShape(Capsule())
+                                .padding(MajorTomTheme.Spacing.sm)
+                        }
+                        Spacer()
+                    }
+                    .allowsHitTesting(false)
                 }
             }
         }

--- a/ios/MajorTom/Features/Terminal/Views/TerminalView.swift
+++ b/ios/MajorTom/Features/Terminal/Views/TerminalView.swift
@@ -35,6 +35,10 @@ struct TerminalView: View {
     /// Toast message for copy/paste feedback.
     @State private var toastMessage: String?
 
+    /// Stable session ID for Live Activity and Watch — doesn't drift with tab switches.
+    /// There is one terminal session with multiple tabs inside it; identity is fixed.
+    private let terminalSessionId = "terminal-session"
+
     /// Timestamp when the terminal first connected — set once, reused for Watch/Activity elapsed time.
     @State private var terminalStartedAt: Date?
 
@@ -218,15 +222,15 @@ struct TerminalView: View {
             switch state {
             case .connected:
                 let sessionInfo = SessionInfo(
-                    sessionId: "terminal-\(viewModel.tabId)",
+                    sessionId: terminalSessionId,
                     sessionName: viewModel.terminalTitle,
                     workingDir: "~"
                 )
                 await liveActivityManager.startActivity(for: sessionInfo)
             case .disconnected:
-                await liveActivityManager.endActivity(for: "terminal-\(viewModel.tabId)")
+                await liveActivityManager.endActivity(for: terminalSessionId)
             case .error:
-                await liveActivityManager.endActivity(for: "terminal-\(viewModel.tabId)")
+                await liveActivityManager.endActivity(for: terminalSessionId)
             case .connecting:
                 break
             }
@@ -247,29 +251,17 @@ struct TerminalView: View {
             terminalStartedAt = nil
         }
 
-        // Build a WatchSession representing the terminal
-        let session = WatchSession(
-            id: "terminal-\(viewModel.tabId)",
-            name: viewModel.terminalTitle,
-            workingDir: "~",
-            status: isConnected ? .active : .idle,
-            agentCount: tabCount,
-            cost: 0,
-            startedAt: isConnected ? terminalStartedAt : nil
-        )
-
-        watchConnectivity.updateContext(
-            sessions: [session],
-            fleetSummary: nil,
-            isRelayConnected: isConnected,
-            latestToolName: isConnected ? "shell" : nil,
-            latestToolStatus: isConnected ? "active" : nil
+        // Send only terminal-specific keys — don't overwrite relay context.
+        watchConnectivity.updateTerminalContext(
+            isActive: isConnected,
+            tabCount: tabCount,
+            title: viewModel.terminalTitle
         )
 
         // Keep the Live Activity in sync with title/tab changes.
         if isConnected {
             liveActivityManager.updateTerminalSession(
-                sessionId: "terminal-\(viewModel.tabId)",
+                sessionId: terminalSessionId,
                 sessionName: viewModel.terminalTitle,
                 tabCount: tabCount
             )

--- a/ios/MajorTom/Features/Terminal/Views/TerminalWebView.swift
+++ b/ios/MajorTom/Features/Terminal/Views/TerminalWebView.swift
@@ -17,10 +17,23 @@ struct TerminalWebView: UIViewRepresentable {
     /// WKWebView → userContentController → coordinator retain cycle.
     /// Without this, the Coordinator (and transitively the WKWebView)
     /// leaks every time SwiftUI recreates the view.
+    ///
+    /// Wave 5 memory leak audit:
+    /// - Removes the majorTom message handler (breaks WKScriptMessageHandler retain)
+    /// - Removes all user scripts (breaks WKUserScript references)
+    /// - Nils the navigation delegate (breaks Coordinator ← WKWebView retain)
+    /// - Stops loading to cancel any in-flight requests
+    /// - Nils the ViewModel's weak webView reference
+    /// - Disconnects the JS WebSocket before teardown
     static func dismantleUIView(_ webView: WKWebView, coordinator: Coordinator) {
+        // Disconnect the JS WebSocket cleanly before tearing down
+        webView.evaluateJavaScript("if(window.MajorTom && window.MajorTom.disconnect){window.MajorTom.disconnect()}") { _, _ in }
+        webView.stopLoading()
         webView.configuration.userContentController.removeScriptMessageHandler(forName: "majorTom")
         webView.configuration.userContentController.removeAllUserScripts()
         webView.navigationDelegate = nil
+        // Nil the viewModel's weak reference to prevent stale calls
+        coordinator.viewModel.webView = nil
     }
 
     func makeUIView(context: Context) -> WKWebView {
@@ -192,7 +205,9 @@ struct TerminalWebView: UIViewRepresentable {
     // MARK: - Coordinator
 
     final class Coordinator: NSObject, WKScriptMessageHandler, WKNavigationDelegate {
-        private let viewModel: TerminalViewModel
+        /// Exposed (not private) so `dismantleUIView` can nil the viewModel's
+        /// weak webView reference during teardown to prevent stale calls.
+        let viewModel: TerminalViewModel
 
         init(viewModel: TerminalViewModel) {
             self.viewModel = viewModel

--- a/ios/MajorTomWatch/Models/WatchModels.swift
+++ b/ios/MajorTomWatch/Models/WatchModels.swift
@@ -115,4 +115,7 @@ enum WatchConnectivityKeys {
     static let totalCostToday = "totalCostToday"
     static let pendingApprovalCount = "pendingApprovalCount"
     static let activeSessionCount = "activeSessionCount"
+    static let terminalActive = "terminalActive"
+    static let terminalTabCount = "terminalTabCount"
+    static let terminalTitle = "terminalTitle"
 }


### PR DESCRIPTION
## Summary

Final wave for SwiftTerm — the native iOS terminal.

- **Terminal as default tab** — ChatView removed from tab bar, terminal is the primary experience
- **Dynamic Island / Live Activity** — terminal session state wired into existing Live Activity system
- **Watch connectivity** — terminal status pushed to Watch via existing `PhoneWatchConnectivityService`
- **Siri shortcut** — "Open Terminal" intent with 4 phrase variations
- **Copy/paste mode** — long-press toggles copy mode, paste from keybar area, toast feedback
- **Orientation transitions** — resize triggers on `horizontalSizeClass` changes
- **Memory leak audit** — proper WKWebView teardown in `dismantleUIView`, no retain cycles

### Modified files (7)
- `App/MajorTomApp.swift` — Default tab → `.terminal`, removed `.control` case
- `Core/Models/WatchModels.swift` — Terminal connectivity keys
- `Features/LiveActivity/LiveActivityManager.swift` — `updateTerminalSession()` method
- `Features/Shortcuts/MajorTomShortcuts.swift` — `OpenTerminalIntent`
- `Features/Terminal/ViewModels/TerminalViewModel.swift` — Copy/paste/resize methods
- `Features/Terminal/Views/TerminalView.swift` — Copy mode UI, paste, Live Activity + Watch wiring
- `Features/Terminal/Views/TerminalWebView.swift` — Proper teardown in `dismantleUIView`

## Test plan
- [ ] Launch app → lands on Terminal tab (not Chat)
- [ ] Dynamic Island shows active session when terminal connects
- [ ] "Open Terminal" Siri shortcut opens app to terminal
- [ ] Long-press terminal → copy mode activates, selection copies to clipboard
- [ ] Long-press keybar → pastes clipboard into terminal
- [ ] Rotate device → terminal resizes smoothly
- [ ] Switch tabs rapidly → no memory leaks (check Instruments)
- [ ] Build passes on iOS Simulator

🤖 Generated with [Claude Code](https://claude.com/claude-code)