### PR TITLE
fix(ios,macos): QA Wave 1 — memory fixes + terminal binary frame encoding

### DIFF
--- a/ios/MajorTom/Core/Services/PhoneWatchConnectivityService.swift
+++ b/ios/MajorTom/Core/Services/PhoneWatchConnectivityService.swift
@@ -15,6 +15,12 @@ final class PhoneWatchConnectivityService: NSObject {
 
     private var wcSession: WCSession?
 
+    /// Debounce task for coalescing rapid terminal context updates.
+    private var terminalContextTask: Task<Void, Never>?
+
+    /// Latest terminal context payload — coalesced across rapid updates.
+    private var pendingTerminalContext: [String: Any]?
+
     override init() {
         super.init()
     }
@@ -77,6 +83,7 @@ final class PhoneWatchConnectivityService: NSObject {
     ///
     /// Unlike `updateContext` (which replaces the entire `applicationContext`), this
     /// uses `transferUserInfo` so it layers on top of whatever RelayService has set.
+    /// Rapid calls are coalesced with a 500ms debounce to avoid filling the transfer queue.
     func updateTerminalContext(isActive: Bool, tabCount: Int, title: String) {
         guard let session = wcSession, session.activationState == .activated else { return }
 
@@ -86,12 +93,21 @@ final class PhoneWatchConnectivityService: NSObject {
             WatchConnectivityKeys.terminalTitle: title,
         ]
 
-        if session.isReachable {
-            session.sendMessage(payload, replyHandler: nil) { _ in
+        pendingTerminalContext = payload
+        terminalContextTask?.cancel()
+        terminalContextTask = Task { [weak self] in
+            try? await Task.sleep(for: .milliseconds(500))
+            guard !Task.isCancelled else { return }
+            guard let self, let payload = self.pendingTerminalContext else { return }
+            self.pendingTerminalContext = nil
+
+            if session.isReachable {
+                session.sendMessage(payload, replyHandler: nil) { _ in
+                    session.transferUserInfo(payload)
+                }
+            } else {
                 session.transferUserInfo(payload)
             }
-        } else {
-            session.transferUserInfo(payload)
         }
     }
 

--- a/ios/MajorTom/Features/LiveActivity/LiveActivityManager.swift
+++ b/ios/MajorTom/Features/LiveActivity/LiveActivityManager.swift
@@ -36,6 +36,9 @@ final class LiveActivityManager {
     func startActivity(for session: SessionInfo) async {
         guard isSupported else { return }
 
+        // Prune orphaned snapshots that no longer have an active activity
+        pruneOrphanedSnapshots()
+
         let sessionId = session.sessionId
         let sessionName = session.sessionName
         let workingDir = session.workingDir
@@ -98,6 +101,11 @@ final class LiveActivityManager {
         let sessionIds = Array(activities.keys)
         for sessionId in sessionIds {
             await endActivity(for: sessionId)
+        }
+        // Prune any orphaned snapshots that survived (defensive)
+        let activeIds = Set(activities.keys)
+        for key in snapshots.keys where !activeIds.contains(key) {
+            snapshots.removeValue(forKey: key)
         }
     }
 
@@ -176,6 +184,18 @@ final class LiveActivityManager {
         snapshots[sessionId]!.status = "idle"
         Task {
             await endActivity(for: sessionId)
+        }
+    }
+
+    // MARK: - Private — Cleanup
+
+    /// Remove snapshots that have no corresponding active activity.
+    private func pruneOrphanedSnapshots() {
+        let activeIds = Set(activities.keys)
+        for key in snapshots.keys where !activeIds.contains(key) {
+            snapshots.removeValue(forKey: key)
+            debounceTasks[key]?.cancel()
+            debounceTasks.removeValue(forKey: key)
         }
     }
 

--- a/ios/MajorTom/Features/LiveActivity/LiveActivityManager.swift
+++ b/ios/MajorTom/Features/LiveActivity/LiveActivityManager.swift
@@ -104,7 +104,8 @@ final class LiveActivityManager {
         }
         // Prune any orphaned snapshots that survived (defensive)
         let activeIds = Set(activities.keys)
-        for key in snapshots.keys where !activeIds.contains(key) {
+        let orphanedSnapshotKeys = Array(snapshots.keys.filter { !activeIds.contains($0) })
+        for key in orphanedSnapshotKeys {
             snapshots.removeValue(forKey: key)
         }
     }
@@ -192,7 +193,8 @@ final class LiveActivityManager {
     /// Remove snapshots that have no corresponding active activity.
     private func pruneOrphanedSnapshots() {
         let activeIds = Set(activities.keys)
-        for key in snapshots.keys where !activeIds.contains(key) {
+        let orphanedKeys = snapshots.keys.filter { !activeIds.contains($0) }
+        for key in orphanedKeys {
             snapshots.removeValue(forKey: key)
             debounceTasks[key]?.cancel()
             debounceTasks.removeValue(forKey: key)

--- a/ios/MajorTom/Features/Terminal/Resources/terminal.html
+++ b/ios/MajorTom/Features/Terminal/Resources/terminal.html
@@ -474,7 +474,7 @@
         // Send directly to the PTY, bypassing xterm input processing
         // to avoid bracket paste mode issues in raw paste.
         // Encode as binary so the relay treats it as PTY input.
-        ws.send(new TextEncoder().encode(text));
+        ws.send(encoder.encode(text));
       }
     },
 

--- a/ios/MajorTom/Features/Terminal/Resources/terminal.html
+++ b/ios/MajorTom/Features/Terminal/Resources/terminal.html
@@ -185,9 +185,11 @@
     });
 
     // Terminal input → WebSocket (keyboard data from xterm)
+    // Encode as binary so the relay treats it as PTY input, not a JSON control frame.
+    var encoder = new TextEncoder();
     term.onData(function(data) {
       if (ws && ws.readyState === WebSocket.OPEN) {
-        ws.send(data);
+        ws.send(encoder.encode(data));
       }
     });
 
@@ -471,7 +473,8 @@
       if (term && ws && ws.readyState === WebSocket.OPEN) {
         // Send directly to the PTY, bypassing xterm input processing
         // to avoid bracket paste mode issues in raw paste.
-        ws.send(text);
+        // Encode as binary so the relay treats it as PTY input.
+        ws.send(new TextEncoder().encode(text));
       }
     },
 

--- a/ios/MajorTom/Features/Terminal/ViewModels/KeybarViewModel.swift
+++ b/ios/MajorTom/Features/Terminal/ViewModels/KeybarViewModel.swift
@@ -61,7 +61,11 @@ final class KeybarViewModel {
     private var synced = false
 
     /// Debounce task for relay sync.
-    private var syncTask: Task<Void, Never>?
+    /// nonisolated(unsafe) so deinit can cancel without MainActor isolation.
+    nonisolated(unsafe) private var syncTask: Task<Void, Never>?
+
+    /// Tracked task for the relay push request.
+    nonisolated(unsafe) private var relayTask: Task<Void, Never>?
 
     // MARK: - Init
 
@@ -93,6 +97,11 @@ final class KeybarViewModel {
         }
 
         self.selectedThemeId = defaults.string(forKey: Self.themeKey) ?? TerminalTheme.majorTom.id
+    }
+
+    deinit {
+        syncTask?.cancel()
+        relayTask?.cancel()
     }
 
     // MARK: - Relay Sync
@@ -284,7 +293,9 @@ final class KeybarViewModel {
 
         guard let body = try? JSONSerialization.data(withJSONObject: payload) else { return }
 
-        Task {
+        relayTask?.cancel()
+        relayTask = Task {
+            guard !Task.isCancelled else { return }
             do {
                 var request = URLRequest(url: url)
                 request.httpMethod = "PUT"

--- a/ios/MajorTom/Features/Terminal/ViewModels/KeybarViewModel.swift
+++ b/ios/MajorTom/Features/Terminal/ViewModels/KeybarViewModel.swift
@@ -61,11 +61,10 @@ final class KeybarViewModel {
     private var synced = false
 
     /// Debounce task for relay sync.
-    /// nonisolated(unsafe) so deinit can cancel without MainActor isolation.
-    nonisolated(unsafe) private var syncTask: Task<Void, Never>?
+    private var syncTask: Task<Void, Never>?
 
     /// Tracked task for the relay push request.
-    nonisolated(unsafe) private var relayTask: Task<Void, Never>?
+    private var relayTask: Task<Void, Never>?
 
     // MARK: - Init
 
@@ -97,11 +96,6 @@ final class KeybarViewModel {
         }
 
         self.selectedThemeId = defaults.string(forKey: Self.themeKey) ?? TerminalTheme.majorTom.id
-    }
-
-    deinit {
-        syncTask?.cancel()
-        relayTask?.cancel()
     }
 
     // MARK: - Relay Sync

--- a/ios/MajorTom/Features/Terminal/Views/TerminalView.swift
+++ b/ios/MajorTom/Features/Terminal/Views/TerminalView.swift
@@ -35,6 +35,12 @@ struct TerminalView: View {
     /// Toast message for copy/paste feedback.
     @State private var toastMessage: String?
 
+    /// Tracked task for toast auto-dismiss.
+    @State private var toastTask: Task<Void, Never>?
+
+    /// Tracked task for Live Activity updates.
+    @State private var liveActivityTask: Task<Void, Never>?
+
     /// Stable session ID for Live Activity and Watch — doesn't drift with tab switches.
     /// There is one terminal session with multiple tabs inside it; identity is fixed.
     private let terminalSessionId = "terminal-session"
@@ -173,6 +179,10 @@ struct TerminalView: View {
         .onChange(of: viewModel.tabs.count) { _, _ in
             updateWatchTerminalState()
         }
+        .onDisappear {
+            toastTask?.cancel()
+            liveActivityTask?.cancel()
+        }
         .task {
             await viewModel.keybarViewModel.syncFromRelay()
             // Wait for the JS terminal to initialize before applying synced preferences,
@@ -206,8 +216,10 @@ struct TerminalView: View {
 
     private func showToast(_ message: String) {
         toastMessage = message
-        Task { @MainActor in
+        toastTask?.cancel()
+        toastTask = Task { @MainActor in
             try? await Task.sleep(for: .seconds(1.5))
+            guard !Task.isCancelled else { return }
             if toastMessage == message {
                 toastMessage = nil
             }
@@ -218,7 +230,9 @@ struct TerminalView: View {
 
     /// Start or end a Live Activity based on terminal connection state.
     private func updateLiveActivity(for state: TerminalConnectionState) {
-        Task {
+        liveActivityTask?.cancel()
+        liveActivityTask = Task {
+            guard !Task.isCancelled else { return }
             switch state {
             case .connected:
                 let sessionInfo = SessionInfo(

--- a/ios/MajorTom/Features/Terminal/Views/TerminalWebView.swift
+++ b/ios/MajorTom/Features/Terminal/Views/TerminalWebView.swift
@@ -29,11 +29,14 @@ struct TerminalWebView: UIViewRepresentable {
         // Disconnect the JS WebSocket cleanly before tearing down
         webView.evaluateJavaScript("if(window.MajorTom && window.MajorTom.disconnect){window.MajorTom.disconnect()}") { _, _ in }
         webView.stopLoading()
-        webView.configuration.userContentController.removeScriptMessageHandler(forName: "majorTom")
-        webView.configuration.userContentController.removeAllUserScripts()
+        let contentController = webView.configuration.userContentController
+        contentController.removeScriptMessageHandler(forName: "majorTom")
+        contentController.removeAllUserScripts()
         webView.navigationDelegate = nil
         // Nil the viewModel's weak reference to prevent stale calls
         coordinator.viewModel.webView = nil
+        // Break WKWebViewConfiguration → WKUserContentController → Coordinator retain cycle
+        webView.configuration.userContentController = WKUserContentController()
     }
 
     func makeUIView(context: Context) -> WKWebView {

--- a/macos/GroundControl/Services/RelayClient.swift
+++ b/macos/GroundControl/Services/RelayClient.swift
@@ -4,7 +4,7 @@ import Foundation
 /// parsed `HealthData` for the Dashboard view.
 ///
 /// Uses `@Observable` (macOS 14+) and Swift Concurrency — no Combine.
-/// Auto-refreshes every 5 seconds while polling is active.
+/// Auto-refreshes every 10 seconds while polling is active.
 @Observable
 final class RelayClient {
     /// Latest health data from the relay. Defaults to `.offline`.
@@ -20,7 +20,7 @@ final class RelayClient {
     var port: Int = 9090
 
     /// Polling interval in seconds.
-    private let pollInterval: TimeInterval = 5.0
+    private let pollInterval: TimeInterval = 10.0
 
     /// Active polling task — cancelled on `stopPolling()`.
     private var pollingTask: Task<Void, Never>?
@@ -33,6 +33,10 @@ final class RelayClient {
         config.timeoutIntervalForRequest = 3
         config.timeoutIntervalForResource = 5
         self.session = URLSession(configuration: config)
+    }
+
+    deinit {
+        session.invalidateAndCancel()
     }
 
     // MARK: - Polling Lifecycle
@@ -74,9 +78,9 @@ final class RelayClient {
             }
 
             let decoded = try JSONDecoder().decode(HealthData.self, from: data)
-            healthData = decoded
-            isConnected = true
-            lastError = nil
+            if healthData != decoded { healthData = decoded }
+            if !isConnected { isConnected = true }
+            if lastError != nil { lastError = nil }
         } catch is CancellationError {
             // Task cancelled — don't update state
         } catch let error as URLError where error.code == .timedOut || error.code == .cannotConnectToHost {
@@ -89,8 +93,8 @@ final class RelayClient {
     // MARK: - Private
 
     private func markOffline(error: String?) {
-        isConnected = false
-        healthData = HealthData.offline
-        lastError = error
+        if isConnected { isConnected = false }
+        if healthData != .offline { healthData = .offline }
+        if lastError != error { lastError = error }
     }
 }

--- a/macos/GroundControl/Services/RelayProcess.swift
+++ b/macos/GroundControl/Services/RelayProcess.swift
@@ -289,7 +289,9 @@ final class RelayProcess {
             // Force flush if buffer exceeds max size
             let forceFlush = bufferRef.count > self.maxBufferSize
 
-            guard let bufferString = String(data: bufferRef, encoding: .utf8) else { return }
+            // Use non-failing decoder — partial UTF-8 sequences get replacement chars
+            // instead of returning nil and stalling the pipeline.
+            let bufferString = String(decoding: bufferRef, as: UTF8.self)
 
             let newline = UInt8(ascii: "\n")
             let hasTrailingNewline = bufferRef.last == newline

--- a/macos/GroundControl/Services/RelayProcess.swift
+++ b/macos/GroundControl/Services/RelayProcess.swift
@@ -240,8 +240,11 @@ final class RelayProcess {
     // MARK: - Output Handling
 
     /// Partial-line buffer per pipe (data may arrive mid-line).
-    private var stdoutBuffer = ""
-    private var stderrBuffer = ""
+    private var stdoutBuffer = Data()
+    private var stderrBuffer = Data()
+
+    /// Maximum buffer size before forcing a flush (256 KB).
+    private let maxBufferSize = 256 * 1024
 
     private func readPipeAsync(_ pipe: Pipe, label: String) {
         pipe.fileHandleForReading.readabilityHandler = { [weak self] handle in
@@ -249,16 +252,16 @@ final class RelayProcess {
             guard !data.isEmpty else {
                 // Flush any remaining partial-line buffer before removing the handler
                 if let self {
-                    let remainder: String
+                    let remainderData: Data
                     if label == "stdout" {
-                        remainder = self.stdoutBuffer
-                        self.stdoutBuffer = ""
+                        remainderData = self.stdoutBuffer
+                        self.stdoutBuffer = Data()
                     } else {
-                        remainder = self.stderrBuffer
-                        self.stderrBuffer = ""
+                        remainderData = self.stderrBuffer
+                        self.stderrBuffer = Data()
                     }
 
-                    if !remainder.isEmpty {
+                    if !remainderData.isEmpty, let remainder = String(data: remainderData, encoding: .utf8) {
                         DispatchQueue.main.async {
                             self.logStore.append(remainder)
                         }
@@ -267,47 +270,74 @@ final class RelayProcess {
                 handle.readabilityHandler = nil
                 return
             }
-            guard let self, let text = String(data: data, encoding: .utf8) else { return }
+            guard let self else { return }
 
-            // Buffer management — data may arrive as partial lines
-            let buffer: String
+            // Append incoming data to the buffer
             if label == "stdout" {
-                buffer = self.stdoutBuffer + text
+                self.stdoutBuffer.append(data)
             } else {
-                buffer = self.stderrBuffer + text
+                self.stderrBuffer.append(data)
             }
 
-            let lines = buffer.split(separator: "\n", omittingEmptySubsequences: false)
-
-            // If the chunk doesn't end with \n, the last element is a partial line — keep it
-            let hasTrailingNewline = text.hasSuffix("\n")
-            let completeLines: ArraySlice<Substring>
-            let remainder: String
-
-            if hasTrailingNewline {
-                completeLines = lines[...]
-                remainder = ""
-            } else {
-                completeLines = lines.dropLast()
-                remainder = String(lines.last ?? "")
-            }
-
+            let bufferRef: Data
             if label == "stdout" {
-                self.stdoutBuffer = remainder
+                bufferRef = self.stdoutBuffer
             } else {
-                self.stderrBuffer = remainder
+                bufferRef = self.stderrBuffer
             }
 
-            // Feed complete lines into LogStore on the main actor
-            let lineStrings = completeLines.compactMap { line -> String? in
-                let s = String(line)
-                return s.isEmpty ? nil : s
-            }
+            // Force flush if buffer exceeds max size
+            let forceFlush = bufferRef.count > self.maxBufferSize
 
-            if !lineStrings.isEmpty {
-                DispatchQueue.main.async {
-                    for line in lineStrings {
-                        self.logStore.append(line)
+            guard let bufferString = String(data: bufferRef, encoding: .utf8) else { return }
+
+            let newline = UInt8(ascii: "\n")
+            let hasTrailingNewline = bufferRef.last == newline
+
+            if !hasTrailingNewline && !forceFlush {
+                // Split into lines, keep the partial last line in the buffer
+                let lines = bufferString.split(separator: "\n", omittingEmptySubsequences: false)
+                if lines.count <= 1 {
+                    // No complete line yet, keep buffering
+                    return
+                }
+                let completeLines = lines.dropLast()
+                let remainder = String(lines.last ?? "")
+
+                if label == "stdout" {
+                    self.stdoutBuffer = Data(remainder.utf8)
+                } else {
+                    self.stderrBuffer = Data(remainder.utf8)
+                }
+
+                let lineStrings = completeLines.compactMap { line -> String? in
+                    let s = String(line)
+                    return s.isEmpty ? nil : s
+                }
+
+                if !lineStrings.isEmpty {
+                    DispatchQueue.main.async {
+                        for line in lineStrings {
+                            self.logStore.append(line)
+                        }
+                    }
+                }
+            } else {
+                // All data forms complete lines (or force flush)
+                if label == "stdout" {
+                    self.stdoutBuffer = Data()
+                } else {
+                    self.stderrBuffer = Data()
+                }
+
+                let lines = bufferString.split(separator: "\n", omittingEmptySubsequences: true)
+                let lineStrings = lines.map { String($0) }
+
+                if !lineStrings.isEmpty {
+                    DispatchQueue.main.async {
+                        for line in lineStrings {
+                            self.logStore.append(line)
+                        }
                     }
                 }
             }

--- a/macos/GroundControl/Views/DashboardView.swift
+++ b/macos/GroundControl/Views/DashboardView.swift
@@ -116,7 +116,6 @@ struct DashboardView: View {
                             .font(.title2)
                             .fontWeight(.semibold)
                             .monospacedDigit()
-                            .contentTransition(.numericText())
                         Text(clients.count == 1 ? "client connected" : "clients connected")
                             .foregroundStyle(.secondary)
                     }
@@ -173,7 +172,6 @@ struct DashboardView: View {
                             .font(.title2)
                             .fontWeight(.semibold)
                             .monospacedDigit()
-                            .contentTransition(.numericText())
                         Text(sessions.count == 1 ? "active session" : "active sessions")
                             .foregroundStyle(.secondary)
                     }

--- a/macos/GroundControl/Views/LogView.swift
+++ b/macos/GroundControl/Views/LogView.swift
@@ -9,7 +9,7 @@ struct LogView: View {
 
     @State private var autoScroll = true
     @State private var expandedEntries: Set<UUID> = []
-    private let prettyJSONCache = PrettyJSONCache()
+    @State private var prettyJSONCache = PrettyJSONCache()
 
     var body: some View {
         VStack(spacing: 0) {

--- a/macos/GroundControl/Views/LogView.swift
+++ b/macos/GroundControl/Views/LogView.swift
@@ -128,6 +128,9 @@ struct LogView: View {
                         proxy.scrollTo(lastEntry.id, anchor: .bottom)
                     }
                 }
+                // Prune cache to match LogStore's ring buffer — evict stale entries
+                let validIds = Set(logStore.entries.map(\.id))
+                prettyJSONCache.prune(keeping: validIds)
             }
             .onChange(of: autoScroll) {
                 if autoScroll, let lastEntry = logStore.filteredEntries.last {
@@ -143,6 +146,7 @@ struct LogView: View {
 // MARK: - Log Row
 
 /// Thread-safe cache for pretty-printed JSON strings keyed by log entry ID.
+/// Prunable: call `prune(keeping:)` when LogStore evicts old entries.
 final class PrettyJSONCache {
     private var cache: [UUID: String] = [:]
     private let lock = NSLock()
@@ -169,6 +173,13 @@ final class PrettyJSONCache {
         cache[id] = result
         lock.unlock()
         return result
+    }
+
+    /// Remove cached entries for IDs no longer in the log store.
+    func prune(keeping validIds: Set<UUID>) {
+        lock.lock()
+        cache = cache.filter { validIds.contains($0.key) }
+        lock.unlock()
     }
 
     func clear() {

--- a/macos/GroundControl/Views/LogView.swift
+++ b/macos/GroundControl/Views/LogView.swift
@@ -9,6 +9,7 @@ struct LogView: View {
 
     @State private var autoScroll = true
     @State private var expandedEntries: Set<UUID> = []
+    private let prettyJSONCache = PrettyJSONCache()
 
     var body: some View {
         VStack(spacing: 0) {
@@ -56,6 +57,7 @@ struct LogView: View {
                 Button {
                     logStore.clear()
                     expandedEntries.removeAll()
+                    prettyJSONCache.clear()
                 } label: {
                     Image(systemName: "trash")
                         .font(.caption)
@@ -98,23 +100,27 @@ struct LogView: View {
     @ViewBuilder
     private var logList: some View {
         ScrollViewReader { proxy in
-            List(logStore.filteredEntries) { entry in
-                LogRowView(
-                    entry: entry,
-                    isExpanded: expandedEntries.contains(entry.id),
-                    onToggleExpand: {
-                        if expandedEntries.contains(entry.id) {
-                            expandedEntries.remove(entry.id)
-                        } else {
-                            expandedEntries.insert(entry.id)
-                        }
+            ScrollView {
+                LazyVStack(alignment: .leading, spacing: 0) {
+                    ForEach(logStore.filteredEntries) { entry in
+                        LogRowView(
+                            entry: entry,
+                            isExpanded: expandedEntries.contains(entry.id),
+                            prettyJSONCache: prettyJSONCache,
+                            onToggleExpand: {
+                                if expandedEntries.contains(entry.id) {
+                                    expandedEntries.remove(entry.id)
+                                } else {
+                                    expandedEntries.insert(entry.id)
+                                }
+                            }
+                        )
+                        .id(entry.id)
+                        .padding(.horizontal, 8)
+                        .padding(.vertical, 1)
                     }
-                )
-                .id(entry.id)
-                .listRowSeparator(.hidden)
-                .listRowInsets(EdgeInsets(top: 1, leading: 8, bottom: 1, trailing: 8))
+                }
             }
-            .listStyle(.plain)
             .font(.system(.body, design: .monospaced))
             .onChange(of: logStore.filteredEntries.count) {
                 if autoScroll, let lastEntry = logStore.filteredEntries.last {
@@ -124,7 +130,6 @@ struct LogView: View {
                 }
             }
             .onChange(of: autoScroll) {
-                // When user re-enables auto-scroll, jump to bottom immediately
                 if autoScroll, let lastEntry = logStore.filteredEntries.last {
                     withAnimation(.easeOut(duration: 0.1)) {
                         proxy.scrollTo(lastEntry.id, anchor: .bottom)
@@ -137,10 +142,47 @@ struct LogView: View {
 
 // MARK: - Log Row
 
+/// Thread-safe cache for pretty-printed JSON strings keyed by log entry ID.
+final class PrettyJSONCache {
+    private var cache: [UUID: String] = [:]
+    private let lock = NSLock()
+
+    func get(_ id: UUID, rawJSON: String) -> String {
+        lock.lock()
+        if let cached = cache[id] {
+            lock.unlock()
+            return cached
+        }
+        lock.unlock()
+
+        let result: String
+        if let data = rawJSON.data(using: .utf8),
+           let json = try? JSONSerialization.jsonObject(with: data),
+           let pretty = try? JSONSerialization.data(withJSONObject: json, options: [.prettyPrinted, .sortedKeys]),
+           let str = String(data: pretty, encoding: .utf8) {
+            result = str
+        } else {
+            result = rawJSON
+        }
+
+        lock.lock()
+        cache[id] = result
+        lock.unlock()
+        return result
+    }
+
+    func clear() {
+        lock.lock()
+        cache.removeAll()
+        lock.unlock()
+    }
+}
+
 /// A single log entry row with timestamp, level badge, message, and expandable JSON.
 private struct LogRowView: View {
     let entry: LogEntry
     let isExpanded: Bool
+    let prettyJSONCache: PrettyJSONCache
     let onToggleExpand: () -> Void
 
     private static let timeFormatter: DateFormatter = {
@@ -201,14 +243,7 @@ private struct LogRowView: View {
     }
 
     private var prettyJSON: String {
-        guard let data = entry.rawJSON.data(using: .utf8),
-              let json = try? JSONSerialization.jsonObject(with: data),
-              let pretty = try? JSONSerialization.data(withJSONObject: json, options: [.prettyPrinted, .sortedKeys]),
-              let str = String(data: pretty, encoding: .utf8)
-        else {
-            return entry.rawJSON
-        }
-        return str
+        prettyJSONCache.get(entry.id, rawJSON: entry.rawJSON)
     }
 }
 


### PR DESCRIPTION
## Summary

- **Ground Control (macOS):** LogView virtualization (LazyVStack + PrettyJSON cache), RelayProcess Data-based pipe buffers with 256KB flush limit, DashboardView poll debounce (10s interval + change-detection guards), RelayClient URLSession deinit cleanup
- **SwiftTerm (iOS):** Task tracking/cancellation for toast, Live Activity, keybar, and relay tasks; WKWebView configuration retain cycle break; LiveActivity snapshot pruning; Watch connectivity 500ms debounce
- **Terminal keyboard fix:** `ws.send(string)` was sending text frames — relay rejected as invalid control JSON. Now encodes with `TextEncoder` for proper binary PTY frames

## Test plan

- [x] iOS build passes (iPhone 17 Pro simulator)
- [x] macOS build passes (`swift build` in macos/)
- [x] PIN auth flow end-to-end
- [x] Terminal connects, keyboard input works (binary frame fix verified)
- [x] App kill + relaunch — clean reconnect, no stale state
- [x] Relay logs clean — zero errors during operation
- [ ] Tab switching stress test (20x) — manual
- [ ] Device rotation — manual
- [ ] Copy/paste mode — manual
- [ ] Heavy output memory stability — manual

🤖 Generated with [Claude Code](https://claude.com/claude-code)