### PR TITLE
feat(ground-control): hardening — auto-restart + managed tunnel

### DIFF
--- a/macos/GroundControl/App/GroundControlApp.swift
+++ b/macos/GroundControl/App/GroundControlApp.swift
@@ -83,6 +83,7 @@ struct GroundControlApp: App {
     /// - Green: relay running
     /// - Red: relay error
     /// - Yellow: starting/stopping
+    /// - Orange: restarting (auto-recovery pending)
     /// - Gray (no overlay): relay stopped
     @ViewBuilder
     private var menuBarLabel: some View {
@@ -99,6 +100,10 @@ struct GroundControlApp: App {
             Image(systemName: "antenna.radiowaves.left.and.right")
                 .symbolRenderingMode(.palette)
                 .foregroundStyle(.yellow, .primary)
+        case .restarting:
+            Image(systemName: "antenna.radiowaves.left.and.right")
+                .symbolRenderingMode(.palette)
+                .foregroundStyle(.orange, .primary)
         case .idle:
             Image(systemName: "antenna.radiowaves.left.and.right")
         }

--- a/macos/GroundControl/Models/RelayConfig.swift
+++ b/macos/GroundControl/Models/RelayConfig.swift
@@ -36,7 +36,7 @@ enum LogLevel: String, Codable, CaseIterable, Identifiable {
 ///
 /// Persisted to `~/.major-tom/config.json`. Secrets (OAuth credentials,
 /// Cloudflare token) are NOT stored here — they live in macOS Keychain.
-struct RelayConfig: Codable, Equatable {
+struct RelayConfig: Equatable {
     var port: Int
     var hookPort: Int
     var authMode: AuthMode
@@ -44,6 +44,10 @@ struct RelayConfig: Codable, Equatable {
     var claudeWorkDir: String
     var logLevel: LogLevel
     var cloudflareEnabled: Bool
+    /// Optional display-only tunnel name (e.g., "major-tom") shown in the UI.
+    /// `cloudflared tunnel run --token <token>` picks the tunnel from the token
+    /// itself, so this field is informational.
+    var cloudflareTunnelName: String
     var autoStart: Bool
 
     /// Sensible defaults for a fresh install.
@@ -55,6 +59,7 @@ struct RelayConfig: Codable, Equatable {
         claudeWorkDir: "~",
         logLevel: .info,
         cloudflareEnabled: false,
+        cloudflareTunnelName: "",
         autoStart: true
     )
 
@@ -95,5 +100,42 @@ struct RelayConfig: Codable, Equatable {
             return (claudeWorkDir as NSString).expandingTildeInPath
         }
         return claudeWorkDir
+    }
+}
+
+// MARK: - Codable
+
+/// Hand-rolled Codable so newly-added fields backfill from older on-disk
+/// configs instead of failing to decode.
+extension RelayConfig: Codable {
+    private enum CodingKeys: String, CodingKey {
+        case port, hookPort, authMode, multiUserEnabled, claudeWorkDir
+        case logLevel, cloudflareEnabled, cloudflareTunnelName, autoStart
+    }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        self.port = try c.decode(Int.self, forKey: .port)
+        self.hookPort = try c.decode(Int.self, forKey: .hookPort)
+        self.authMode = try c.decode(AuthMode.self, forKey: .authMode)
+        self.multiUserEnabled = try c.decode(Bool.self, forKey: .multiUserEnabled)
+        self.claudeWorkDir = try c.decode(String.self, forKey: .claudeWorkDir)
+        self.logLevel = try c.decode(LogLevel.self, forKey: .logLevel)
+        self.cloudflareEnabled = try c.decode(Bool.self, forKey: .cloudflareEnabled)
+        self.cloudflareTunnelName = try c.decodeIfPresent(String.self, forKey: .cloudflareTunnelName) ?? ""
+        self.autoStart = try c.decode(Bool.self, forKey: .autoStart)
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var c = encoder.container(keyedBy: CodingKeys.self)
+        try c.encode(port, forKey: .port)
+        try c.encode(hookPort, forKey: .hookPort)
+        try c.encode(authMode, forKey: .authMode)
+        try c.encode(multiUserEnabled, forKey: .multiUserEnabled)
+        try c.encode(claudeWorkDir, forKey: .claudeWorkDir)
+        try c.encode(logLevel, forKey: .logLevel)
+        try c.encode(cloudflareEnabled, forKey: .cloudflareEnabled)
+        try c.encode(cloudflareTunnelName, forKey: .cloudflareTunnelName)
+        try c.encode(autoStart, forKey: .autoStart)
     }
 }

--- a/macos/GroundControl/Models/RelayState.swift
+++ b/macos/GroundControl/Models/RelayState.swift
@@ -10,6 +10,8 @@ final class RelayState {
         case running
         case stopping
         case error(String)
+        /// Relay crashed and is waiting to auto-restart. `attempt` is 1-based.
+        case restarting(attempt: Int)
     }
 
     var processState: ProcessState = .idle
@@ -17,10 +19,22 @@ final class RelayState {
     var hookPort: Int = 9091
     var clientCount: Int = 0
 
+    /// Total number of auto-restart attempts since the last successful long-lived run.
+    /// Reset to 0 when the process stays up past the "healthy" window.
+    var restartCount: Int = 0
+
+    /// Timestamp of the last auto-restart attempt (nil if never restarted this session).
+    var lastRestartAt: Date?
+
     // MARK: - Computed Properties
 
     var isRunning: Bool {
         processState == .running
+    }
+
+    var isRestarting: Bool {
+        if case .restarting = processState { return true }
+        return false
     }
 
     var canStart: Bool {
@@ -28,12 +42,20 @@ final class RelayState {
         case .idle, .error:
             return true
         default:
+            // While restarting, starting is a no-op (auto-restart timer is pending).
+            // Users can `stop()` to cancel the retry.
             return false
         }
     }
 
     var canStop: Bool {
-        processState == .running
+        switch processState {
+        case .running, .restarting:
+            // Allow stop during auto-restart wait so the user can cancel the retry.
+            return true
+        default:
+            return false
+        }
     }
 
     var statusText: String {
@@ -48,6 +70,8 @@ final class RelayState {
             return "Relay Stopping..."
         case .error(let message):
             return "Error: \(message)"
+        case .restarting(let attempt):
+            return "Relay Restarting (attempt \(attempt)/5)..."
         }
     }
 
@@ -55,7 +79,7 @@ final class RelayState {
         switch processState {
         case .idle, .stopping:
             return "gray"
-        case .starting:
+        case .starting, .restarting:
             return "yellow"
         case .running:
             return "green"

--- a/macos/GroundControl/Models/RelayState.swift
+++ b/macos/GroundControl/Models/RelayState.swift
@@ -42,8 +42,11 @@ final class RelayState {
         case .idle, .error:
             return true
         default:
-            // While restarting, starting is a no-op (auto-restart timer is pending).
-            // Users can `stop()` to cancel the retry.
+            // `canStart` excludes `.restarting` so button-driven callers see
+            // "already starting" — but `RelayProcess.start()` has an internal
+            // `|| isRestarting` escape that lets a manual start cancel the
+            // pending auto-restart and launch immediately. Same applies to
+            // the transitional states .starting / .running / .stopping.
             return false
         }
     }

--- a/macos/GroundControl/Services/RelayProcess.swift
+++ b/macos/GroundControl/Services/RelayProcess.swift
@@ -15,6 +15,10 @@ final class RelayProcess {
     /// Config manager providing relay settings and Keychain secrets.
     let configManager: ConfigManager
 
+    /// Cloudflare tunnel child process. Shares this RelayProcess's LogStore so
+    /// tunnel stdout/stderr shows up in the same log viewer.
+    let tunnel: TunnelProcess
+
     private var process: Process?
     private var stdoutPipe: Pipe?
     private var stderrPipe: Pipe?
@@ -23,10 +27,43 @@ final class RelayProcess {
     /// Grace period before SIGKILL after SIGTERM (seconds).
     private let shutdownTimeout: TimeInterval = 5.0
 
+    // MARK: - Auto-Restart State
+
+    /// When the current process was launched. Used to decide whether a run was
+    /// "healthy" (stayed alive past the reset threshold) before crashing.
+    private var lastSuccessfulStart: Date?
+
+    /// Pending auto-restart task, if one is scheduled. Cancelled when the user
+    /// calls `stop()` or manually starts the relay.
+    private var pendingRestartTask: Task<Void, Never>?
+
+    /// Max consecutive auto-restart attempts before giving up with an error.
+    private let maxRestartAttempts = 5
+
+    /// A run that stays alive longer than this is considered healthy and resets
+    /// the restart counter on the next crash.
+    private let healthyRunThreshold: TimeInterval = 30.0
+
+    /// Upper bound on backoff delay (seconds).
+    private let maxRestartDelay: TimeInterval = 30.0
+
+    // MARK: - Health Monitoring
+
+    /// Periodic /health probe task. Kills the relay if it becomes unresponsive.
+    private var healthMonitorTask: Task<Void, Never>?
+
+    /// How often to hit /health while the relay is running.
+    private let healthCheckInterval: TimeInterval = 30.0
+
+    /// Number of consecutive failures allowed before we treat the process as a
+    /// zombie and send SIGTERM (which triggers the normal auto-restart path).
+    private let healthCheckFailureThreshold = 3
+
     // MARK: - Init
 
     init(configManager: ConfigManager = ConfigManager()) {
         self.configManager = configManager
+        self.tunnel = TunnelProcess(logStore: logStore)
         // Sync RelayState ports from config
         self.state.port = configManager.config.port
         self.state.hookPort = configManager.config.hookPort
@@ -35,7 +72,12 @@ final class RelayProcess {
     // MARK: - Lifecycle
 
     func start() async {
-        guard state.canStart else { return }
+        // Starting manually cancels any pending auto-restart.
+        pendingRestartTask?.cancel()
+        pendingRestartTask = nil
+
+        // Allow starting from .idle, .error, or an in-flight .restarting wait.
+        guard state.canStart || state.isRestarting else { return }
 
         state.processState = .starting
 
@@ -55,19 +97,103 @@ final class RelayProcess {
 
             try launchProcess(paths: paths)
             state.processState = .running
+            lastSuccessfulStart = Date()
 
             if paths.isDevelopment {
                 print("[GroundControl] Running in DEVELOPMENT mode")
                 print("[GroundControl] Node: \(paths.nodeBinary.path)")
                 print("[GroundControl] Relay: \(paths.relayEntry.path)")
             }
+
+            // Kick off the tunnel (best-effort, in the background) once the
+            // relay is confirmed listening. We don't block `start()` on this
+            // since the UI should show "Running" as soon as the process is up.
+            Task { [weak self] in
+                await self?.startTunnelIfConfigured()
+            }
+
+            // Start the zombie-process health monitor.
+            startHealthMonitor()
         } catch {
             state.processState = .error(error.localizedDescription)
         }
     }
 
+    /// Wait for the relay's `/health` endpoint to return 200, then start the
+    /// Cloudflare tunnel if it is enabled in config and has a token.
+    private func startTunnelIfConfigured() async {
+        guard configManager.config.cloudflareEnabled else { return }
+
+        // Wait for the relay to actually be listening before bringing up the
+        // tunnel — otherwise cloudflared will open with a broken origin.
+        let ready = await waitForRelayReady(timeout: 15.0)
+        guard ready else {
+            appendGroundControlLog(
+                level: .warn,
+                message: "Relay port \(state.port) not ready — skipping tunnel start"
+            )
+            return
+        }
+
+        guard let token = configManager.getSecret(ConfigManager.SecretKey.cloudflareToken),
+              !token.isEmpty else {
+            appendGroundControlLog(
+                level: .warn,
+                message: "Cloudflare tunnel enabled but no token in Keychain — skipping"
+            )
+            return
+        }
+
+        await tunnel.start(token: token)
+    }
+
+    /// Poll `http://127.0.0.1:<port>/health` every 500ms until it returns 200
+    /// or the timeout elapses. Used both for tunnel-start gating and (future)
+    /// zombie-process health monitoring.
+    func waitForRelayReady(timeout: TimeInterval = 15.0) async -> Bool {
+        let deadline = Date().addingTimeInterval(timeout)
+        let url = URL(string: "http://127.0.0.1:\(state.port)/health")!
+        var request = URLRequest(url: url)
+        request.timeoutInterval = 2.0
+        request.cachePolicy = .reloadIgnoringLocalAndRemoteCacheData
+
+        while Date() < deadline {
+            if Task.isCancelled { return false }
+            do {
+                let (_, response) = try await URLSession.shared.data(for: request)
+                if let http = response as? HTTPURLResponse, http.statusCode == 200 {
+                    return true
+                }
+            } catch {
+                // Not ready yet — keep polling.
+            }
+            try? await Task.sleep(for: .milliseconds(500))
+        }
+        return false
+    }
+
     func stop() async {
-        guard state.canStop, let proc = process else { return }
+        guard state.canStop else { return }
+
+        // Stop the zombie monitor — we don't want it killing the relay during
+        // a graceful shutdown.
+        stopHealthMonitor()
+
+        // Stopping cancels any pending auto-restart and resets the counter.
+        pendingRestartTask?.cancel()
+        pendingRestartTask = nil
+        state.restartCount = 0
+        state.lastRestartAt = nil
+
+        // Tear down the tunnel first so cloudflared doesn't thrash
+        // reconnecting to a dying origin.
+        await tunnel.stop()
+
+        // If we were only in .restarting (no live process), just go idle.
+        guard let proc = process else {
+            state.processState = .idle
+            return
+        }
 
         state.processState = .stopping
 
@@ -94,6 +220,9 @@ final class RelayProcess {
         await stop()
         // Brief pause to let the port release
         try? await Task.sleep(for: .milliseconds(500))
+        // Manual restart — clear any carryover auto-restart state.
+        state.restartCount = 0
+        state.lastRestartAt = nil
         await start()
     }
 
@@ -182,19 +311,183 @@ final class RelayProcess {
 
         let status = proc.terminationStatus
 
+        // Any termination ends the old health monitor — the next start() will
+        // spawn a fresh one if we auto-restart.
+        stopHealthMonitor()
+
         // If we're in .stopping state, this is expected — stop() handles the cleanup
         if state.processState == .stopping { return }
 
-        // Unexpected termination
-        if status != 0 {
-            state.processState = .error("Process exited with code \(status)")
-            print("[GroundControl] Relay exited unexpectedly (code: \(status))")
-        } else {
-            state.processState = .idle
-            print("[GroundControl] Relay exited cleanly")
+        // If the last run was "healthy" (stayed alive past the threshold),
+        // reset the restart counter before evaluating the next attempt.
+        if let started = lastSuccessfulStart,
+           Date().timeIntervalSince(started) > healthyRunThreshold {
+            state.restartCount = 0
         }
 
+        // Clean exit — go idle, clear restart state.
+        if status == 0 {
+            state.processState = .idle
+            state.restartCount = 0
+            state.lastRestartAt = nil
+            print("[GroundControl] Relay exited cleanly")
+            cleanup()
+            return
+        }
+
+        // Unexpected crash — try to auto-restart if we're under the cap.
+        print("[GroundControl] Relay exited unexpectedly (code: \(status))")
         cleanup()
+
+        if state.restartCount >= maxRestartAttempts {
+            let msg = "Relay crashed \(maxRestartAttempts) times — check logs"
+            state.processState = .error(msg)
+            appendGroundControlLog(level: .error, message: msg)
+            return
+        }
+
+        scheduleAutoRestart(previousExitCode: status)
+    }
+
+    /// Compute exponential backoff delay for attempt `n` (1-based):
+    /// 1s → 2s → 4s → 8s → 16s (capped at `maxRestartDelay`).
+    private func backoffDelay(forAttempt attempt: Int) -> TimeInterval {
+        let exponent = max(0, attempt - 1)
+        let raw = pow(2.0, Double(exponent))
+        return min(raw, maxRestartDelay)
+    }
+
+    /// Schedule an auto-restart task with exponential backoff. Cancellable via
+    /// `pendingRestartTask?.cancel()` (called from stop()/start()).
+    private func scheduleAutoRestart(previousExitCode: Int32) {
+        let nextAttempt = state.restartCount + 1
+        let delay = backoffDelay(forAttempt: nextAttempt)
+
+        state.restartCount = nextAttempt
+        state.lastRestartAt = Date()
+        state.processState = .restarting(attempt: nextAttempt)
+
+        let message = "Relay crashed (exit \(previousExitCode)) — restarting in \(Int(delay))s (attempt \(nextAttempt)/\(maxRestartAttempts))"
+        print("[GroundControl] \(message)")
+        appendGroundControlLog(level: .warn, message: message)
+
+        pendingRestartTask?.cancel()
+        pendingRestartTask = Task { [weak self] in
+            try? await Task.sleep(for: .seconds(delay))
+            guard !Task.isCancelled else { return }
+            guard let self else { return }
+            // Only proceed if we're still waiting for this restart. A user
+            // could have called stop() during the sleep, which cancels this
+            // Task — but check defensively in case state changed otherwise.
+            let stillRestarting = await MainActor.run { self.state.isRestarting }
+            guard stillRestarting else { return }
+            await self.start()
+        }
+    }
+
+    // MARK: - Zombie Health Monitor
+
+    /// Start a periodic task that polls /health. After `healthCheckFailureThreshold`
+    /// consecutive failures, sends SIGTERM to the relay — the termination
+    /// observer then routes through the normal auto-restart path.
+    private func startHealthMonitor() {
+        stopHealthMonitor()
+        healthMonitorTask = Task { [weak self] in
+            var consecutiveFailures = 0
+
+            while !Task.isCancelled {
+                // Sleep first so the initial startup has time to bind the port
+                // before we start counting failures.
+                try? await Task.sleep(for: .seconds(self?.healthCheckInterval ?? 30.0))
+                guard !Task.isCancelled, let self else { return }
+
+                // Only probe when the relay is in the running state — if we're
+                // already mid-restart or shutting down, skip.
+                let running = await MainActor.run { self.state.processState == .running }
+                guard running else { continue }
+
+                let ok = await self.probeHealth()
+                if ok {
+                    consecutiveFailures = 0
+                } else {
+                    consecutiveFailures += 1
+                    let failureCount = consecutiveFailures
+                    let threshold = self.healthCheckFailureThreshold
+                    await MainActor.run {
+                        self.appendGroundControlLog(
+                            level: .warn,
+                            message: "Relay health check failed (\(failureCount)/\(threshold))"
+                        )
+                    }
+
+                    if failureCount >= threshold {
+                        await MainActor.run {
+                            self.appendGroundControlLog(
+                                level: .error,
+                                message: "Relay unresponsive — sending SIGTERM to trigger auto-restart"
+                            )
+                            self.killUnresponsiveRelay()
+                        }
+                        return // Task exits; next start() will spawn a new one.
+                    }
+                }
+            }
+        }
+    }
+
+    /// Cancel the periodic health monitor task (called from stop()).
+    private func stopHealthMonitor() {
+        healthMonitorTask?.cancel()
+        healthMonitorTask = nil
+    }
+
+    /// Signal an unresponsive relay. We deliberately do NOT set state to
+    /// .stopping — we want handleTermination to treat this as an unexpected
+    /// crash and kick off auto-restart.
+    private func killUnresponsiveRelay() {
+        guard let proc = process, proc.isRunning else { return }
+        kill(proc.processIdentifier, SIGTERM)
+        // Give the relay 2s to respond to SIGTERM, then escalate to SIGKILL.
+        Task { [weak self] in
+            try? await Task.sleep(for: .seconds(2))
+            guard let self, let proc = self.process, proc.isRunning else { return }
+            kill(proc.processIdentifier, SIGKILL)
+        }
+    }
+
+    /// One-shot /health probe. Returns true on HTTP 200.
+    private func probeHealth() async -> Bool {
+        let port = await MainActor.run { self.state.port }
+        guard let url = URL(string: "http://127.0.0.1:\(port)/health") else { return false }
+        var request = URLRequest(url: url)
+        request.timeoutInterval = 5.0
+        request.cachePolicy = .reloadIgnoringLocalAndRemoteCacheData
+
+        do {
+            let (_, response) = try await URLSession.shared.data(for: request)
+            if let http = response as? HTTPURLResponse, http.statusCode == 200 {
+                return true
+            }
+            return false
+        } catch {
+            return false
+        }
+    }
+
+    /// Emit a synthesized pino-style log line so internal GroundControl events
+    /// (restarts, tunnel lifecycle, etc.) show up in the LogStore with the
+    /// right level and color.
+    private func appendGroundControlLog(level: LogEntry.LogLevel, message: String) {
+        let timeMs = Int(Date().timeIntervalSince1970 * 1000)
+        // Escape message for JSON embedding — cover the characters that matter
+        // for a one-line status string (no newlines expected in our messages).
+        let escaped = message
+            .replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "\"", with: "\\\"")
+        let line = "{\"level\":\(level.rawValue),\"time\":\(timeMs),\"name\":\"ground-control\",\"msg\":\"\(escaped)\"}"
+        DispatchQueue.main.async { [weak self] in
+            self?.logStore.append(line)
+        }
     }
 
     private func cleanup() {
@@ -388,6 +681,8 @@ final class RelayProcess {
 
     deinit {
         // Best-effort cleanup if the object is destroyed while running
+        pendingRestartTask?.cancel()
+        healthMonitorTask?.cancel()
         if let proc = process, proc.isRunning {
             kill(proc.processIdentifier, SIGTERM)
         }

--- a/macos/GroundControl/Services/RelayProcess.swift
+++ b/macos/GroundControl/Services/RelayProcess.swift
@@ -43,6 +43,11 @@ final class RelayProcess {
     /// calls `stop()` or manually starts the relay.
     private var pendingRestartTask: Task<Void, Never>?
 
+    /// Fire-and-forget task that waits for /health then starts the tunnel.
+    /// Cancelled on `stop()` so a user who aborts during the wait doesn't
+    /// end up with a tunnel pointing at a dead relay.
+    private var tunnelStartupTask: Task<Void, Never>?
+
     /// Max consecutive auto-restart attempts before giving up with an error.
     private let maxRestartAttempts = 5
 
@@ -115,7 +120,9 @@ final class RelayProcess {
             // Kick off the tunnel (best-effort, in the background) once the
             // relay is confirmed listening. We don't block `start()` on this
             // since the UI should show "Running" as soon as the process is up.
-            Task { [weak self] in
+            // Stored so `stop()` can cancel an in-flight /health wait.
+            tunnelStartupTask?.cancel()
+            tunnelStartupTask = Task { @MainActor [weak self] in
                 await self?.startTunnelIfConfigured()
             }
 
@@ -135,6 +142,13 @@ final class RelayProcess {
         // Wait for the relay to actually be listening before bringing up the
         // tunnel — otherwise cloudflared will open with a broken origin.
         let ready = await waitForRelayReady(timeout: 15.0)
+
+        // Bail if the user stopped the relay (or this task was cancelled)
+        // while we were polling /health — don't leave cloudflared pointing
+        // at a dead origin.
+        if Task.isCancelled { return }
+        guard state.processState == .running else { return }
+
         guard ready else {
             appendGroundControlLog(
                 level: .warn,
@@ -191,6 +205,11 @@ final class RelayProcess {
         // Stop the zombie monitor — we don't want it killing the relay during
         // a graceful shutdown.
         stopHealthMonitor()
+
+        // Cancel any in-flight tunnel startup wait so it can't race with
+        // stop() and bring up cloudflared against the dying origin.
+        tunnelStartupTask?.cancel()
+        tunnelStartupTask = nil
 
         // Stopping cancels any pending auto-restart and resets the counter.
         pendingRestartTask?.cancel()
@@ -480,15 +499,19 @@ final class RelayProcess {
         let signaledPID = proc.processIdentifier
         kill(signaledPID, SIGTERM)
 
+        // Hop back to MainActor before reading `self.process` so we don't
+        // race with start/stop/cleanup on lifecycle state.
         Task { [weak self, weak signaledProcess] in
             try? await Task.sleep(for: .seconds(2))
-            guard let self,
-                  let signaledProcess,
-                  let currentProcess = self.process,
-                  currentProcess === signaledProcess,
-                  currentProcess.isRunning
-            else { return }
-            kill(signaledPID, SIGKILL)
+            await MainActor.run {
+                guard let self,
+                      let signaledProcess,
+                      let currentProcess = self.process,
+                      currentProcess === signaledProcess,
+                      currentProcess.isRunning
+                else { return }
+                kill(signaledPID, SIGKILL)
+            }
         }
     }
 
@@ -720,6 +743,7 @@ final class RelayProcess {
         // Best-effort cleanup if the object is destroyed while running
         pendingRestartTask?.cancel()
         healthMonitorTask?.cancel()
+        tunnelStartupTask?.cancel()
         if let proc = process, proc.isRunning {
             kill(proc.processIdentifier, SIGTERM)
         }

--- a/macos/GroundControl/Services/RelayProcess.swift
+++ b/macos/GroundControl/Services/RelayProcess.swift
@@ -5,6 +5,12 @@ import Foundation
 ///
 /// Spawns `node server.js` with the bundled (or system) Node binary,
 /// handles graceful shutdown via SIGTERM, and tracks process state.
+///
+/// All lifecycle methods (`start`, `stop`, `restart`) and the termination/
+/// restart handlers are pinned to `@MainActor` so that mutations to the
+/// `@Observable` state don't race with SwiftUI observation. The pipe reader
+/// stays non-isolated because `FileHandle.readabilityHandler` fires on a
+/// background dispatch thread.
 @Observable
 final class RelayProcess {
     private(set) var state = RelayState()
@@ -71,6 +77,7 @@ final class RelayProcess {
 
     // MARK: - Lifecycle
 
+    @MainActor
     func start() async {
         // Starting manually cancels any pending auto-restart.
         pendingRestartTask?.cancel()
@@ -121,6 +128,7 @@ final class RelayProcess {
 
     /// Wait for the relay's `/health` endpoint to return 200, then start the
     /// Cloudflare tunnel if it is enabled in config and has a token.
+    @MainActor
     private func startTunnelIfConfigured() async {
         guard configManager.config.cloudflareEnabled else { return }
 
@@ -152,7 +160,11 @@ final class RelayProcess {
     /// zombie-process health monitoring.
     func waitForRelayReady(timeout: TimeInterval = 15.0) async -> Bool {
         let deadline = Date().addingTimeInterval(timeout)
-        let url = URL(string: "http://127.0.0.1:\(state.port)/health")!
+        // Guard against a malformed/hand-edited port value in config.json. An
+        // invalid port would force-unwrap-crash the app; instead just bail.
+        guard let url = URL(string: "http://127.0.0.1:\(state.port)/health") else {
+            return false
+        }
         var request = URLRequest(url: url)
         request.timeoutInterval = 2.0
         request.cachePolicy = .reloadIgnoringLocalAndRemoteCacheData
@@ -172,6 +184,7 @@ final class RelayProcess {
         return false
     }
 
+    @MainActor
     func stop() async {
         guard state.canStop else { return }
 
@@ -216,6 +229,7 @@ final class RelayProcess {
         state.processState = .idle
     }
 
+    @MainActor
     func restart() async {
         await stop()
         // Brief pause to let the port release
@@ -288,13 +302,17 @@ final class RelayProcess {
         readPipeAsync(stdout, label: "stdout")
         readPipeAsync(stderr, label: "stderr")
 
-        // Watch for unexpected termination
+        // Watch for unexpected termination. The block runs on the main queue
+        // but the observer API hands us a @Sendable closure, so hop through
+        // an explicit main-actor Task before touching @MainActor state.
         terminationObserver = NotificationCenter.default.addObserver(
             forName: Process.didTerminateNotification,
             object: proc,
             queue: .main
         ) { [weak self] _ in
-            self?.handleTermination()
+            Task { @MainActor [weak self] in
+                self?.handleTermination()
+            }
         }
 
         try proc.run()
@@ -306,6 +324,7 @@ final class RelayProcess {
         print("[GroundControl] Relay started (PID: \(proc.processIdentifier)) on port \(state.port)")
     }
 
+    @MainActor
     private func handleTermination() {
         guard let proc = process else { return }
 
@@ -359,6 +378,7 @@ final class RelayProcess {
 
     /// Schedule an auto-restart task with exponential backoff. Cancellable via
     /// `pendingRestartTask?.cancel()` (called from stop()/start()).
+    @MainActor
     private func scheduleAutoRestart(previousExitCode: Int32) {
         let nextAttempt = state.restartCount + 1
         let delay = backoffDelay(forAttempt: nextAttempt)
@@ -372,15 +392,18 @@ final class RelayProcess {
         appendGroundControlLog(level: .warn, message: message)
 
         pendingRestartTask?.cancel()
-        pendingRestartTask = Task { [weak self] in
+        // Run the restart body on the main actor so state mutations in
+        // start()/launchProcess() observe the MainActor isolation expected by
+        // an @Observable class. Without @MainActor, mutating state.* from an
+        // unstructured Task can race with SwiftUI's observation bookkeeping.
+        pendingRestartTask = Task { @MainActor [weak self] in
             try? await Task.sleep(for: .seconds(delay))
             guard !Task.isCancelled else { return }
             guard let self else { return }
-            // Only proceed if we're still waiting for this restart. A user
-            // could have called stop() during the sleep, which cancels this
-            // Task — but check defensively in case state changed otherwise.
-            let stillRestarting = await MainActor.run { self.state.isRestarting }
-            guard stillRestarting else { return }
+            // Only proceed if we're still waiting for this restart. stop()
+            // cancels this Task during its sleep; this guard catches any
+            // other state transition that raced with us.
+            guard self.state.isRestarting else { return }
             await self.start()
         }
     }
@@ -390,6 +413,7 @@ final class RelayProcess {
     /// Start a periodic task that polls /health. After `healthCheckFailureThreshold`
     /// consecutive failures, sends SIGTERM to the relay — the termination
     /// observer then routes through the normal auto-restart path.
+    @MainActor
     private func startHealthMonitor() {
         stopHealthMonitor()
         healthMonitorTask = Task { [weak self] in
@@ -436,6 +460,7 @@ final class RelayProcess {
     }
 
     /// Cancel the periodic health monitor task (called from stop()).
+    @MainActor
     private func stopHealthMonitor() {
         healthMonitorTask?.cancel()
         healthMonitorTask = nil
@@ -444,14 +469,26 @@ final class RelayProcess {
     /// Signal an unresponsive relay. We deliberately do NOT set state to
     /// .stopping — we want handleTermination to treat this as an unexpected
     /// crash and kick off auto-restart.
+    @MainActor
     private func killUnresponsiveRelay() {
         guard let proc = process, proc.isRunning else { return }
-        kill(proc.processIdentifier, SIGTERM)
-        // Give the relay 2s to respond to SIGTERM, then escalate to SIGKILL.
-        Task { [weak self] in
+
+        // Capture the exact process we just SIGTERM'd. After the 2s delay the
+        // auto-restart path may have spawned a new child — we must not escalate
+        // SIGKILL against the replacement.
+        let signaledProcess = proc
+        let signaledPID = proc.processIdentifier
+        kill(signaledPID, SIGTERM)
+
+        Task { [weak self, weak signaledProcess] in
             try? await Task.sleep(for: .seconds(2))
-            guard let self, let proc = self.process, proc.isRunning else { return }
-            kill(proc.processIdentifier, SIGKILL)
+            guard let self,
+                  let signaledProcess,
+                  let currentProcess = self.process,
+                  currentProcess === signaledProcess,
+                  currentProcess.isRunning
+            else { return }
+            kill(signaledPID, SIGKILL)
         }
     }
 

--- a/macos/GroundControl/Services/TunnelProcess.swift
+++ b/macos/GroundControl/Services/TunnelProcess.swift
@@ -1,0 +1,401 @@
+@preconcurrency import Dispatch
+import Foundation
+
+/// Manages the `cloudflared` tunnel as a child process.
+///
+/// Spawns `cloudflared tunnel --no-autoupdate run --token <token>` alongside
+/// the relay and tracks lifecycle. Auto-restarts on unexpected termination
+/// using the same exponential-backoff strategy as `RelayProcess`, and pipes
+/// stdout/stderr into the shared `LogStore` so tunnel events appear in the
+/// Ground Control log viewer.
+@Observable
+final class TunnelProcess {
+    /// Tunnel lifecycle state — mirrors `RelayState.ProcessState` loosely but
+    /// keeps its own type so the two processes are independently observable.
+    enum TunnelState: Equatable {
+        case idle
+        case starting
+        case running
+        case stopping
+        case error(String)
+        case restarting(attempt: Int)
+    }
+
+    /// Errors surfaced by `TunnelProcess`. `localizedDescription` is shown in the UI.
+    enum TunnelError: LocalizedError {
+        case cloudflaredNotFound
+        case emptyToken
+
+        var errorDescription: String? {
+            switch self {
+            case .cloudflaredNotFound:
+                return "cloudflared not found — install with 'brew install cloudflared'"
+            case .emptyToken:
+                return "Cloudflare tunnel token is empty — paste it in Config"
+            }
+        }
+    }
+
+    private(set) var state: TunnelState = .idle
+
+    /// Total number of auto-restart attempts since the last healthy run.
+    private(set) var restartCount: Int = 0
+    /// Timestamp of the last auto-restart attempt.
+    private(set) var lastRestartAt: Date?
+
+    /// Shared log store — tunnel output is routed here so it shows up alongside relay logs.
+    private let logStore: LogStore
+
+    private var process: Process?
+    private var stdoutPipe: Pipe?
+    private var stderrPipe: Pipe?
+    private var terminationObserver: NSObjectProtocol?
+    private var pendingRestartTask: Task<Void, Never>?
+
+    /// The token we launched with — needed to relaunch on crash without
+    /// touching the Keychain on every retry.
+    private var activeToken: String?
+    private var lastSuccessfulStart: Date?
+
+    // MARK: - Tuning
+
+    private let shutdownTimeout: TimeInterval = 5.0
+    private let maxRestartAttempts = 5
+    private let healthyRunThreshold: TimeInterval = 30.0
+    private let maxRestartDelay: TimeInterval = 30.0
+
+    // MARK: - Init
+
+    init(logStore: LogStore) {
+        self.logStore = logStore
+    }
+
+    // MARK: - Binary discovery
+
+    /// Candidate paths where `cloudflared` is typically installed. Ordered by
+    /// most-likely-first for Apple Silicon machines.
+    private static let knownBinaryPaths = [
+        "/opt/homebrew/bin/cloudflared",   // Apple Silicon Homebrew
+        "/usr/local/bin/cloudflared",      // Intel Homebrew
+        "/opt/homebrew/sbin/cloudflared",  // Alt Homebrew prefix
+        "/usr/bin/cloudflared",            // System (rare)
+    ]
+
+    /// Resolve the path to `cloudflared`, checking known locations first then
+    /// falling back to `which` with an augmented PATH.
+    static func findCloudflared() -> URL? {
+        for path in knownBinaryPaths {
+            if FileManager.default.isExecutableFile(atPath: path) {
+                return URL(fileURLWithPath: path)
+            }
+        }
+
+        // Fallback: which(1) with Homebrew paths added — GUI-launched apps
+        // often have a minimal PATH.
+        let proc = Process()
+        proc.executableURL = URL(fileURLWithPath: "/usr/bin/which")
+        proc.arguments = ["cloudflared"]
+        let pipe = Pipe()
+        proc.standardOutput = pipe
+        proc.standardError = FileHandle.nullDevice
+
+        var env = ProcessInfo.processInfo.environment
+        env["PATH"] = "/opt/homebrew/bin:/usr/local/bin:" + (env["PATH"] ?? "/usr/bin:/bin")
+        proc.environment = env
+
+        do {
+            try proc.run()
+            proc.waitUntilExit()
+            guard proc.terminationStatus == 0 else { return nil }
+            let data = pipe.fileHandleForReading.availableData
+            guard let output = String(data: data, encoding: .utf8)?
+                .trimmingCharacters(in: .whitespacesAndNewlines),
+                  !output.isEmpty,
+                  FileManager.default.isExecutableFile(atPath: output)
+            else { return nil }
+            return URL(fileURLWithPath: output)
+        } catch {
+            return nil
+        }
+    }
+
+    // MARK: - Lifecycle
+
+    /// Start the tunnel with the given token. Does nothing if already running.
+    func start(token: String) async {
+        // Starting manually cancels any pending auto-restart.
+        pendingRestartTask?.cancel()
+        pendingRestartTask = nil
+
+        guard canStart else { return }
+
+        let trimmed = token.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else {
+            state = .error(TunnelError.emptyToken.localizedDescription)
+            return
+        }
+
+        guard let binary = Self.findCloudflared() else {
+            state = .error(TunnelError.cloudflaredNotFound.localizedDescription)
+            return
+        }
+
+        state = .starting
+
+        do {
+            try launchProcess(binary: binary, token: trimmed)
+            activeToken = trimmed
+            state = .running
+            lastSuccessfulStart = Date()
+        } catch {
+            state = .error(error.localizedDescription)
+        }
+    }
+
+    /// Stop the tunnel. Cancels any pending auto-restart.
+    func stop() async {
+        pendingRestartTask?.cancel()
+        pendingRestartTask = nil
+        restartCount = 0
+        lastRestartAt = nil
+        activeToken = nil
+
+        guard let proc = process else {
+            state = .idle
+            return
+        }
+
+        state = .stopping
+
+        kill(proc.processIdentifier, SIGTERM)
+        let terminated = await waitForTermination(timeout: shutdownTimeout)
+        if !terminated {
+            kill(proc.processIdentifier, SIGKILL)
+        }
+
+        cleanup()
+        state = .idle
+    }
+
+    // MARK: - Process Management
+
+    private func launchProcess(binary: URL, token: String) throws {
+        let proc = Process()
+        let stdout = Pipe()
+        let stderr = Pipe()
+
+        proc.executableURL = binary
+        proc.arguments = ["tunnel", "--no-autoupdate", "run", "--token", token]
+
+        // Minimal environment — pass through HOME and PATH so cloudflared can
+        // find its config/credentials directories.
+        var env = ProcessInfo.processInfo.environment
+        env["PATH"] = "/opt/homebrew/bin:/usr/local/bin:" + (env["PATH"] ?? "/usr/bin:/bin")
+        proc.environment = env
+
+        proc.standardOutput = stdout
+        proc.standardError = stderr
+
+        readPipeAsync(stdout, label: "cloudflared-stdout")
+        readPipeAsync(stderr, label: "cloudflared-stderr")
+
+        terminationObserver = NotificationCenter.default.addObserver(
+            forName: Process.didTerminateNotification,
+            object: proc,
+            queue: .main
+        ) { [weak self] _ in
+            self?.handleTermination()
+        }
+
+        try proc.run()
+
+        self.process = proc
+        self.stdoutPipe = stdout
+        self.stderrPipe = stderr
+
+        appendGroundControlLog(level: .info, message: "Cloudflare tunnel started (PID: \(proc.processIdentifier))")
+    }
+
+    private func handleTermination() {
+        guard let proc = process else { return }
+        let status = proc.terminationStatus
+
+        // If we're in .stopping state, this is expected.
+        if state == .stopping { return }
+
+        // Reset restart counter after a healthy run.
+        if let started = lastSuccessfulStart,
+           Date().timeIntervalSince(started) > healthyRunThreshold {
+            restartCount = 0
+        }
+
+        if status == 0 {
+            state = .idle
+            restartCount = 0
+            lastRestartAt = nil
+            appendGroundControlLog(level: .info, message: "Cloudflare tunnel exited cleanly")
+            cleanup()
+            return
+        }
+
+        appendGroundControlLog(level: .warn, message: "Cloudflare tunnel exited (code \(status))")
+        cleanup()
+
+        if restartCount >= maxRestartAttempts {
+            let msg = "Cloudflare tunnel crashed \(maxRestartAttempts) times — check logs"
+            state = .error(msg)
+            appendGroundControlLog(level: .error, message: msg)
+            return
+        }
+
+        scheduleAutoRestart(previousExitCode: status)
+    }
+
+    private func backoffDelay(forAttempt attempt: Int) -> TimeInterval {
+        let exponent = max(0, attempt - 1)
+        let raw = pow(2.0, Double(exponent))
+        return min(raw, maxRestartDelay)
+    }
+
+    private func scheduleAutoRestart(previousExitCode: Int32) {
+        guard let token = activeToken else {
+            state = .error("Lost tunnel token — cannot auto-restart")
+            return
+        }
+
+        let nextAttempt = restartCount + 1
+        let delay = backoffDelay(forAttempt: nextAttempt)
+
+        restartCount = nextAttempt
+        lastRestartAt = Date()
+        state = .restarting(attempt: nextAttempt)
+
+        let message = "Cloudflare tunnel crashed (exit \(previousExitCode)) — restarting in \(Int(delay))s (attempt \(nextAttempt)/\(maxRestartAttempts))"
+        appendGroundControlLog(level: .warn, message: message)
+
+        pendingRestartTask?.cancel()
+        pendingRestartTask = Task { [weak self] in
+            try? await Task.sleep(for: .seconds(delay))
+            guard !Task.isCancelled else { return }
+            guard let self else { return }
+            let stillRestarting = await MainActor.run {
+                if case .restarting = self.state { return true }
+                return false
+            }
+            guard stillRestarting else { return }
+            await self.start(token: token)
+        }
+    }
+
+    private func cleanup() {
+        if let observer = terminationObserver {
+            NotificationCenter.default.removeObserver(observer)
+            terminationObserver = nil
+        }
+        process = nil
+        stdoutPipe = nil
+        stderrPipe = nil
+    }
+
+    private func waitForTermination(timeout: TimeInterval) async -> Bool {
+        guard let proc = process else { return true }
+
+        return await withCheckedContinuation { continuation in
+            let resumeLock = NSLock()
+            var didResume = false
+
+            func resumeOnce(_ result: Bool) {
+                resumeLock.lock()
+                defer { resumeLock.unlock() }
+                guard !didResume else { return }
+                didResume = true
+                continuation.resume(returning: result)
+            }
+
+            let workItem = DispatchWorkItem {
+                proc.waitUntilExit()
+                resumeOnce(true)
+            }
+
+            DispatchQueue.global().async(execute: workItem)
+
+            DispatchQueue.global().asyncAfter(deadline: .now() + timeout) {
+                workItem.cancel()
+                resumeOnce(false)
+            }
+        }
+    }
+
+    // MARK: - Output Handling
+
+    /// Stream pipe data into the log store as plain-text INFO entries.
+    /// cloudflared emits human-readable lines, not JSON — LogEntry.parse()
+    /// falls back to plain-text INFO which is what we want.
+    private func readPipeAsync(_ pipe: Pipe, label: String) {
+        pipe.fileHandleForReading.readabilityHandler = { [weak self] handle in
+            let data = handle.availableData
+            guard !data.isEmpty else {
+                handle.readabilityHandler = nil
+                return
+            }
+            guard let self else { return }
+            guard let text = String(data: data, encoding: .utf8) else { return }
+            let lines = text.split(whereSeparator: { $0.isNewline })
+                .map { String($0) }
+                .filter { !$0.isEmpty }
+            DispatchQueue.main.async {
+                for line in lines {
+                    // Prefix so tunnel logs are distinguishable from relay
+                    // logs in the management log viewer.
+                    self.logStore.append("[cloudflared] \(line)")
+                }
+            }
+        }
+    }
+
+    private func appendGroundControlLog(level: LogEntry.LogLevel, message: String) {
+        let timeMs = Int(Date().timeIntervalSince1970 * 1000)
+        let escaped = message
+            .replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "\"", with: "\\\"")
+        let line = "{\"level\":\(level.rawValue),\"time\":\(timeMs),\"name\":\"tunnel\",\"msg\":\"\(escaped)\"}"
+        DispatchQueue.main.async { [weak self] in
+            self?.logStore.append(line)
+        }
+    }
+
+    // MARK: - Computed
+
+    var canStart: Bool {
+        switch state {
+        case .idle, .error:
+            return true
+        default:
+            return false
+        }
+    }
+
+    var isRunning: Bool {
+        state == .running
+    }
+
+    /// Human-readable status line for the UI.
+    var statusText: String {
+        switch state {
+        case .idle: return "Tunnel idle"
+        case .starting: return "Tunnel starting..."
+        case .running: return "Tunnel running"
+        case .stopping: return "Tunnel stopping..."
+        case .error(let msg): return "Tunnel error: \(msg)"
+        case .restarting(let attempt): return "Tunnel restarting (attempt \(attempt)/5)..."
+        }
+    }
+
+    deinit {
+        pendingRestartTask?.cancel()
+        if let proc = process, proc.isRunning {
+            kill(proc.processIdentifier, SIGTERM)
+        }
+        cleanup()
+    }
+}

--- a/macos/GroundControl/Services/TunnelProcess.swift
+++ b/macos/GroundControl/Services/TunnelProcess.swift
@@ -8,6 +8,10 @@ import Foundation
 /// using the same exponential-backoff strategy as `RelayProcess`, and pipes
 /// stdout/stderr into the shared `LogStore` so tunnel events appear in the
 /// Ground Control log viewer.
+///
+/// Same isolation story as `RelayProcess`: lifecycle methods are `@MainActor`
+/// so state mutations are race-free; the pipe reader runs non-isolated since
+/// `FileHandle.readabilityHandler` lives on a background dispatch thread.
 @Observable
 final class TunnelProcess {
     /// Tunnel lifecycle state — mirrors `RelayState.ProcessState` loosely but
@@ -122,6 +126,7 @@ final class TunnelProcess {
     // MARK: - Lifecycle
 
     /// Start the tunnel with the given token. Does nothing if already running.
+    @MainActor
     func start(token: String) async {
         // Starting manually cancels any pending auto-restart.
         pendingRestartTask?.cancel()
@@ -153,6 +158,7 @@ final class TunnelProcess {
     }
 
     /// Stop the tunnel. Cancels any pending auto-restart.
+    @MainActor
     func stop() async {
         pendingRestartTask?.cancel()
         pendingRestartTask = nil
@@ -204,7 +210,9 @@ final class TunnelProcess {
             object: proc,
             queue: .main
         ) { [weak self] _ in
-            self?.handleTermination()
+            Task { @MainActor [weak self] in
+                self?.handleTermination()
+            }
         }
 
         try proc.run()
@@ -216,6 +224,7 @@ final class TunnelProcess {
         appendGroundControlLog(level: .info, message: "Cloudflare tunnel started (PID: \(proc.processIdentifier))")
     }
 
+    @MainActor
     private func handleTermination() {
         guard let proc = process else { return }
         let status = proc.terminationStatus
@@ -257,6 +266,7 @@ final class TunnelProcess {
         return min(raw, maxRestartDelay)
     }
 
+    @MainActor
     private func scheduleAutoRestart(previousExitCode: Int32) {
         guard let token = activeToken else {
             state = .error("Lost tunnel token — cannot auto-restart")
@@ -274,15 +284,13 @@ final class TunnelProcess {
         appendGroundControlLog(level: .warn, message: message)
 
         pendingRestartTask?.cancel()
-        pendingRestartTask = Task { [weak self] in
+        // Run the restart body on the main actor so state mutations inside
+        // start(token:)/launchProcess() don't race with SwiftUI observation.
+        pendingRestartTask = Task { @MainActor [weak self] in
             try? await Task.sleep(for: .seconds(delay))
             guard !Task.isCancelled else { return }
             guard let self else { return }
-            let stillRestarting = await MainActor.run {
-                if case .restarting = self.state { return true }
-                return false
-            }
-            guard stillRestarting else { return }
+            guard case .restarting = self.state else { return }
             await self.start(token: token)
         }
     }
@@ -328,25 +336,95 @@ final class TunnelProcess {
 
     // MARK: - Output Handling
 
+    /// Per-pipe partial-line buffers. cloudflared output can split mid-line
+    /// across Data chunks; we hold the tail until the next newline arrives so
+    /// no log output is dropped.
+    private var stdoutBuffer = Data()
+    private var stderrBuffer = Data()
+    private let pipeBufferLock = NSLock()
+
     /// Stream pipe data into the log store as plain-text INFO entries.
     /// cloudflared emits human-readable lines, not JSON — LogEntry.parse()
     /// falls back to plain-text INFO which is what we want.
+    ///
+    /// Buffers partial lines so a chunk that ends mid-line doesn't get flushed
+    /// early, and uses `String(decoding:as:)` so partial UTF-8 sequences get
+    /// replacement chars instead of being dropped.
     private func readPipeAsync(_ pipe: Pipe, label: String) {
         pipe.fileHandleForReading.readabilityHandler = { [weak self] handle in
             let data = handle.availableData
+            guard let self else { return }
+
+            // EOF — flush any remainder and detach the handler.
             guard !data.isEmpty else {
+                let remainder: Data = {
+                    self.pipeBufferLock.lock()
+                    defer { self.pipeBufferLock.unlock() }
+                    if label == "cloudflared-stdout" {
+                        let r = self.stdoutBuffer
+                        self.stdoutBuffer = Data()
+                        return r
+                    } else {
+                        let r = self.stderrBuffer
+                        self.stderrBuffer = Data()
+                        return r
+                    }
+                }()
+                if !remainder.isEmpty {
+                    let line = String(decoding: remainder, as: UTF8.self)
+                        .trimmingCharacters(in: .whitespacesAndNewlines)
+                    if !line.isEmpty {
+                        DispatchQueue.main.async {
+                            self.logStore.append("[cloudflared] \(line)")
+                        }
+                    }
+                }
                 handle.readabilityHandler = nil
                 return
             }
-            guard let self else { return }
-            guard let text = String(data: data, encoding: .utf8) else { return }
-            let lines = text.split(whereSeparator: { $0.isNewline })
-                .map { String($0) }
-                .filter { !$0.isEmpty }
+
+            // Append, split on newlines, retain the trailing remainder.
+            let linesToEmit: [String] = {
+                self.pipeBufferLock.lock()
+                defer { self.pipeBufferLock.unlock() }
+
+                if label == "cloudflared-stdout" {
+                    self.stdoutBuffer.append(data)
+                } else {
+                    self.stderrBuffer.append(data)
+                }
+
+                let buffer: Data = label == "cloudflared-stdout"
+                    ? self.stdoutBuffer
+                    : self.stderrBuffer
+
+                // Non-failing decode — partial UTF-8 sequences get replacement
+                // chars instead of returning nil and stalling the pipeline.
+                let decoded = String(decoding: buffer, as: UTF8.self)
+                let endsWithNewline = buffer.last == UInt8(ascii: "\n")
+                let parts = decoded.split(separator: "\n", omittingEmptySubsequences: false)
+
+                if endsWithNewline {
+                    if label == "cloudflared-stdout" {
+                        self.stdoutBuffer = Data()
+                    } else {
+                        self.stderrBuffer = Data()
+                    }
+                    return parts.map(String.init).filter { !$0.isEmpty }
+                } else {
+                    let remainder = parts.last.map(String.init) ?? ""
+                    if label == "cloudflared-stdout" {
+                        self.stdoutBuffer = Data(remainder.utf8)
+                    } else {
+                        self.stderrBuffer = Data(remainder.utf8)
+                    }
+                    return parts.dropLast().map(String.init).filter { !$0.isEmpty }
+                }
+            }()
+
+            guard !linesToEmit.isEmpty else { return }
             DispatchQueue.main.async {
-                for line in lines {
-                    // Prefix so tunnel logs are distinguishable from relay
-                    // logs in the management log viewer.
+                for line in linesToEmit {
                     self.logStore.append("[cloudflared] \(line)")
                 }
             }

--- a/macos/GroundControl/Services/TunnelProcess.swift
+++ b/macos/GroundControl/Services/TunnelProcess.swift
@@ -132,7 +132,16 @@ final class TunnelProcess {
         pendingRestartTask?.cancel()
         pendingRestartTask = nil
 
-        guard canStart else { return }
+        // Allow starting from .idle, .error, or from inside an auto-restart
+        // wait. `canStart` excludes `.restarting` so that external callers
+        // can't blow up a pending auto-restart — but the auto-restart task
+        // itself needs to relaunch cloudflared from this state.
+        switch state {
+        case .idle, .error, .restarting:
+            break
+        case .starting, .running, .stopping:
+            return
+        }
 
         let trimmed = token.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else {
@@ -191,12 +200,18 @@ final class TunnelProcess {
         let stderr = Pipe()
 
         proc.executableURL = binary
-        proc.arguments = ["tunnel", "--no-autoupdate", "run", "--token", token]
+        // Deliberately NOT passing the token via `--token <token>` — argv is
+        // world-readable on macOS via `ps` / Activity Monitor, which would
+        // leak the Keychain secret. cloudflared supports `TUNNEL_TOKEN` as an
+        // env var; the child's environment is per-process and not visible to
+        // other users' tools.
+        proc.arguments = ["tunnel", "--no-autoupdate", "run"]
 
         // Minimal environment — pass through HOME and PATH so cloudflared can
-        // find its config/credentials directories.
+        // find its config/credentials directories; inject TUNNEL_TOKEN.
         var env = ProcessInfo.processInfo.environment
         env["PATH"] = "/opt/homebrew/bin:/usr/local/bin:" + (env["PATH"] ?? "/usr/bin:/bin")
+        env["TUNNEL_TOKEN"] = token
         proc.environment = env
 
         proc.standardOutput = stdout

--- a/macos/GroundControl/Services/TunnelProcess.swift
+++ b/macos/GroundControl/Services/TunnelProcess.swift
@@ -61,6 +61,11 @@ final class TunnelProcess {
     private var activeToken: String?
     private var lastSuccessfulStart: Date?
 
+    /// Memoized result of `findCloudflared`. Populated lazily on first
+    /// successful lookup so auto-restart attempts don't re-spawn `which`.
+    /// Reset when we detect the binary has moved/disappeared.
+    private var cachedCloudflaredURL: URL?
+
     // MARK: - Tuning
 
     private let shutdownTimeout: TimeInterval = 5.0
@@ -85,17 +90,21 @@ final class TunnelProcess {
         "/usr/bin/cloudflared",            // System (rare)
     ]
 
-    /// Resolve the path to `cloudflared`, checking known locations first then
-    /// falling back to `which` with an augmented PATH.
-    static func findCloudflared() -> URL? {
+    /// Check the well-known install paths without spawning any subprocess.
+    /// Cheap enough to call from MainActor — just a few filesystem stats.
+    static func findCloudflaredInKnownPaths() -> URL? {
         for path in knownBinaryPaths {
             if FileManager.default.isExecutableFile(atPath: path) {
                 return URL(fileURLWithPath: path)
             }
         }
+        return nil
+    }
 
-        // Fallback: which(1) with Homebrew paths added — GUI-launched apps
-        // often have a minimal PATH.
+    /// Slow fallback — spawns `/usr/bin/which cloudflared` with an augmented
+    /// PATH (GUI-launched apps often have a minimal PATH). This MUST NOT be
+    /// called from MainActor; it blocks until the child process exits.
+    static func findCloudflaredViaWhich() -> URL? {
         let proc = Process()
         proc.executableURL = URL(fileURLWithPath: "/usr/bin/which")
         proc.arguments = ["cloudflared"]
@@ -121,6 +130,40 @@ final class TunnelProcess {
         } catch {
             return nil
         }
+    }
+
+    /// Resolve the path to `cloudflared`. Checks known locations inline
+    /// (fast), and only falls back to `which` off the main actor to avoid
+    /// blocking the UI. Retained for callers (like `CloudflareTunnelView`)
+    /// that already hop off main via `Task.detached`.
+    static func findCloudflared() -> URL? {
+        if let known = findCloudflaredInKnownPaths() { return known }
+        return findCloudflaredViaWhich()
+    }
+
+    /// Main-actor-friendly resolver: returns the cached URL if still valid,
+    /// otherwise checks known paths inline and hops off-main for the `which`
+    /// fallback. Updates the cache on success.
+    @MainActor
+    private func resolveCloudflared() async -> URL? {
+        // Re-validate the cache — the binary may have been moved/deleted.
+        if let cached = cachedCloudflaredURL,
+           FileManager.default.isExecutableFile(atPath: cached.path) {
+            return cached
+        }
+        cachedCloudflaredURL = nil
+
+        // Fast path: inline known-path check.
+        if let known = Self.findCloudflaredInKnownPaths() {
+            cachedCloudflaredURL = known
+            return known
+        }
+
+        // Slow path: hop off main so `/usr/bin/which` can run synchronously
+        // without stalling the UI.
+        let resolved = await Task.detached { Self.findCloudflaredViaWhich() }.value
+        cachedCloudflaredURL = resolved
+        return resolved
     }
 
     // MARK: - Lifecycle
@@ -149,7 +192,7 @@ final class TunnelProcess {
             return
         }
 
-        guard let binary = Self.findCloudflared() else {
+        guard let binary = await resolveCloudflared() else {
             state = .error(TunnelError.cloudflaredNotFound.localizedDescription)
             return
         }

--- a/macos/GroundControl/Views/CloudflareTunnelView.swift
+++ b/macos/GroundControl/Views/CloudflareTunnelView.swift
@@ -16,6 +16,11 @@ struct CloudflareTunnelView: View {
     @State private var testResult: TestResult?
     @State private var isTesting = false
 
+    /// Cached result of `TunnelProcess.findCloudflared()`. The fallback path
+    /// spawns `/usr/bin/which` synchronously, so we must not re-evaluate on
+    /// every view recomputation (any field edit triggers one).
+    @State private var cloudflaredInstalled = true
+
     private enum TestResult: Equatable {
         case success(statusCode: Int)
         case failure(String)
@@ -56,10 +61,6 @@ struct CloudflareTunnelView: View {
         case .error:
             return .red
         }
-    }
-
-    private var cloudflaredInstalled: Bool {
-        TunnelProcess.findCloudflared() != nil
     }
 
     var body: some View {
@@ -168,6 +169,12 @@ struct CloudflareTunnelView: View {
         }
         .onAppear {
             tunnelToken = configManager.getSecret(ConfigManager.SecretKey.cloudflareToken) ?? ""
+            // Probe for cloudflared once. `findCloudflared` may spawn `which`
+            // synchronously, so hop off the main thread for the discovery.
+            Task.detached {
+                let found = TunnelProcess.findCloudflared() != nil
+                await MainActor.run { self.cloudflaredInstalled = found }
+            }
         }
         .onChange(of: tunnelToken) {
             // Debounce Keychain writes — only persist after 1s of inactivity

--- a/macos/GroundControl/Views/CloudflareTunnelView.swift
+++ b/macos/GroundControl/Views/CloudflareTunnelView.swift
@@ -3,25 +3,63 @@ import SwiftUI
 /// Cloudflare Tunnel configuration section.
 ///
 /// Toggle to enable/disable, token stored in Keychain (masked by default),
-/// and a status indicator.
+/// optional tunnel name (display-only), live tunnel status from TunnelProcess,
+/// and a "Test Tunnel" button that probes the relay's /health endpoint.
 struct CloudflareTunnelView: View {
+    let relay: RelayProcess
     @Bindable var configManager: ConfigManager
 
     @State private var tunnelToken = ""
     @State private var showToken = false
     @State private var tokenSaveTask: Task<Void, Never>?
 
-    /// Derived status label for the tunnel (uses @State to avoid Keychain reads during recomputation).
+    @State private var testResult: TestResult?
+    @State private var isTesting = false
+
+    private enum TestResult: Equatable {
+        case success(statusCode: Int)
+        case failure(String)
+    }
+
+    // MARK: - Derived status
+
     private var statusText: String {
         if !configManager.config.cloudflareEnabled {
             return "Disabled"
         }
-        return !tunnelToken.isEmpty ? "Token saved" : "Not configured"
+        // Prefer live process state over static "token saved" when enabled.
+        switch relay.tunnel.state {
+        case .idle:
+            return tunnelToken.isEmpty ? "No token" : "Idle (waiting for relay)"
+        case .starting:
+            return "Starting..."
+        case .running:
+            return "Running"
+        case .stopping:
+            return "Stopping..."
+        case .restarting(let attempt):
+            return "Restarting (attempt \(attempt)/5)..."
+        case .error(let msg):
+            return msg
+        }
     }
 
     private var statusColor: Color {
         if !configManager.config.cloudflareEnabled { return .secondary }
-        return !tunnelToken.isEmpty ? .green : .orange
+        switch relay.tunnel.state {
+        case .idle:
+            return tunnelToken.isEmpty ? .orange : .gray
+        case .starting, .stopping, .restarting:
+            return .yellow
+        case .running:
+            return .green
+        case .error:
+            return .red
+        }
+    }
+
+    private var cloudflaredInstalled: Bool {
+        TunnelProcess.findCloudflared() != nil
     }
 
     var body: some View {
@@ -39,11 +77,29 @@ struct CloudflareTunnelView: View {
                         Text(statusText)
                             .font(.caption)
                             .foregroundStyle(.secondary)
+                            .lineLimit(1)
+                            .truncationMode(.tail)
                     }
                 }
 
                 if configManager.config.cloudflareEnabled {
                     Divider()
+
+                    if !cloudflaredInstalled {
+                        HStack(spacing: 6) {
+                            Image(systemName: "exclamationmark.triangle.fill")
+                                .foregroundStyle(.orange)
+                            Text("cloudflared not found — install with ") +
+                            Text("`brew install cloudflared`").font(.body.monospaced())
+                        }
+                        .font(.caption)
+                    }
+
+                    LabeledContent("Tunnel Name") {
+                        TextField("major-tom", text: $configManager.config.cloudflareTunnelName)
+                            .textFieldStyle(.roundedBorder)
+                            .frame(width: 300)
+                    }
 
                     LabeledContent("Tunnel Token") {
                         HStack(spacing: 4) {
@@ -64,6 +120,42 @@ struct CloudflareTunnelView: View {
                             }
                             .buttonStyle(.borderless)
                             .help(showToken ? "Hide" : "Reveal")
+                        }
+                    }
+
+                    HStack(spacing: 8) {
+                        Button {
+                            Task { await testTunnel() }
+                        } label: {
+                            if isTesting {
+                                ProgressView().controlSize(.small)
+                            } else {
+                                Text("Test Tunnel")
+                            }
+                        }
+                        .disabled(isTesting || !relay.state.isRunning)
+                        .help(relay.state.isRunning
+                              ? "Probe the relay /health endpoint"
+                              : "Start the relay first")
+
+                        if let testResult {
+                            switch testResult {
+                            case .success(let code):
+                                HStack(spacing: 4) {
+                                    Image(systemName: "checkmark.circle.fill")
+                                        .foregroundStyle(.green)
+                                    Text("OK (HTTP \(code))")
+                                }
+                                .font(.caption)
+                            case .failure(let msg):
+                                HStack(spacing: 4) {
+                                    Image(systemName: "xmark.circle.fill")
+                                        .foregroundStyle(.red)
+                                    Text(msg)
+                                        .lineLimit(2)
+                                }
+                                .font(.caption)
+                            }
                         }
                     }
 
@@ -89,6 +181,41 @@ struct CloudflareTunnelView: View {
                     configManager.setSecret(ConfigManager.SecretKey.cloudflareToken, value: tunnelToken)
                 }
             }
+        }
+    }
+
+    // MARK: - Actions
+
+    /// Probe the relay's local `/health` endpoint. This validates that the
+    /// relay is reachable on its configured port — which is the first thing
+    /// that has to be true before the tunnel can forward traffic.
+    private func testTunnel() async {
+        isTesting = true
+        testResult = nil
+        defer { isTesting = false }
+
+        guard let url = URL(string: "http://127.0.0.1:\(relay.state.port)/health") else {
+            testResult = .failure("Invalid URL")
+            return
+        }
+
+        var request = URLRequest(url: url)
+        request.timeoutInterval = 5.0
+        request.cachePolicy = .reloadIgnoringLocalAndRemoteCacheData
+
+        do {
+            let (_, response) = try await URLSession.shared.data(for: request)
+            if let http = response as? HTTPURLResponse {
+                if http.statusCode == 200 {
+                    testResult = .success(statusCode: http.statusCode)
+                } else {
+                    testResult = .failure("HTTP \(http.statusCode)")
+                }
+            } else {
+                testResult = .failure("No HTTP response")
+            }
+        } catch {
+            testResult = .failure(error.localizedDescription)
         }
     }
 }

--- a/macos/GroundControl/Views/ConfigView.swift
+++ b/macos/GroundControl/Views/ConfigView.swift
@@ -31,7 +31,7 @@ struct ConfigView: View {
                 directoriesSection
                 featuresSection
                 startupSection
-                CloudflareTunnelView(configManager: configManager)
+                CloudflareTunnelView(relay: relay, configManager: configManager)
 
                 Divider()
                 actionButtons

--- a/macos/GroundControl/Views/DashboardView.swift
+++ b/macos/GroundControl/Views/DashboardView.swift
@@ -249,7 +249,9 @@ struct DashboardView: View {
         case .starting, .stopping:
             .yellow
         case .restarting:
-            .yellow
+            // Match MenuBarView / GroundControlApp menu bar icon so the
+            // "auto-recovering" signal is visually distinct from plain start/stop.
+            .orange
         case .idle:
             .gray
         case .error:

--- a/macos/GroundControl/Views/DashboardView.swift
+++ b/macos/GroundControl/Views/DashboardView.swift
@@ -228,6 +228,8 @@ struct DashboardView: View {
             "Stopped"
         case .error(let msg):
             "Error: \(msg)"
+        case .restarting(let attempt):
+            "Restarting (attempt \(attempt)/5)..."
         }
     }
 
@@ -245,6 +247,8 @@ struct DashboardView: View {
         case .running:
             relayClient.isConnected ? .green : .yellow
         case .starting, .stopping:
+            .yellow
+        case .restarting:
             .yellow
         case .idle:
             .gray

--- a/macos/GroundControl/Views/MenuBarView.swift
+++ b/macos/GroundControl/Views/MenuBarView.swift
@@ -134,6 +134,10 @@ struct MenuBarView: View {
             Image(systemName: "circle.fill")
                 .foregroundStyle(.yellow)
                 .font(.caption2)
+        case .restarting:
+            Image(systemName: "arrow.triangle.2.circlepath")
+                .foregroundStyle(.orange)
+                .font(.caption2)
         case .error:
             Image(systemName: "exclamationmark.triangle.fill")
                 .foregroundStyle(.red)


### PR DESCRIPTION
## Summary

Make Ground Control "launch and forget" — relay auto-recovers from crashes, the Cloudflare tunnel lives alongside the relay, and zombie processes get detected instead of silently rotting.

Spec: [docs/GROUND-CONTROL-HARDENING.md](../blob/main/docs/GROUND-CONTROL-HARDENING.md)

## Changes

### Auto-restart with exponential backoff
- New `.restarting(attempt:)` `ProcessState` case; `restartCount` + `lastRestartAt` added to `RelayState` so the UI can show recovery status.
- `handleTermination` now distinguishes clean exits from crashes. Crashes schedule an auto-restart with exponential backoff (1→2→4→8→16s, capped at 30s), up to 5 consecutive attempts. Runs that stay alive past 30s reset the counter.
- `stop()` cancels any pending restart so users can abort a wait mid-backoff.
- `start()` cancels a pending restart before spawning (manual start wins over auto).

### Managed Cloudflare tunnel (`TunnelProcess.swift`)
- New `@Observable` service that mirrors `RelayProcess`: finds `cloudflared` in `/opt/homebrew/bin`, `/usr/local/bin`, then falls back to `which` with augmented PATH.
- Spawns `cloudflared tunnel --no-autoupdate run --token <token>`, pipes stdout/stderr into the shared `LogStore` with a `[cloudflared]` prefix so tunnel output shows up in the log viewer.
- Auto-restarts on crash using the same exponential-backoff strategy as the relay.
- `RelayProcess` owns a `TunnelProcess`. On `start()`, once `/health` returns 200 (15s timeout) and the Keychain has a token, the tunnel comes up. On `stop()` the tunnel is torn down before the relay so cloudflared doesn't thrash reconnecting to a dying origin.

### Zombie process monitor
- Periodic 30s `/health` probe while running. 3 consecutive failures → SIGTERM the relay (not marked as `.stopping`), which routes through the normal auto-restart path. Catches hung Node processes that are alive but unresponsive.
- Paused during graceful shutdown so `stop()` doesn't race with the monitor.

### Config
- `RelayConfig.cloudflareTunnelName` (display-only) added with a custom `init(from:)` that uses `decodeIfPresent` + empty-string fallback, so existing `~/.major-tom/config.json` files still parse.

### UI
- `CloudflareTunnelView` rewritten to show live tunnel state (idle/starting/running/restarting/error), a "cloudflared not found — `brew install cloudflared`" warning, a Tunnel Name field, and a Test Tunnel button that probes local `/health`.
- `MenuBarView`, `DashboardView`, and `GroundControlApp` handle the new `.restarting` state with an orange refresh indicator.
- Synthetic log entries (`{"level":40,"name":"ground-control","msg":"..."}`) emitted from RelayProcess/TunnelProcess so internal lifecycle events show up colorized in the log viewer.

## Test plan

Build: `swift build` from `macos/` — clean, no warnings.

Manual QA (spec checklist — needs real cloudflared + running relay):

- [ ] Relay crash → auto-restarts within backoff delay
- [ ] 5 consecutive crashes → stops with "Relay crashed 5 times — check logs"
- [ ] Successful run > 30s → resets restart counter
- [ ] Cloudflare toggle ON → tunnel spawns after relay `/health` is ready
- [ ] Cloudflare toggle OFF → tunnel doesn't spawn
- [ ] Relay stop → tunnel stops first, then relay
- [ ] Tunnel crash → auto-restarts independently with backoff
- [ ] Missing `cloudflared` binary → clear "cloudflared not found" error in UI
- [ ] Config changes saved → next relay restart picks them up
- [ ] Zombie relay (hung Node) → 3 failed health checks → SIGTERM → auto-restart

## Out of scope

- Tunnel name is display-only; `cloudflared tunnel run --token <token>` picks the tunnel from the token itself. Left as a UI affordance so the user can see which tunnel is wired up without digging through Cloudflare dashboard.
- No unit tests — the `macos/` SwiftPM package doesn't have a test target, and lifecycle behavior is hard to mock without stubbing `Process`. Tracked as tech debt if we want it later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)