### PR TITLE
feat: Ground Control MCP server + HTTP control API

### DIFF
--- a/macos/GroundControl/App/GroundControlApp.swift
+++ b/macos/GroundControl/App/GroundControlApp.swift
@@ -62,13 +62,14 @@ struct GroundControlApp: App {
     init() {
         let cm = ConfigManager()
         let rp = RelayProcess(configManager: cm)
-        _configManager = State(initialValue: cm)
-        _relay = State(initialValue: rp)
-        _controlServer = State(initialValue: ControlServer(
+        let cs = ControlServer(
             port: UInt16(exactly: cm.config.controlPort) ?? 9092,
             relay: rp,
             configManager: cm
-        ))
+        )
+        _configManager = State(initialValue: cm)
+        _relay = State(initialValue: rp)
+        _controlServer = State(initialValue: cs)
         _showOnboarding = State(initialValue: !UserDefaults.standard.bool(forKey: "hasCompletedOnboarding"))
 
         // Start checking for updates at launch so the menu bar can show availability
@@ -78,6 +79,10 @@ struct GroundControlApp: App {
         // Sync Login Item state with config — handles drift if the user
         // toggled the Login Item from System Settings independently.
         LoginItemManager.syncWithConfig(launchAtLogin: cm.config.launchAtLogin)
+
+        // Start the control API server immediately so it is available at launch,
+        // not deferred until the menu bar popover is first opened.
+        cs.start()
     }
 
     var body: some Scene {
@@ -132,8 +137,6 @@ struct GroundControlApp: App {
         var body: some View {
             MenuBarView(relay: relay, updateChecker: updateChecker)
                 .onAppear {
-                    // Start the control API server for MCP bridge access
-                    controlServer.start()
                     // Open onboarding window on first launch.
                     if showOnboarding {
                         NSApplication.shared.activate(ignoringOtherApps: true)

--- a/macos/GroundControl/App/GroundControlApp.swift
+++ b/macos/GroundControl/App/GroundControlApp.swift
@@ -65,7 +65,7 @@ struct GroundControlApp: App {
         _configManager = State(initialValue: cm)
         _relay = State(initialValue: rp)
         _controlServer = State(initialValue: ControlServer(
-            port: UInt16(cm.config.controlPort),
+            port: UInt16(exactly: cm.config.controlPort) ?? 9092,
             relay: rp,
             configManager: cm
         ))

--- a/macos/GroundControl/App/GroundControlApp.swift
+++ b/macos/GroundControl/App/GroundControlApp.swift
@@ -55,13 +55,20 @@ struct GroundControlApp: App {
 
     @State private var configManager: ConfigManager
     @State private var relay: RelayProcess
+    @State private var controlServer: ControlServer
     @State private var updateChecker = UpdateChecker()
     @State private var showOnboarding: Bool
 
     init() {
         let cm = ConfigManager()
+        let rp = RelayProcess(configManager: cm)
         _configManager = State(initialValue: cm)
-        _relay = State(initialValue: RelayProcess(configManager: cm))
+        _relay = State(initialValue: rp)
+        _controlServer = State(initialValue: ControlServer(
+            port: UInt16(cm.config.controlPort),
+            relay: rp,
+            configManager: cm
+        ))
         _showOnboarding = State(initialValue: !UserDefaults.standard.bool(forKey: "hasCompletedOnboarding"))
 
         // Start checking for updates at launch so the menu bar can show availability
@@ -78,6 +85,7 @@ struct GroundControlApp: App {
         MenuBarExtra {
             MenuBarExtraContent(
                 relay: relay,
+                controlServer: controlServer,
                 updateChecker: updateChecker,
                 showOnboarding: showOnboarding
             )
@@ -115,6 +123,7 @@ struct GroundControlApp: App {
     /// so the Dock-reopen notification can be routed into SwiftUI's scene API.
     private struct MenuBarExtraContent: View {
         let relay: RelayProcess
+        let controlServer: ControlServer
         let updateChecker: UpdateChecker
         let showOnboarding: Bool
 
@@ -123,6 +132,8 @@ struct GroundControlApp: App {
         var body: some View {
             MenuBarView(relay: relay, updateChecker: updateChecker)
                 .onAppear {
+                    // Start the control API server for MCP bridge access
+                    controlServer.start()
                     // Open onboarding window on first launch.
                     if showOnboarding {
                         NSApplication.shared.activate(ignoringOtherApps: true)

--- a/macos/GroundControl/Models/RelayConfig.swift
+++ b/macos/GroundControl/Models/RelayConfig.swift
@@ -51,6 +51,8 @@ struct RelayConfig: Equatable {
     var autoStart: Bool
     /// Whether to register as a Login Item so the app launches at system startup.
     var launchAtLogin: Bool
+    /// Port for the local HTTP control API (MCP bridge talks to this).
+    var controlPort: Int
 
     /// Sensible defaults for a fresh install.
     static let defaults = RelayConfig(
@@ -63,7 +65,8 @@ struct RelayConfig: Equatable {
         cloudflareEnabled: false,
         cloudflareTunnelName: "",
         autoStart: true,
-        launchAtLogin: false
+        launchAtLogin: false,
+        controlPort: 9092
     )
 
     // MARK: - Validation
@@ -72,9 +75,10 @@ struct RelayConfig: Equatable {
     struct ValidationResult {
         var portError: String?
         var hookPortError: String?
+        var controlPortError: String?
 
         var isValid: Bool {
-            portError == nil && hookPortError == nil
+            portError == nil && hookPortError == nil && controlPortError == nil
         }
     }
 
@@ -90,8 +94,17 @@ struct RelayConfig: Equatable {
             result.hookPortError = "Hook port must be between 1024 and 65535"
         }
 
+        if controlPort < 1024 || controlPort > 65535 {
+            result.controlPortError = "Control port must be between 1024 and 65535"
+        }
+
         if result.portError == nil && result.hookPortError == nil && port == hookPort {
             result.hookPortError = "Hook port must differ from relay port"
+        }
+
+        let allPorts = [port, hookPort, controlPort]
+        if result.controlPortError == nil && Set(allPorts).count != allPorts.count {
+            result.controlPortError = "Control port must differ from relay and hook ports"
         }
 
         return result
@@ -115,6 +128,7 @@ extension RelayConfig: Codable {
         case port, hookPort, authMode, multiUserEnabled, claudeWorkDir
         case logLevel, cloudflareEnabled, cloudflareTunnelName, autoStart
         case launchAtLogin
+        case controlPort
     }
 
     init(from decoder: Decoder) throws {
@@ -130,6 +144,7 @@ extension RelayConfig: Codable {
         self.autoStart = try c.decode(Bool.self, forKey: .autoStart)
         // Backfill: older configs won't have this field
         self.launchAtLogin = try c.decodeIfPresent(Bool.self, forKey: .launchAtLogin) ?? false
+        self.controlPort = try c.decodeIfPresent(Int.self, forKey: .controlPort) ?? 9092
     }
 
     func encode(to encoder: Encoder) throws {
@@ -144,5 +159,6 @@ extension RelayConfig: Codable {
         try c.encode(cloudflareTunnelName, forKey: .cloudflareTunnelName)
         try c.encode(autoStart, forKey: .autoStart)
         try c.encode(launchAtLogin, forKey: .launchAtLogin)
+        try c.encode(controlPort, forKey: .controlPort)
     }
 }

--- a/macos/GroundControl/Models/RelayConfig.swift
+++ b/macos/GroundControl/Models/RelayConfig.swift
@@ -102,8 +102,7 @@ struct RelayConfig: Equatable {
             result.hookPortError = "Hook port must differ from relay port"
         }
 
-        let allPorts = [port, hookPort, controlPort]
-        if result.controlPortError == nil && Set(allPorts).count != allPorts.count {
+        if result.controlPortError == nil && (controlPort == port || controlPort == hookPort) {
             result.controlPortError = "Control port must differ from relay and hook ports"
         }
 

--- a/macos/GroundControl/Services/ControlServer.swift
+++ b/macos/GroundControl/Services/ControlServer.swift
@@ -1,0 +1,562 @@
+import Foundation
+import Network
+
+/// Lightweight HTTP control API for Ground Control, bound to loopback only.
+///
+/// Exposes relay/tunnel lifecycle, logs, and config via REST endpoints so that
+/// external tools (e.g. an MCP server bridge) can programmatically manage
+/// the app without touching the GUI.
+///
+/// Security: NWListener is bound to `127.0.0.1` exclusively. Every incoming
+/// connection is validated against loopback before processing. Same model as
+/// the relay's own admin API.
+@Observable
+final class ControlServer {
+    private(set) var isRunning = false
+
+    private var listener: NWListener?
+    private let port: UInt16
+    private let queue = DispatchQueue(label: "com.majortom.groundcontrol.control-server")
+
+    /// Timestamp when the control server started (used for uptime calculation).
+    private var startTime: Date?
+
+    // MARK: - Dependencies (injected from app)
+
+    private weak var relay: RelayProcess?
+    private weak var configManager: ConfigManager?
+
+    // MARK: - Init
+
+    init(port: UInt16, relay: RelayProcess, configManager: ConfigManager) {
+        self.port = port
+        self.relay = relay
+        self.configManager = configManager
+    }
+
+    // MARK: - Lifecycle
+
+    func start() {
+        guard !isRunning else { return }
+
+        do {
+            let params = NWParameters.tcp
+            // Bind to loopback only — reject non-local connections at the network level
+            params.requiredLocalEndpoint = NWEndpoint.hostPort(
+                host: NWEndpoint.Host("127.0.0.1"),
+                port: NWEndpoint.Port(rawValue: port)!
+            )
+
+            let nwListener = try NWListener(using: params)
+            nwListener.stateUpdateHandler = { [weak self] state in
+                switch state {
+                case .ready:
+                    self?.isRunning = true
+                    self?.startTime = Date()
+                    print("[ControlServer] Listening on 127.0.0.1:\(self?.port ?? 0)")
+                case .failed(let error):
+                    print("[ControlServer] Failed: \(error)")
+                    self?.isRunning = false
+                case .cancelled:
+                    self?.isRunning = false
+                default:
+                    break
+                }
+            }
+
+            nwListener.newConnectionHandler = { [weak self] connection in
+                self?.handleConnection(connection)
+            }
+
+            nwListener.start(queue: queue)
+            self.listener = nwListener
+        } catch {
+            print("[ControlServer] Failed to create listener: \(error)")
+        }
+    }
+
+    func stop() {
+        listener?.cancel()
+        listener = nil
+        isRunning = false
+        startTime = nil
+    }
+
+    // MARK: - Connection Handling
+
+    private func handleConnection(_ connection: NWConnection) {
+        connection.start(queue: queue)
+
+        // Read the full HTTP request (up to 64KB should be plenty for control API)
+        connection.receive(minimumIncompleteLength: 1, maximumLength: 65536) { [weak self] data, _, _, error in
+            guard let self, let data, error == nil else {
+                connection.cancel()
+                return
+            }
+
+            // Validate loopback — defense in depth beyond the bind
+            if let endpoint = connection.currentPath?.remoteEndpoint,
+               case let .hostPort(host, _) = endpoint {
+                let hostStr = "\(host)"
+                let isLoopback = hostStr == "127.0.0.1" || hostStr == "::1" || hostStr == "::ffff:127.0.0.1"
+                if !isLoopback {
+                    self.sendResponse(connection: connection, status: 403, body: ["error": "Forbidden — loopback only"])
+                    return
+                }
+            }
+
+            guard let requestString = String(data: data, encoding: .utf8) else {
+                self.sendResponse(connection: connection, status: 400, body: ["error": "Invalid request"])
+                return
+            }
+
+            self.routeRequest(requestString, rawData: data, connection: connection)
+        }
+    }
+
+    // MARK: - Routing
+
+    private func routeRequest(_ request: String, rawData: Data, connection: NWConnection) {
+        // Parse HTTP method and path from first line
+        let lines = request.components(separatedBy: "\r\n")
+        guard let requestLine = lines.first else {
+            sendResponse(connection: connection, status: 400, body: ["error": "Empty request"])
+            return
+        }
+
+        let parts = requestLine.split(separator: " ")
+        guard parts.count >= 2 else {
+            sendResponse(connection: connection, status: 400, body: ["error": "Malformed request line"])
+            return
+        }
+
+        let method = String(parts[0])
+        let fullPath = String(parts[1])
+        // Strip query string for routing
+        let path = fullPath.components(separatedBy: "?").first ?? fullPath
+        let queryString = fullPath.contains("?") ? String(fullPath.split(separator: "?", maxSplits: 1).last ?? "") : ""
+
+        // Extract body from request (after blank line)
+        let bodyString: String? = {
+            if let range = request.range(of: "\r\n\r\n") {
+                let body = String(request[range.upperBound...])
+                return body.isEmpty ? nil : body
+            }
+            return nil
+        }()
+
+        switch (method, path) {
+        case ("GET", "/control/status"):
+            handleGetStatus(connection: connection)
+        case ("POST", "/control/relay/start"):
+            handleRelayStart(connection: connection)
+        case ("POST", "/control/relay/stop"):
+            handleRelayStop(connection: connection)
+        case ("POST", "/control/relay/restart"):
+            handleRelayRestart(connection: connection)
+        case ("POST", "/control/tunnel/start"):
+            handleTunnelStart(connection: connection)
+        case ("POST", "/control/tunnel/stop"):
+            handleTunnelStop(connection: connection)
+        case ("GET", "/control/logs"):
+            handleGetLogs(queryString: queryString, connection: connection)
+        case ("GET", "/control/logs/stream"):
+            handleLogStream(connection: connection)
+        case ("GET", "/control/config"):
+            handleGetConfig(connection: connection)
+        case ("PATCH", "/control/config"):
+            handlePatchConfig(body: bodyString, connection: connection)
+        default:
+            sendResponse(connection: connection, status: 404, body: ["error": "Not found"])
+        }
+    }
+
+    // MARK: - Endpoint Handlers
+
+    private func handleGetStatus(connection: NWConnection) {
+        guard let relay else {
+            sendResponse(connection: connection, status: 503, body: ["error": "Relay not available"])
+            return
+        }
+
+        let relayStateStr: String
+        let relayRunning: Bool
+        switch relay.state.processState {
+        case .idle: relayStateStr = "idle"; relayRunning = false
+        case .starting: relayStateStr = "starting"; relayRunning = false
+        case .running: relayStateStr = "running"; relayRunning = true
+        case .stopping: relayStateStr = "stopping"; relayRunning = false
+        case .error(let msg): relayStateStr = "error: \(msg)"; relayRunning = false
+        case .restarting(let attempt): relayStateStr = "restarting (attempt \(attempt))"; relayRunning = false
+        }
+
+        let tunnelStateStr: String
+        switch relay.tunnel.state {
+        case .idle: tunnelStateStr = "idle"
+        case .starting: tunnelStateStr = "starting"
+        case .running: tunnelStateStr = "running"
+        case .stopping: tunnelStateStr = "stopping"
+        case .error(let msg): tunnelStateStr = "error: \(msg)"
+        case .restarting(let attempt): tunnelStateStr = "restarting (attempt \(attempt))"
+        }
+
+        var body: [String: Any] = [
+            "relay": [
+                "state": relayStateStr,
+                "running": relayRunning,
+                "port": relay.state.port,
+                "hookPort": relay.state.hookPort,
+                "restartCount": relay.state.restartCount,
+            ] as [String: Any],
+            "tunnel": [
+                "state": tunnelStateStr,
+                "running": relay.tunnel.isRunning,
+                "restartCount": relay.tunnel.restartCount,
+            ] as [String: Any],
+        ]
+
+        if let start = startTime {
+            body["uptime"] = Date().timeIntervalSince(start)
+        }
+
+        sendResponse(connection: connection, status: 200, body: body)
+    }
+
+    private func handleRelayStart(connection: NWConnection) {
+        guard let relay else {
+            sendResponse(connection: connection, status: 503, body: ["error": "Relay not available"])
+            return
+        }
+
+        Task { @MainActor in
+            await relay.start()
+            self.sendResponse(connection: connection, status: 200, body: ["ok": true, "state": "starting"])
+        }
+    }
+
+    private func handleRelayStop(connection: NWConnection) {
+        guard let relay else {
+            sendResponse(connection: connection, status: 503, body: ["error": "Relay not available"])
+            return
+        }
+
+        Task { @MainActor in
+            await relay.stop()
+            self.sendResponse(connection: connection, status: 200, body: ["ok": true, "state": "stopped"])
+        }
+    }
+
+    private func handleRelayRestart(connection: NWConnection) {
+        guard let relay else {
+            sendResponse(connection: connection, status: 503, body: ["error": "Relay not available"])
+            return
+        }
+
+        Task { @MainActor in
+            await relay.restart()
+            self.sendResponse(connection: connection, status: 200, body: ["ok": true, "state": "restarting"])
+        }
+    }
+
+    private func handleTunnelStart(connection: NWConnection) {
+        guard let relay, let configManager else {
+            sendResponse(connection: connection, status: 503, body: ["error": "Relay or config not available"])
+            return
+        }
+
+        guard configManager.config.cloudflareEnabled else {
+            sendResponse(connection: connection, status: 400, body: ["error": "Cloudflare tunnel not enabled in config"])
+            return
+        }
+
+        guard let token = configManager.getSecret(ConfigManager.SecretKey.cloudflareToken),
+              !token.isEmpty else {
+            sendResponse(connection: connection, status: 400, body: ["error": "Cloudflare tunnel token not configured"])
+            return
+        }
+
+        Task { @MainActor in
+            await relay.tunnel.start(token: token)
+            self.sendResponse(connection: connection, status: 200, body: ["ok": true, "state": "starting"])
+        }
+    }
+
+    private func handleTunnelStop(connection: NWConnection) {
+        guard let relay else {
+            sendResponse(connection: connection, status: 503, body: ["error": "Relay not available"])
+            return
+        }
+
+        Task { @MainActor in
+            await relay.tunnel.stop()
+            self.sendResponse(connection: connection, status: 200, body: ["ok": true, "state": "stopped"])
+        }
+    }
+
+    private func handleGetLogs(queryString: String, connection: NWConnection) {
+        guard let relay else {
+            sendResponse(connection: connection, status: 503, body: ["error": "Relay not available"])
+            return
+        }
+
+        // Parse query parameters
+        let params = parseQueryString(queryString)
+        let count = Int(params["count"] ?? "") ?? 100
+        let level = params["level"]
+        let since = params["since"].flatMap { Double($0) }.map { Date(timeIntervalSince1970: $0) }
+
+        let entries = relay.logStore.entries
+        var filtered = Array(entries)
+
+        // Filter by timestamp if provided
+        if let sinceDate = since {
+            filtered = filtered.filter { $0.timestamp >= sinceDate }
+        }
+
+        // Filter by level if provided
+        if let levelStr = level, let pinoLevel = pinoLevelFromString(levelStr) {
+            filtered = filtered.filter { $0.level.rawValue >= pinoLevel }
+        }
+
+        // Take last N entries
+        let clamped = min(count, filtered.count)
+        let result = Array(filtered.suffix(clamped))
+
+        let logEntries: [[String: Any]] = result.map { entry in
+            [
+                "timestamp": entry.timestamp.timeIntervalSince1970,
+                "level": entry.level.displayName.lowercased(),
+                "message": entry.message,
+            ]
+        }
+
+        sendResponse(connection: connection, status: 200, body: [
+            "count": logEntries.count,
+            "entries": logEntries,
+        ])
+    }
+
+    private func handleLogStream(connection: NWConnection) {
+        guard let relay else {
+            sendResponse(connection: connection, status: 503, body: ["error": "Relay not available"])
+            return
+        }
+
+        // Send SSE headers
+        let headers = "HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\nCache-Control: no-cache\r\nConnection: keep-alive\r\n\r\n"
+        guard let headerData = headers.data(using: .utf8) else {
+            connection.cancel()
+            return
+        }
+
+        connection.send(content: headerData, completion: .contentProcessed { error in
+            if let error {
+                print("[ControlServer] SSE header send error: \(error)")
+                connection.cancel()
+                return
+            }
+        })
+
+        // Poll for new log entries every 500ms and send as SSE events.
+        // Track the last-seen entry count to only send new entries.
+        var lastSeenCount = relay.logStore.entries.count
+
+        let timer = DispatchSource.makeTimerSource(queue: queue)
+        timer.schedule(deadline: .now() + .milliseconds(500), repeating: .milliseconds(500))
+        timer.setEventHandler { [weak relay] in
+            guard let relay else {
+                timer.cancel()
+                connection.cancel()
+                return
+            }
+
+            let currentCount = relay.logStore.entries.count
+            guard currentCount > lastSeenCount else { return }
+
+            let newEntries = Array(relay.logStore.entries.suffix(currentCount - lastSeenCount))
+            lastSeenCount = currentCount
+
+            for entry in newEntries {
+                let eventData: [String: Any] = [
+                    "timestamp": entry.timestamp.timeIntervalSince1970,
+                    "level": entry.level.displayName.lowercased(),
+                    "message": entry.message,
+                ]
+
+                guard let jsonData = try? JSONSerialization.data(withJSONObject: eventData),
+                      let jsonStr = String(data: jsonData, encoding: .utf8) else { continue }
+
+                let sseEvent = "data: \(jsonStr)\n\n"
+                guard let eventBytes = sseEvent.data(using: .utf8) else { continue }
+
+                connection.send(content: eventBytes, completion: .contentProcessed { error in
+                    if error != nil {
+                        timer.cancel()
+                        connection.cancel()
+                    }
+                })
+            }
+        }
+
+        timer.resume()
+
+        // Clean up timer when connection dies
+        connection.stateUpdateHandler = { state in
+            switch state {
+            case .cancelled, .failed:
+                timer.cancel()
+            default:
+                break
+            }
+        }
+    }
+
+    private func handleGetConfig(connection: NWConnection) {
+        guard let configManager else {
+            sendResponse(connection: connection, status: 503, body: ["error": "Config not available"])
+            return
+        }
+
+        let config = configManager.config
+        let body: [String: Any] = [
+            "port": config.port,
+            "hookPort": config.hookPort,
+            "authMode": config.authMode.rawValue,
+            "multiUserEnabled": config.multiUserEnabled,
+            "claudeWorkDir": config.claudeWorkDir,
+            "logLevel": config.logLevel.rawValue,
+            "cloudflareEnabled": config.cloudflareEnabled,
+            "cloudflareTunnelName": config.cloudflareTunnelName,
+            "autoStart": config.autoStart,
+            "controlPort": self.port,
+        ]
+
+        sendResponse(connection: connection, status: 200, body: body)
+    }
+
+    private func handlePatchConfig(body: String?, connection: NWConnection) {
+        guard let configManager else {
+            sendResponse(connection: connection, status: 503, body: ["error": "Config not available"])
+            return
+        }
+
+        guard let body, let data = body.data(using: .utf8),
+              let updates = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            sendResponse(connection: connection, status: 400, body: ["error": "Invalid JSON body"])
+            return
+        }
+
+        // Apply updates to config fields
+        if let port = updates["port"] as? Int {
+            configManager.config.port = port
+        }
+        if let hookPort = updates["hookPort"] as? Int {
+            configManager.config.hookPort = hookPort
+        }
+        if let authModeStr = updates["authMode"] as? String, let authMode = AuthMode(rawValue: authModeStr) {
+            configManager.config.authMode = authMode
+        }
+        if let multiUser = updates["multiUserEnabled"] as? Bool {
+            configManager.config.multiUserEnabled = multiUser
+        }
+        if let workDir = updates["claudeWorkDir"] as? String {
+            configManager.config.claudeWorkDir = workDir
+        }
+        if let logLevelStr = updates["logLevel"] as? String, let logLevel = LogLevel(rawValue: logLevelStr) {
+            configManager.config.logLevel = logLevel
+        }
+        if let cfEnabled = updates["cloudflareEnabled"] as? Bool {
+            configManager.config.cloudflareEnabled = cfEnabled
+        }
+        if let tunnelName = updates["cloudflareTunnelName"] as? String {
+            configManager.config.cloudflareTunnelName = tunnelName
+        }
+        if let autoStart = updates["autoStart"] as? Bool {
+            configManager.config.autoStart = autoStart
+        }
+
+        // Validate before saving
+        let validation = configManager.config.validate()
+        guard validation.isValid else {
+            var errors: [String: String] = [:]
+            if let portErr = validation.portError { errors["port"] = portErr }
+            if let hookErr = validation.hookPortError { errors["hookPort"] = hookErr }
+            sendResponse(connection: connection, status: 400, body: ["error": "Validation failed", "details": errors])
+            return
+        }
+
+        do {
+            try configManager.save()
+            sendResponse(connection: connection, status: 200, body: [
+                "ok": true,
+                "message": "Config updated — restart relay to apply changes",
+            ])
+        } catch {
+            sendResponse(connection: connection, status: 500, body: ["error": "Failed to save config: \(error.localizedDescription)"])
+        }
+    }
+
+    // MARK: - Response Helpers
+
+    private func sendResponse(connection: NWConnection, status: Int, body: [String: Any]) {
+        let statusText: String
+        switch status {
+        case 200: statusText = "OK"
+        case 400: statusText = "Bad Request"
+        case 403: statusText = "Forbidden"
+        case 404: statusText = "Not Found"
+        case 500: statusText = "Internal Server Error"
+        case 503: statusText = "Service Unavailable"
+        default: statusText = "Unknown"
+        }
+
+        guard let jsonData = try? JSONSerialization.data(withJSONObject: body, options: [.sortedKeys]),
+              let jsonStr = String(data: jsonData, encoding: .utf8) else {
+            connection.cancel()
+            return
+        }
+
+        let response = "HTTP/1.1 \(status) \(statusText)\r\nContent-Type: application/json\r\nContent-Length: \(jsonData.count)\r\nConnection: close\r\n\r\n\(jsonStr)"
+
+        guard let responseData = response.data(using: .utf8) else {
+            connection.cancel()
+            return
+        }
+
+        connection.send(content: responseData, completion: .contentProcessed { _ in
+            connection.cancel()
+        })
+    }
+
+    // MARK: - Utilities
+
+    private func parseQueryString(_ query: String) -> [String: String] {
+        guard !query.isEmpty else { return [:] }
+        var result: [String: String] = [:]
+        for pair in query.split(separator: "&") {
+            let kv = pair.split(separator: "=", maxSplits: 1)
+            if kv.count == 2 {
+                let key = String(kv[0]).removingPercentEncoding ?? String(kv[0])
+                let val = String(kv[1]).removingPercentEncoding ?? String(kv[1])
+                result[key] = val
+            }
+        }
+        return result
+    }
+
+    private func pinoLevelFromString(_ str: String) -> Int? {
+        switch str.lowercased() {
+        case "trace": return 10
+        case "debug": return 20
+        case "info": return 30
+        case "warn": return 40
+        case "error": return 50
+        case "fatal": return 60
+        default: return Int(str)
+        }
+    }
+
+    deinit {
+        stop()
+    }
+}

--- a/macos/GroundControl/Services/ControlServer.swift
+++ b/macos/GroundControl/Services/ControlServer.swift
@@ -18,6 +18,11 @@ final class ControlServer {
     private let port: UInt16
     private let queue = DispatchQueue(label: "com.majortom.groundcontrol.control-server")
 
+    /// Maximum allowed size for a single request buffer (1 MB). Connections that
+    /// exceed this without delivering a complete HTTP request are terminated with
+    /// a 413 response to prevent memory exhaustion from misbehaving clients.
+    private static let maxBufferSize = 1_048_576
+
     /// Timestamp when the control server started (used for uptime calculation).
     private var startTime: Date?
 
@@ -120,6 +125,13 @@ final class ControlServer {
 
             if let data {
                 self.connectionBuffers[connID, default: Data()].append(data)
+            }
+
+            // Guard against unbounded buffer growth — reject oversized requests
+            if let currentSize = self.connectionBuffers[connID]?.count, currentSize > Self.maxBufferSize {
+                self.connectionBuffers.removeValue(forKey: connID)
+                self.sendResponse(connection: connection, status: 413, body: ["error": "Request too large"])
+                return
             }
 
             guard let buffer = self.connectionBuffers[connID] else {

--- a/macos/GroundControl/Services/ControlServer.swift
+++ b/macos/GroundControl/Services/ControlServer.swift
@@ -101,9 +101,16 @@ final class ControlServer {
         receiveMore(connection: connection, connID: connID)
     }
 
+    /// Byte sequence for HTTP header terminator `\r\n\r\n`.
+    private static let headerTerminator = Data([0x0D, 0x0A, 0x0D, 0x0A])
+
     /// Accumulates TCP frames into `connectionBuffers` until a full HTTP
     /// request (headers + optional body based on Content-Length) is available,
     /// then dispatches to `routeRequest`.
+    ///
+    /// Header terminator detection operates at the byte/Data level so that
+    /// a multibyte UTF-8 character split across TCP frames doesn't stall the
+    /// connection (String decoding is deferred until the full payload is ready).
     private func receiveMore(connection: NWConnection, connID: ObjectIdentifier) {
         connection.receive(minimumIncompleteLength: 1, maximumLength: 65536) { [weak self] data, _, isComplete, error in
             guard let self else {
@@ -115,8 +122,7 @@ final class ControlServer {
                 self.connectionBuffers[connID, default: Data()].append(data)
             }
 
-            guard let buffer = self.connectionBuffers[connID],
-                  let requestString = String(data: buffer, encoding: .utf8) else {
+            guard let buffer = self.connectionBuffers[connID] else {
                 if isComplete || error != nil {
                     self.connectionBuffers.removeValue(forKey: connID)
                     connection.cancel()
@@ -124,8 +130,9 @@ final class ControlServer {
                 return
             }
 
-            // Wait until we have the full headers (terminated by \r\n\r\n)
-            guard let headerEnd = requestString.range(of: "\r\n\r\n") else {
+            // Search for header terminator at the byte level — avoids UTF-8
+            // decode failures when multibyte characters are split across frames.
+            guard let terminatorRange = buffer.range(of: Self.headerTerminator) else {
                 if isComplete || error != nil {
                     self.connectionBuffers.removeValue(forKey: connID)
                     connection.cancel()
@@ -135,13 +142,16 @@ final class ControlServer {
                 return
             }
 
-            // If Content-Length is present, wait for the full body too
-            let headerSection = String(requestString[..<headerEnd.lowerBound])
-            if let clLine = headerSection.components(separatedBy: "\r\n")
+            // If Content-Length is present, wait for the full body too.
+            // Parse the header bytes to find the value.
+            let headerBytes = buffer[buffer.startIndex..<terminatorRange.lowerBound]
+            let bodyStartIndex = terminatorRange.upperBound
+            if let headerString = String(data: headerBytes, encoding: .utf8),
+               let clLine = headerString.components(separatedBy: "\r\n")
                 .first(where: { $0.lowercased().hasPrefix("content-length:") }),
                let clValue = Int(clLine.split(separator: ":").last?.trimmingCharacters(in: .whitespaces) ?? "") {
-                let bodyStart = requestString[headerEnd.upperBound...]
-                if bodyStart.utf8.count < clValue {
+                let bodyLength = buffer.count - bodyStartIndex
+                if bodyLength < clValue {
                     if isComplete || error != nil {
                         self.connectionBuffers.removeValue(forKey: connID)
                         connection.cancel()
@@ -152,7 +162,12 @@ final class ControlServer {
                 }
             }
 
-            // Full request received — clean up buffer and process
+            // Full request received — decode to String, clean up buffer and process.
+            guard let requestString = String(data: buffer, encoding: .utf8) else {
+                self.connectionBuffers.removeValue(forKey: connID)
+                self.sendResponse(connection: connection, status: 400, body: ["error": "Invalid UTF-8 in request"])
+                return
+            }
             self.connectionBuffers.removeValue(forKey: connID)
 
             // Validate loopback — defense in depth beyond the bind
@@ -328,20 +343,21 @@ final class ControlServer {
             return
         }
 
-        guard configManager.config.cloudflareEnabled else {
-            sendResponse(connection: connection, status: 400, body: ["error": "Cloudflare tunnel not enabled in config"])
-            return
-        }
+        Task { @MainActor [weak self] in
+            let config = configManager.config
+            guard config.cloudflareEnabled else {
+                self?.sendResponse(connection: connection, status: 400, body: ["error": "Cloudflare tunnel not enabled in config"])
+                return
+            }
 
-        guard let token = configManager.getSecret(ConfigManager.SecretKey.cloudflareToken),
-              !token.isEmpty else {
-            sendResponse(connection: connection, status: 400, body: ["error": "Cloudflare tunnel token not configured"])
-            return
-        }
+            guard let token = configManager.getSecret(ConfigManager.SecretKey.cloudflareToken),
+                  !token.isEmpty else {
+                self?.sendResponse(connection: connection, status: 400, body: ["error": "Cloudflare tunnel token not configured"])
+                return
+            }
 
-        Task { @MainActor in
             await relay.tunnel.start(token: token)
-            self.sendResponse(connection: connection, status: 200, body: ["ok": true, "state": "starting"])
+            self?.sendResponse(connection: connection, status: 200, body: ["ok": true, "state": "starting"])
         }
     }
 
@@ -451,33 +467,35 @@ final class ControlServer {
                 return
             }
 
-            // Snapshot entries from main actor would be ideal, but the timer
-            // fires on our serial queue. We snapshot just the suffix we need.
-            let entries = relay.logStore.entries
-            let newEntries = entries.filter { $0.timestamp > lastSeenTimestamp }
-            guard !newEntries.isEmpty else { return }
+            // Snapshot entries on @MainActor — Deque isn't thread-safe.
+            // Use a Task to hop to main, snapshot, then send SSE events.
+            Task { @MainActor in
+                let entries = Array(relay.logStore.entries)
+                let newEntries = entries.filter { $0.timestamp > lastSeenTimestamp }
+                guard !newEntries.isEmpty else { return }
 
-            lastSeenTimestamp = newEntries.last!.timestamp
+                lastSeenTimestamp = newEntries.last!.timestamp
 
-            for entry in newEntries {
-                let eventData: [String: Any] = [
-                    "timestamp": entry.timestamp.timeIntervalSince1970,
-                    "level": entry.level.displayName.lowercased(),
-                    "message": entry.message,
-                ]
+                for entry in newEntries {
+                    let eventData: [String: Any] = [
+                        "timestamp": entry.timestamp.timeIntervalSince1970,
+                        "level": entry.level.displayName.lowercased(),
+                        "message": entry.message,
+                    ]
 
-                guard let jsonData = try? JSONSerialization.data(withJSONObject: eventData),
-                      let jsonStr = String(data: jsonData, encoding: .utf8) else { continue }
+                    guard let jsonData = try? JSONSerialization.data(withJSONObject: eventData),
+                          let jsonStr = String(data: jsonData, encoding: .utf8) else { continue }
 
-                let sseEvent = "data: \(jsonStr)\n\n"
-                guard let eventBytes = sseEvent.data(using: .utf8) else { continue }
+                    let sseEvent = "data: \(jsonStr)\n\n"
+                    guard let eventBytes = sseEvent.data(using: .utf8) else { continue }
 
-                connection.send(content: eventBytes, completion: .contentProcessed { error in
-                    if error != nil {
-                        timer.cancel()
-                        connection.cancel()
-                    }
-                })
+                    connection.send(content: eventBytes, completion: .contentProcessed { error in
+                        if error != nil {
+                            timer.cancel()
+                            connection.cancel()
+                        }
+                    })
+                }
             }
         }
 
@@ -535,67 +553,76 @@ final class ControlServer {
             return
         }
 
-        // Apply updates to a copy — only commit to configManager on successful validation
-        var updatedConfig = configManager.config
-        let previousControlPort = updatedConfig.controlPort
+        Task { [weak self] in
+            guard let self else { return }
 
-        if let port = updates["port"] as? Int {
-            updatedConfig.port = port
-        }
-        if let hookPort = updates["hookPort"] as? Int {
-            updatedConfig.hookPort = hookPort
-        }
-        if let controlPort = updates["controlPort"] as? Int {
-            updatedConfig.controlPort = controlPort
-        }
-        if let authModeStr = updates["authMode"] as? String, let authMode = AuthMode(rawValue: authModeStr) {
-            updatedConfig.authMode = authMode
-        }
-        if let multiUser = updates["multiUserEnabled"] as? Bool {
-            updatedConfig.multiUserEnabled = multiUser
-        }
-        if let workDir = updates["claudeWorkDir"] as? String {
-            updatedConfig.claudeWorkDir = workDir
-        }
-        if let logLevelStr = updates["logLevel"] as? String, let logLevel = LogLevel(rawValue: logLevelStr) {
-            updatedConfig.logLevel = logLevel
-        }
-        if let cfEnabled = updates["cloudflareEnabled"] as? Bool {
-            updatedConfig.cloudflareEnabled = cfEnabled
-        }
-        if let tunnelName = updates["cloudflareTunnelName"] as? String {
-            updatedConfig.cloudflareTunnelName = tunnelName
-        }
-        if let autoStart = updates["autoStart"] as? Bool {
-            updatedConfig.autoStart = autoStart
-        }
+            // Snapshot initial config on @MainActor — ConfigManager is @Observable
+            // and bound to SwiftUI on main actor
+            let initialConfig = await MainActor.run { configManager.config }
+            var updatedConfig = initialConfig
+            let previousControlPort = updatedConfig.controlPort
 
-        // Validate the copy before mutating the live config
-        let validation = updatedConfig.validate()
-        guard validation.isValid else {
-            var errors: [String: String] = [:]
-            if let portErr = validation.portError { errors["port"] = portErr }
-            if let hookErr = validation.hookPortError { errors["hookPort"] = hookErr }
-            if let controlPortErr = validation.controlPortError { errors["controlPort"] = controlPortErr }
-            sendResponse(connection: connection, status: 400, body: ["error": "Validation failed", "details": errors])
-            return
-        }
-
-        configManager.config = updatedConfig
-        do {
-            try configManager.save()
-            let controlPortChanged = updatedConfig.controlPort != previousControlPort
-            var responseBody: [String: Any] = [
-                "ok": true,
-                "message": "Config updated — restart relay to apply changes",
-            ]
-            if controlPortChanged {
-                responseBody["requiresRestart"] = true
-                responseBody["message"] = "Config updated — restart Ground Control to apply control port change, restart relay for other changes"
+            if let port = updates["port"] as? Int {
+                updatedConfig.port = port
             }
-            sendResponse(connection: connection, status: 200, body: responseBody)
-        } catch {
-            sendResponse(connection: connection, status: 500, body: ["error": "Failed to save config: \(error.localizedDescription)"])
+            if let hookPort = updates["hookPort"] as? Int {
+                updatedConfig.hookPort = hookPort
+            }
+            if let controlPort = updates["controlPort"] as? Int {
+                updatedConfig.controlPort = controlPort
+            }
+            if let authModeStr = updates["authMode"] as? String, let authMode = AuthMode(rawValue: authModeStr) {
+                updatedConfig.authMode = authMode
+            }
+            if let multiUser = updates["multiUserEnabled"] as? Bool {
+                updatedConfig.multiUserEnabled = multiUser
+            }
+            if let workDir = updates["claudeWorkDir"] as? String {
+                updatedConfig.claudeWorkDir = workDir
+            }
+            if let logLevelStr = updates["logLevel"] as? String, let logLevel = LogLevel(rawValue: logLevelStr) {
+                updatedConfig.logLevel = logLevel
+            }
+            if let cfEnabled = updates["cloudflareEnabled"] as? Bool {
+                updatedConfig.cloudflareEnabled = cfEnabled
+            }
+            if let tunnelName = updates["cloudflareTunnelName"] as? String {
+                updatedConfig.cloudflareTunnelName = tunnelName
+            }
+            if let autoStart = updates["autoStart"] as? Bool {
+                updatedConfig.autoStart = autoStart
+            }
+
+            // Validate the copy before mutating the live config
+            let validation = updatedConfig.validate()
+            guard validation.isValid else {
+                var errors: [String: String] = [:]
+                if let portErr = validation.portError { errors["port"] = portErr }
+                if let hookErr = validation.hookPortError { errors["hookPort"] = hookErr }
+                if let controlPortErr = validation.controlPortError { errors["controlPort"] = controlPortErr }
+                self.sendResponse(connection: connection, status: 400, body: ["error": "Validation failed", "details": errors])
+                return
+            }
+
+            // Assign back + save on @MainActor
+            do {
+                try await MainActor.run {
+                    configManager.config = updatedConfig
+                    try configManager.save()
+                }
+                let controlPortChanged = updatedConfig.controlPort != previousControlPort
+                var responseBody: [String: Any] = [
+                    "ok": true,
+                    "message": "Config updated — restart relay to apply changes",
+                ]
+                if controlPortChanged {
+                    responseBody["requiresRestart"] = true
+                    responseBody["message"] = "Config updated — restart Ground Control to apply control port change, restart relay for other changes"
+                }
+                self.sendResponse(connection: connection, status: 200, body: responseBody)
+            } catch {
+                self.sendResponse(connection: connection, status: 500, body: ["error": "Failed to save config: \(error.localizedDescription)"])
+            }
         }
     }
 

--- a/macos/GroundControl/Services/ControlServer.swift
+++ b/macos/GroundControl/Services/ControlServer.swift
@@ -23,6 +23,10 @@ final class ControlServer {
 
     // MARK: - Dependencies (injected from app)
 
+    /// Per-connection buffer for accumulating TCP frames until a complete HTTP
+    /// request has been received (headers + body).
+    private var connectionBuffers: [ObjectIdentifier: Data] = [:]
+
     private weak var relay: RelayProcess?
     private weak var configManager: ConfigManager?
 
@@ -51,14 +55,20 @@ final class ControlServer {
             nwListener.stateUpdateHandler = { [weak self] state in
                 switch state {
                 case .ready:
-                    self?.isRunning = true
-                    self?.startTime = Date()
+                    Task { @MainActor [weak self] in
+                        self?.isRunning = true
+                        self?.startTime = Date()
+                    }
                     print("[ControlServer] Listening on 127.0.0.1:\(self?.port ?? 0)")
                 case .failed(let error):
                     print("[ControlServer] Failed: \(error)")
-                    self?.isRunning = false
+                    Task { @MainActor [weak self] in
+                        self?.isRunning = false
+                    }
                 case .cancelled:
-                    self?.isRunning = false
+                    Task { @MainActor [weak self] in
+                        self?.isRunning = false
+                    }
                 default:
                     break
                 }
@@ -85,14 +95,65 @@ final class ControlServer {
     // MARK: - Connection Handling
 
     private func handleConnection(_ connection: NWConnection) {
+        let connID = ObjectIdentifier(connection)
+        connectionBuffers[connID] = Data()
         connection.start(queue: queue)
+        receiveMore(connection: connection, connID: connID)
+    }
 
-        // Read the full HTTP request (up to 64KB should be plenty for control API)
-        connection.receive(minimumIncompleteLength: 1, maximumLength: 65536) { [weak self] data, _, _, error in
-            guard let self, let data, error == nil else {
+    /// Accumulates TCP frames into `connectionBuffers` until a full HTTP
+    /// request (headers + optional body based on Content-Length) is available,
+    /// then dispatches to `routeRequest`.
+    private func receiveMore(connection: NWConnection, connID: ObjectIdentifier) {
+        connection.receive(minimumIncompleteLength: 1, maximumLength: 65536) { [weak self] data, _, isComplete, error in
+            guard let self else {
                 connection.cancel()
                 return
             }
+
+            if let data {
+                self.connectionBuffers[connID, default: Data()].append(data)
+            }
+
+            guard let buffer = self.connectionBuffers[connID],
+                  let requestString = String(data: buffer, encoding: .utf8) else {
+                if isComplete || error != nil {
+                    self.connectionBuffers.removeValue(forKey: connID)
+                    connection.cancel()
+                }
+                return
+            }
+
+            // Wait until we have the full headers (terminated by \r\n\r\n)
+            guard let headerEnd = requestString.range(of: "\r\n\r\n") else {
+                if isComplete || error != nil {
+                    self.connectionBuffers.removeValue(forKey: connID)
+                    connection.cancel()
+                } else {
+                    self.receiveMore(connection: connection, connID: connID)
+                }
+                return
+            }
+
+            // If Content-Length is present, wait for the full body too
+            let headerSection = String(requestString[..<headerEnd.lowerBound])
+            if let clLine = headerSection.components(separatedBy: "\r\n")
+                .first(where: { $0.lowercased().hasPrefix("content-length:") }),
+               let clValue = Int(clLine.split(separator: ":").last?.trimmingCharacters(in: .whitespaces) ?? "") {
+                let bodyStart = requestString[headerEnd.upperBound...]
+                if bodyStart.utf8.count < clValue {
+                    if isComplete || error != nil {
+                        self.connectionBuffers.removeValue(forKey: connID)
+                        connection.cancel()
+                    } else {
+                        self.receiveMore(connection: connection, connID: connID)
+                    }
+                    return
+                }
+            }
+
+            // Full request received — clean up buffer and process
+            self.connectionBuffers.removeValue(forKey: connID)
 
             // Validate loopback — defense in depth beyond the bind
             if let endpoint = connection.currentPath?.remoteEndpoint,
@@ -105,12 +166,7 @@ final class ControlServer {
                 }
             }
 
-            guard let requestString = String(data: data, encoding: .utf8) else {
-                self.sendResponse(connection: connection, status: 400, body: ["error": "Invalid request"])
-                return
-            }
-
-            self.routeRequest(requestString, rawData: data, connection: connection)
+            self.routeRequest(requestString, rawData: buffer, connection: connection)
         }
     }
 
@@ -301,7 +357,16 @@ final class ControlServer {
 
         // Parse query parameters
         let params = parseQueryString(queryString)
-        let count = Int(params["count"] ?? "") ?? 100
+        let count: Int
+        if let countString = params["count"] {
+            guard let parsedCount = Int(countString), (1...1000).contains(parsedCount) else {
+                sendResponse(connection: connection, status: 400, body: ["error": "Invalid count; expected integer in range 1...1000"])
+                return
+            }
+            count = parsedCount
+        } else {
+            count = 100
+        }
         let level = params["level"]
         let since = params["since"].flatMap { Double($0) }.map { Date(timeIntervalSince1970: $0) }
 
@@ -446,45 +511,48 @@ final class ControlServer {
             return
         }
 
-        // Apply updates to config fields
+        // Apply updates to a copy — only commit to configManager on successful validation
+        var updatedConfig = configManager.config
         if let port = updates["port"] as? Int {
-            configManager.config.port = port
+            updatedConfig.port = port
         }
         if let hookPort = updates["hookPort"] as? Int {
-            configManager.config.hookPort = hookPort
+            updatedConfig.hookPort = hookPort
         }
         if let authModeStr = updates["authMode"] as? String, let authMode = AuthMode(rawValue: authModeStr) {
-            configManager.config.authMode = authMode
+            updatedConfig.authMode = authMode
         }
         if let multiUser = updates["multiUserEnabled"] as? Bool {
-            configManager.config.multiUserEnabled = multiUser
+            updatedConfig.multiUserEnabled = multiUser
         }
         if let workDir = updates["claudeWorkDir"] as? String {
-            configManager.config.claudeWorkDir = workDir
+            updatedConfig.claudeWorkDir = workDir
         }
         if let logLevelStr = updates["logLevel"] as? String, let logLevel = LogLevel(rawValue: logLevelStr) {
-            configManager.config.logLevel = logLevel
+            updatedConfig.logLevel = logLevel
         }
         if let cfEnabled = updates["cloudflareEnabled"] as? Bool {
-            configManager.config.cloudflareEnabled = cfEnabled
+            updatedConfig.cloudflareEnabled = cfEnabled
         }
         if let tunnelName = updates["cloudflareTunnelName"] as? String {
-            configManager.config.cloudflareTunnelName = tunnelName
+            updatedConfig.cloudflareTunnelName = tunnelName
         }
         if let autoStart = updates["autoStart"] as? Bool {
-            configManager.config.autoStart = autoStart
+            updatedConfig.autoStart = autoStart
         }
 
-        // Validate before saving
-        let validation = configManager.config.validate()
+        // Validate the copy before mutating the live config
+        let validation = updatedConfig.validate()
         guard validation.isValid else {
             var errors: [String: String] = [:]
             if let portErr = validation.portError { errors["port"] = portErr }
             if let hookErr = validation.hookPortError { errors["hookPort"] = hookErr }
+            if let controlPortErr = validation.controlPortError { errors["controlPort"] = controlPortErr }
             sendResponse(connection: connection, status: 400, body: ["error": "Validation failed", "details": errors])
             return
         }
 
+        configManager.config = updatedConfig
         do {
             try configManager.save()
             sendResponse(connection: connection, status: 200, body: [

--- a/macos/GroundControl/Services/ControlServer.swift
+++ b/macos/GroundControl/Services/ControlServer.swift
@@ -235,47 +235,55 @@ final class ControlServer {
             return
         }
 
-        let relayStateStr: String
-        let relayRunning: Bool
-        switch relay.state.processState {
-        case .idle: relayStateStr = "idle"; relayRunning = false
-        case .starting: relayStateStr = "starting"; relayRunning = false
-        case .running: relayStateStr = "running"; relayRunning = true
-        case .stopping: relayStateStr = "stopping"; relayRunning = false
-        case .error(let msg): relayStateStr = "error: \(msg)"; relayRunning = false
-        case .restarting(let attempt): relayStateStr = "restarting (attempt \(attempt))"; relayRunning = false
+        Task { [weak self] in
+            // Snapshot relay state on @MainActor to avoid data races
+            let body: [String: Any] = await MainActor.run {
+                let relayStateStr: String
+                let relayRunning: Bool
+                switch relay.state.processState {
+                case .idle: relayStateStr = "idle"; relayRunning = false
+                case .starting: relayStateStr = "starting"; relayRunning = false
+                case .running: relayStateStr = "running"; relayRunning = true
+                case .stopping: relayStateStr = "stopping"; relayRunning = false
+                case .error(let msg): relayStateStr = "error: \(msg)"; relayRunning = false
+                case .restarting(let attempt): relayStateStr = "restarting (attempt \(attempt))"; relayRunning = false
+                }
+
+                let tunnelStateStr: String
+                switch relay.tunnel.state {
+                case .idle: tunnelStateStr = "idle"
+                case .starting: tunnelStateStr = "starting"
+                case .running: tunnelStateStr = "running"
+                case .stopping: tunnelStateStr = "stopping"
+                case .error(let msg): tunnelStateStr = "error: \(msg)"
+                case .restarting(let attempt): tunnelStateStr = "restarting (attempt \(attempt))"
+                }
+
+                var result: [String: Any] = [
+                    "relay": [
+                        "state": relayStateStr,
+                        "running": relayRunning,
+                        "port": relay.state.port,
+                        "hookPort": relay.state.hookPort,
+                        "restartCount": relay.state.restartCount,
+                    ] as [String: Any],
+                    "tunnel": [
+                        "state": tunnelStateStr,
+                        "running": relay.tunnel.isRunning,
+                        "restartCount": relay.tunnel.restartCount,
+                    ] as [String: Any],
+                ]
+
+                if let start = self?.startTime {
+                    result["uptime"] = Date().timeIntervalSince(start)
+                }
+
+                return result
+            }
+
+            guard let self else { return }
+            self.sendResponse(connection: connection, status: 200, body: body)
         }
-
-        let tunnelStateStr: String
-        switch relay.tunnel.state {
-        case .idle: tunnelStateStr = "idle"
-        case .starting: tunnelStateStr = "starting"
-        case .running: tunnelStateStr = "running"
-        case .stopping: tunnelStateStr = "stopping"
-        case .error(let msg): tunnelStateStr = "error: \(msg)"
-        case .restarting(let attempt): tunnelStateStr = "restarting (attempt \(attempt))"
-        }
-
-        var body: [String: Any] = [
-            "relay": [
-                "state": relayStateStr,
-                "running": relayRunning,
-                "port": relay.state.port,
-                "hookPort": relay.state.hookPort,
-                "restartCount": relay.state.restartCount,
-            ] as [String: Any],
-            "tunnel": [
-                "state": tunnelStateStr,
-                "running": relay.tunnel.isRunning,
-                "restartCount": relay.tunnel.restartCount,
-            ] as [String: Any],
-        ]
-
-        if let start = startTime {
-            body["uptime"] = Date().timeIntervalSince(start)
-        }
-
-        sendResponse(connection: connection, status: 200, body: body)
     }
 
     private func handleRelayStart(connection: NWConnection) {
@@ -370,35 +378,42 @@ final class ControlServer {
         let level = params["level"]
         let since = params["since"].flatMap { Double($0) }.map { Date(timeIntervalSince1970: $0) }
 
-        let entries = relay.logStore.entries
-        var filtered = Array(entries)
+        Task { [weak self] in
+            // Snapshot entries on @MainActor — Deque isn't thread-safe
+            let entries = await MainActor.run {
+                Array(relay.logStore.entries)
+            }
+            guard let self else { return }
 
-        // Filter by timestamp if provided
-        if let sinceDate = since {
-            filtered = filtered.filter { $0.timestamp >= sinceDate }
+            var filtered = entries
+
+            // Filter by timestamp if provided
+            if let sinceDate = since {
+                filtered = filtered.filter { $0.timestamp >= sinceDate }
+            }
+
+            // Filter by level if provided
+            if let levelStr = level, let pinoLevel = self.pinoLevelFromString(levelStr) {
+                filtered = filtered.filter { $0.level.rawValue >= pinoLevel }
+            }
+
+            // Take last N entries
+            let clamped = min(count, filtered.count)
+            let result = Array(filtered.suffix(clamped))
+
+            let logEntries: [[String: Any]] = result.map { entry in
+                [
+                    "timestamp": entry.timestamp.timeIntervalSince1970,
+                    "level": entry.level.displayName.lowercased(),
+                    "message": entry.message,
+                ]
+            }
+
+            self.sendResponse(connection: connection, status: 200, body: [
+                "count": logEntries.count,
+                "entries": logEntries,
+            ])
         }
-
-        // Filter by level if provided
-        if let levelStr = level, let pinoLevel = pinoLevelFromString(levelStr) {
-            filtered = filtered.filter { $0.level.rawValue >= pinoLevel }
-        }
-
-        // Take last N entries
-        let clamped = min(count, filtered.count)
-        let result = Array(filtered.suffix(clamped))
-
-        let logEntries: [[String: Any]] = result.map { entry in
-            [
-                "timestamp": entry.timestamp.timeIntervalSince1970,
-                "level": entry.level.displayName.lowercased(),
-                "message": entry.message,
-            ]
-        }
-
-        sendResponse(connection: connection, status: 200, body: [
-            "count": logEntries.count,
-            "entries": logEntries,
-        ])
     }
 
     private func handleLogStream(connection: NWConnection) {
@@ -423,8 +438,9 @@ final class ControlServer {
         })
 
         // Poll for new log entries every 500ms and send as SSE events.
-        // Track the last-seen entry count to only send new entries.
-        var lastSeenCount = relay.logStore.entries.count
+        // Track by last-seen timestamp instead of count — ring buffer eviction
+        // causes count to plateau, which would silently stop streaming.
+        var lastSeenTimestamp: Date = Date()
 
         let timer = DispatchSource.makeTimerSource(queue: queue)
         timer.schedule(deadline: .now() + .milliseconds(500), repeating: .milliseconds(500))
@@ -435,11 +451,13 @@ final class ControlServer {
                 return
             }
 
-            let currentCount = relay.logStore.entries.count
-            guard currentCount > lastSeenCount else { return }
+            // Snapshot entries from main actor would be ideal, but the timer
+            // fires on our serial queue. We snapshot just the suffix we need.
+            let entries = relay.logStore.entries
+            let newEntries = entries.filter { $0.timestamp > lastSeenTimestamp }
+            guard !newEntries.isEmpty else { return }
 
-            let newEntries = Array(relay.logStore.entries.suffix(currentCount - lastSeenCount))
-            lastSeenCount = currentCount
+            lastSeenTimestamp = newEntries.last!.timestamp
 
             for entry in newEntries {
                 let eventData: [String: Any] = [
@@ -482,21 +500,27 @@ final class ControlServer {
             return
         }
 
-        let config = configManager.config
-        let body: [String: Any] = [
-            "port": config.port,
-            "hookPort": config.hookPort,
-            "authMode": config.authMode.rawValue,
-            "multiUserEnabled": config.multiUserEnabled,
-            "claudeWorkDir": config.claudeWorkDir,
-            "logLevel": config.logLevel.rawValue,
-            "cloudflareEnabled": config.cloudflareEnabled,
-            "cloudflareTunnelName": config.cloudflareTunnelName,
-            "autoStart": config.autoStart,
-            "controlPort": self.port,
-        ]
+        Task { [weak self] in
+            guard let self else { return }
+            // Snapshot config on @MainActor to avoid racing with SwiftUI edits
+            let body: [String: Any] = await MainActor.run {
+                let config = configManager.config
+                return [
+                    "port": config.port,
+                    "hookPort": config.hookPort,
+                    "authMode": config.authMode.rawValue,
+                    "multiUserEnabled": config.multiUserEnabled,
+                    "claudeWorkDir": config.claudeWorkDir,
+                    "logLevel": config.logLevel.rawValue,
+                    "cloudflareEnabled": config.cloudflareEnabled,
+                    "cloudflareTunnelName": config.cloudflareTunnelName,
+                    "autoStart": config.autoStart,
+                    "controlPort": config.controlPort,
+                ]
+            }
 
-        sendResponse(connection: connection, status: 200, body: body)
+            self.sendResponse(connection: connection, status: 200, body: body)
+        }
     }
 
     private func handlePatchConfig(body: String?, connection: NWConnection) {
@@ -513,11 +537,16 @@ final class ControlServer {
 
         // Apply updates to a copy — only commit to configManager on successful validation
         var updatedConfig = configManager.config
+        let previousControlPort = updatedConfig.controlPort
+
         if let port = updates["port"] as? Int {
             updatedConfig.port = port
         }
         if let hookPort = updates["hookPort"] as? Int {
             updatedConfig.hookPort = hookPort
+        }
+        if let controlPort = updates["controlPort"] as? Int {
+            updatedConfig.controlPort = controlPort
         }
         if let authModeStr = updates["authMode"] as? String, let authMode = AuthMode(rawValue: authModeStr) {
             updatedConfig.authMode = authMode
@@ -555,10 +584,16 @@ final class ControlServer {
         configManager.config = updatedConfig
         do {
             try configManager.save()
-            sendResponse(connection: connection, status: 200, body: [
+            let controlPortChanged = updatedConfig.controlPort != previousControlPort
+            var responseBody: [String: Any] = [
                 "ok": true,
                 "message": "Config updated — restart relay to apply changes",
-            ])
+            ]
+            if controlPortChanged {
+                responseBody["requiresRestart"] = true
+                responseBody["message"] = "Config updated — restart Ground Control to apply control port change, restart relay for other changes"
+            }
+            sendResponse(connection: connection, status: 200, body: responseBody)
         } catch {
             sendResponse(connection: connection, status: 500, body: ["error": "Failed to save config: \(error.localizedDescription)"])
         }

--- a/mcp/ground-control-mcp/package-lock.json
+++ b/mcp/ground-control-mcp/package-lock.json
@@ -1,0 +1,1183 @@
+{
+  "name": "@major-tom/ground-control-mcp",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@major-tom/ground-control-mcp",
+      "version": "1.0.0",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.29.0",
+        "zod": "^3.25.1"
+      },
+      "bin": {
+        "ground-control-mcp": "dist/index.js"
+      },
+      "devDependencies": {
+        "@types/node": "^22.0.0",
+        "typescript": "^5.8.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.13",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.13.tgz",
+      "integrity": "sha512-TsQLe4i2gvoTtrHje625ngThGBySOgSK3Xo2XRYOdqGN1teR8+I7vchQC46uLJi8OF62YTYA3AhSpumtkhsaKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "22.19.17",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.17.tgz",
+      "integrity": "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
+      "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.2.tgz",
+      "integrity": "sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "10.1.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.12",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.12.tgz",
+      "integrity": "sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/jose": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.2.tgz",
+      "integrity": "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
+      }
+    }
+  }
+}

--- a/mcp/ground-control-mcp/package.json
+++ b/mcp/ground-control-mcp/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@major-tom/ground-control-mcp",
+  "version": "1.0.0",
+  "description": "MCP server bridge for Ground Control — programmatic relay/tunnel management",
+  "type": "module",
+  "main": "dist/index.js",
+  "bin": {
+    "ground-control-mcp": "dist/index.js"
+  },
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch",
+    "start": "node dist/index.js"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.29.0",
+    "zod": "^3.25.1"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "typescript": "^5.8.0"
+  },
+  "engines": {
+    "node": ">=20.0.0"
+  },
+  "private": true
+}

--- a/mcp/ground-control-mcp/src/index.ts
+++ b/mcp/ground-control-mcp/src/index.ts
@@ -1,0 +1,68 @@
+#!/usr/bin/env node
+
+/**
+ * Ground Control MCP Server
+ *
+ * Bridges Claude Code agents to the Ground Control macOS app via MCP tools.
+ * Each tool is a thin wrapper around the ControlServer HTTP API running on
+ * 127.0.0.1:<controlPort> (default 9092).
+ *
+ * Usage:
+ *   npx ground-control-mcp
+ *   GROUND_CONTROL_URL=http://127.0.0.1:9092 npx ground-control-mcp
+ *
+ * Claude Code config (~/.claude.json or project .mcp.json):
+ *   {
+ *     "mcpServers": {
+ *       "ground-control": {
+ *         "command": "node",
+ *         "args": ["<path>/mcp/ground-control-mcp/dist/index.js"]
+ *       }
+ *     }
+ *   }
+ */
+
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { registerTools } from "./tools.js";
+
+async function main() {
+  const server = new McpServer(
+    {
+      name: "ground-control",
+      version: "1.0.0",
+    },
+    {
+      capabilities: { logging: {} },
+      instructions: [
+        "Ground Control MCP server — manages the Major Tom relay server and Cloudflare tunnel.",
+        "The relay is a Node.js WebSocket server that bridges Claude Code to the Major Tom PWA/iOS app.",
+        "The tunnel is an optional Cloudflare tunnel for remote access.",
+        "",
+        "Available tools:",
+        "  get_relay_status  — Check relay + tunnel state, uptime, restart count",
+        "  start_relay       — Start the relay server",
+        "  stop_relay        — Stop the relay server",
+        "  restart_relay     — Restart the relay (stop then start)",
+        "  start_tunnel      — Start the Cloudflare tunnel",
+        "  stop_tunnel       — Stop the Cloudflare tunnel",
+        "  get_logs          — Fetch recent log entries (filterable by level/count)",
+        "  get_config        — Read current configuration",
+        "  update_config     — Update config fields (restart relay to apply)",
+        "",
+        "Always check get_relay_status before starting/stopping to avoid redundant operations.",
+      ].join("\n"),
+    }
+  );
+
+  registerTools(server);
+
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+  console.error("[ground-control-mcp] Server running on stdio");
+}
+
+main().catch((error) => {
+  console.error("[ground-control-mcp] Fatal error:", error);
+  process.exit(1);
+});

--- a/mcp/ground-control-mcp/src/tools.ts
+++ b/mcp/ground-control-mcp/src/tools.ts
@@ -345,6 +345,13 @@ export function registerTools(server: McpServer): void {
         .boolean()
         .optional()
         .describe("Auto-start relay on app launch"),
+      controlPort: z
+        .number()
+        .int()
+        .min(1024)
+        .max(65535)
+        .optional()
+        .describe("Control API port (requires Ground Control restart to take effect)"),
     },
     async (params) => {
       try {

--- a/mcp/ground-control-mcp/src/tools.ts
+++ b/mcp/ground-control-mcp/src/tools.ts
@@ -1,0 +1,388 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+
+// ---------------------------------------------------------------------------
+// Control API client — thin HTTP wrapper for Ground Control's ControlServer
+// ---------------------------------------------------------------------------
+
+const DEFAULT_BASE_URL = "http://127.0.0.1:9092";
+
+function getBaseUrl(): string {
+  return process.env.GROUND_CONTROL_URL || DEFAULT_BASE_URL;
+}
+
+interface ControlResponse {
+  status: number;
+  body: Record<string, unknown>;
+}
+
+async function controlRequest(
+  method: string,
+  path: string,
+  body?: Record<string, unknown>
+): Promise<ControlResponse> {
+  const url = `${getBaseUrl()}${path}`;
+
+  const opts: RequestInit = {
+    method,
+    headers: { "Content-Type": "application/json" },
+  };
+
+  if (body) {
+    opts.body = JSON.stringify(body);
+  }
+
+  const res = await fetch(url, opts);
+  const text = await res.text();
+
+  let parsed: Record<string, unknown>;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    parsed = { raw: text };
+  }
+
+  return { status: res.status, body: parsed };
+}
+
+// ---------------------------------------------------------------------------
+// Tool registration — each tool maps 1:1 to a ControlServer endpoint
+// ---------------------------------------------------------------------------
+
+export function registerTools(server: McpServer): void {
+  // ── get_relay_status ────────────────────────────────────────
+  server.tool(
+    "get_relay_status",
+    "Get relay state, tunnel state, restart count, and uptime",
+    {},
+    async () => {
+      try {
+        const res = await controlRequest("GET", "/control/status");
+        return {
+          content: [
+            { type: "text" as const, text: JSON.stringify(res.body, null, 2) },
+          ],
+          isError: res.status !== 200,
+        };
+      } catch (error) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: `Failed to reach Ground Control: ${error instanceof Error ? error.message : String(error)}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+    }
+  );
+
+  // ── start_relay ─────────────────────────────────────────────
+  server.tool(
+    "start_relay",
+    "Start the relay server",
+    {},
+    async () => {
+      try {
+        const res = await controlRequest("POST", "/control/relay/start");
+        return {
+          content: [
+            { type: "text" as const, text: JSON.stringify(res.body, null, 2) },
+          ],
+          isError: res.status !== 200,
+        };
+      } catch (error) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: `Failed to start relay: ${error instanceof Error ? error.message : String(error)}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+    }
+  );
+
+  // ── stop_relay ──────────────────────────────────────────────
+  server.tool(
+    "stop_relay",
+    "Stop the relay server",
+    {},
+    async () => {
+      try {
+        const res = await controlRequest("POST", "/control/relay/stop");
+        return {
+          content: [
+            { type: "text" as const, text: JSON.stringify(res.body, null, 2) },
+          ],
+          isError: res.status !== 200,
+        };
+      } catch (error) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: `Failed to stop relay: ${error instanceof Error ? error.message : String(error)}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+    }
+  );
+
+  // ── restart_relay ───────────────────────────────────────────
+  server.tool(
+    "restart_relay",
+    "Restart the relay server (stop then start)",
+    {},
+    async () => {
+      try {
+        const res = await controlRequest("POST", "/control/relay/restart");
+        return {
+          content: [
+            { type: "text" as const, text: JSON.stringify(res.body, null, 2) },
+          ],
+          isError: res.status !== 200,
+        };
+      } catch (error) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: `Failed to restart relay: ${error instanceof Error ? error.message : String(error)}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+    }
+  );
+
+  // ── start_tunnel ────────────────────────────────────────────
+  server.tool(
+    "start_tunnel",
+    "Start the Cloudflare tunnel (must be configured in Ground Control)",
+    {},
+    async () => {
+      try {
+        const res = await controlRequest("POST", "/control/tunnel/start");
+        return {
+          content: [
+            { type: "text" as const, text: JSON.stringify(res.body, null, 2) },
+          ],
+          isError: res.status !== 200,
+        };
+      } catch (error) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: `Failed to start tunnel: ${error instanceof Error ? error.message : String(error)}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+    }
+  );
+
+  // ── stop_tunnel ─────────────────────────────────────────────
+  server.tool(
+    "stop_tunnel",
+    "Stop the Cloudflare tunnel",
+    {},
+    async () => {
+      try {
+        const res = await controlRequest("POST", "/control/tunnel/stop");
+        return {
+          content: [
+            { type: "text" as const, text: JSON.stringify(res.body, null, 2) },
+          ],
+          isError: res.status !== 200,
+        };
+      } catch (error) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: `Failed to stop tunnel: ${error instanceof Error ? error.message : String(error)}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+    }
+  );
+
+  // ── get_logs ────────────────────────────────────────────────
+  server.tool(
+    "get_logs",
+    "Get recent log entries from Ground Control, optionally filtered by level and count",
+    {
+      count: z
+        .number()
+        .int()
+        .min(1)
+        .max(1000)
+        .optional()
+        .describe("Number of recent log entries to return (default 100, max 1000)"),
+      level: z
+        .enum(["trace", "debug", "info", "warn", "error", "fatal"])
+        .optional()
+        .describe("Minimum log level to include (default: all levels)"),
+      since: z
+        .number()
+        .optional()
+        .describe("Unix timestamp — only return entries after this time"),
+    },
+    async ({ count, level, since }) => {
+      try {
+        const params = new URLSearchParams();
+        if (count !== undefined) params.set("count", String(count));
+        if (level) params.set("level", level);
+        if (since !== undefined) params.set("since", String(since));
+
+        const query = params.toString();
+        const path = `/control/logs${query ? `?${query}` : ""}`;
+        const res = await controlRequest("GET", path);
+
+        return {
+          content: [
+            { type: "text" as const, text: JSON.stringify(res.body, null, 2) },
+          ],
+          isError: res.status !== 200,
+        };
+      } catch (error) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: `Failed to get logs: ${error instanceof Error ? error.message : String(error)}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+    }
+  );
+
+  // ── get_config ──────────────────────────────────────────────
+  server.tool(
+    "get_config",
+    "Get current Ground Control configuration (non-secret fields only)",
+    {},
+    async () => {
+      try {
+        const res = await controlRequest("GET", "/control/config");
+        return {
+          content: [
+            { type: "text" as const, text: JSON.stringify(res.body, null, 2) },
+          ],
+          isError: res.status !== 200,
+        };
+      } catch (error) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: `Failed to get config: ${error instanceof Error ? error.message : String(error)}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+    }
+  );
+
+  // ── update_config ───────────────────────────────────────────
+  server.tool(
+    "update_config",
+    "Update Ground Control config fields. Restart the relay to apply changes.",
+    {
+      port: z
+        .number()
+        .int()
+        .min(1024)
+        .max(65535)
+        .optional()
+        .describe("Relay WebSocket port"),
+      hookPort: z
+        .number()
+        .int()
+        .min(1024)
+        .max(65535)
+        .optional()
+        .describe("Hook listener port"),
+      authMode: z
+        .enum(["none", "pin", "google"])
+        .optional()
+        .describe("Authentication mode"),
+      multiUserEnabled: z
+        .boolean()
+        .optional()
+        .describe("Enable multi-user mode"),
+      claudeWorkDir: z
+        .string()
+        .optional()
+        .describe("Claude working directory (supports ~ expansion)"),
+      logLevel: z
+        .enum(["trace", "debug", "info", "warn", "error"])
+        .optional()
+        .describe("Log level for the relay process"),
+      cloudflareEnabled: z
+        .boolean()
+        .optional()
+        .describe("Enable Cloudflare tunnel"),
+      cloudflareTunnelName: z
+        .string()
+        .optional()
+        .describe("Display name for the Cloudflare tunnel"),
+      autoStart: z
+        .boolean()
+        .optional()
+        .describe("Auto-start relay on app launch"),
+    },
+    async (params) => {
+      try {
+        // Only send fields that were actually provided
+        const updates: Record<string, unknown> = {};
+        for (const [key, value] of Object.entries(params)) {
+          if (value !== undefined) {
+            updates[key] = value;
+          }
+        }
+
+        if (Object.keys(updates).length === 0) {
+          return {
+            content: [
+              { type: "text" as const, text: "No config fields provided to update" },
+            ],
+            isError: true,
+          };
+        }
+
+        const res = await controlRequest("PATCH", "/control/config", updates);
+        return {
+          content: [
+            { type: "text" as const, text: JSON.stringify(res.body, null, 2) },
+          ],
+          isError: res.status !== 200,
+        };
+      } catch (error) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: `Failed to update config: ${error instanceof Error ? error.message : String(error)}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+    }
+  );
+}

--- a/mcp/ground-control-mcp/src/tools.ts
+++ b/mcp/ground-control-mcp/src/tools.ts
@@ -8,7 +8,7 @@ import { z } from "zod";
 const DEFAULT_BASE_URL = "http://127.0.0.1:9092";
 
 function getBaseUrl(): string {
-  return process.env.GROUND_CONTROL_URL || DEFAULT_BASE_URL;
+  return (process.env.GROUND_CONTROL_URL || DEFAULT_BASE_URL).replace(/\/+$/, "");
 }
 
 interface ControlResponse {
@@ -32,17 +32,31 @@ async function controlRequest(
     opts.body = JSON.stringify(body);
   }
 
-  const res = await fetch(url, opts);
-  const text = await res.text();
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 10_000);
 
-  let parsed: Record<string, unknown>;
   try {
-    parsed = JSON.parse(text);
-  } catch {
-    parsed = { raw: text };
-  }
+    const res = await fetch(url, { ...opts, signal: controller.signal });
+    const text = await res.text();
 
-  return { status: res.status, body: parsed };
+    let parsed: Record<string, unknown>;
+    try {
+      parsed = JSON.parse(text);
+    } catch {
+      parsed = { raw: text };
+    }
+
+    return { status: res.status, body: parsed };
+  } catch (err) {
+    if (err instanceof DOMException && err.name === "AbortError") {
+      throw new Error(
+        "Ground Control did not respond within 10s \u2014 is it running?"
+      );
+    }
+    throw err;
+  } finally {
+    clearTimeout(timeout);
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/mcp/ground-control-mcp/tsconfig.json
+++ b/mcp/ground-control-mcp/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary

- **ControlServer.swift** — Loopback-only HTTP control API (NWListener on `127.0.0.1:9092`) exposing relay/tunnel lifecycle, log access, and config management via REST endpoints. Same security model as the existing relay admin API.
- **RelayConfig + GroundControlApp** — Added `controlPort` field to config (default 9092, with validation). ControlServer starts automatically on app launch.
- **MCP bridge** (`mcp/ground-control-mcp/`) — Node.js MCP server using `@modelcontextprotocol/sdk` v1.29 with 9 tools that map 1:1 to ControlServer endpoints: `get_relay_status`, `start_relay`, `stop_relay`, `restart_relay`, `start_tunnel`, `stop_tunnel`, `get_logs`, `get_config`, `update_config`.

### Endpoints (ControlServer)
| Method | Path | Description |
|--------|------|-------------|
| GET | `/control/status` | Relay + tunnel state, restart count, uptime |
| POST | `/control/relay/start` | Start the relay |
| POST | `/control/relay/stop` | Stop the relay |
| POST | `/control/relay/restart` | Restart the relay |
| POST | `/control/tunnel/start` | Start the tunnel |
| POST | `/control/tunnel/stop` | Stop the tunnel |
| GET | `/control/logs` | Recent log entries (filterable by level/count/since) |
| GET | `/control/logs/stream` | SSE stream of new log entries |
| GET | `/control/config` | Current config (non-secret fields) |
| PATCH | `/control/config` | Update config fields |

### Build verification
- Swift package builds clean (zero warnings)
- TypeScript MCP server compiles clean
- `controlPort` uses `decodeIfPresent` for backward compat with existing config.json

## Test plan
- [ ] Build and launch Ground Control — verify ControlServer starts on port 9092
- [ ] `curl http://127.0.0.1:9092/control/status` returns relay/tunnel state
- [ ] `curl -X POST http://127.0.0.1:9092/control/relay/start` starts the relay
- [ ] `curl http://127.0.0.1:9092/control/logs?count=10` returns recent logs
- [ ] `curl http://127.0.0.1:9092/control/config` returns config (no secrets)
- [ ] Add MCP server to Claude Code config and verify tools are listed
- [ ] Verify non-loopback connections are rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)