### PR TITLE
fix(relay,ios): eliminate tmux window orphan accumulation

### DIFF
--- a/ios/MajorTom/Features/Terminal/ViewModels/TerminalViewModel.swift
+++ b/ios/MajorTom/Features/Terminal/ViewModels/TerminalViewModel.swift
@@ -124,12 +124,116 @@ final class TerminalViewModel {
     /// Reference to the auth service for relay URL and token.
     private let auth: AuthService
 
+    // MARK: - Tab Persistence
+
+    /// UserDefaults key for persisted tab IDs (string array).
+    private static let persistedTabIdsKey = "mt-terminal-tab-ids"
+
+    /// UserDefaults key for the active tab ID (string).
+    private static let persistedActiveTabIdKey = "mt-terminal-active-tab-id"
+
     init(auth: AuthService) {
         self.auth = auth
         self.keybarViewModel = KeybarViewModel(auth: auth)
-        // Create the initial default tab.
-        let initialTab = TerminalTab(title: "Terminal", isActive: true)
-        self.tabs = [initialTab]
+
+        // Restore persisted tab IDs, or create default.
+        // This is the critical fix for tmux window orphan accumulation:
+        // previously, every app launch generated a random UUID → new tabId
+        // → new tmux window on the relay. By persisting and restoring the
+        // tab IDs, we reconnect to the SAME tmux windows across launches.
+        let defaults = UserDefaults.standard
+        let savedTabIds = defaults.stringArray(forKey: Self.persistedTabIdsKey) ?? []
+        let savedActiveId = defaults.string(forKey: Self.persistedActiveTabIdKey)
+
+        if !savedTabIds.isEmpty {
+            self.tabs = savedTabIds.map { tabId in
+                TerminalTab(
+                    tabId: tabId,
+                    title: "Terminal",
+                    isActive: tabId == savedActiveId
+                )
+            }
+            // Ensure at least one tab is active.
+            if !self.tabs.contains(where: { $0.isActive }) {
+                self.tabs[0].isActive = true
+            }
+        } else {
+            // First launch — create a default tab and persist it.
+            let initialTab = TerminalTab(title: "Terminal", isActive: true)
+            self.tabs = [initialTab]
+            persistTabIds()
+        }
+    }
+
+    /// Persist current tab IDs and active tab to UserDefaults.
+    private func persistTabIds() {
+        let defaults = UserDefaults.standard
+        defaults.set(tabs.map(\.tabId), forKey: Self.persistedTabIdsKey)
+        defaults.set(activeTab?.tabId, forKey: Self.persistedActiveTabIdKey)
+    }
+
+    /// Reconcile persisted tabs with the relay's actual tmux windows.
+    ///
+    /// Fetches `GET /shell/tabs` and removes any local tabs whose windows
+    /// no longer exist on the relay (e.g. reaped after a relay restart).
+    /// Tabs whose windows are gone are pruned silently — the relay will
+    /// create fresh windows when the remaining tabs connect.
+    ///
+    /// Call once after auth is established (e.g. from the terminal view's
+    /// onAppear or after a successful auth check).
+    func reconcileWithRelay() async {
+        let base = relayBaseURL
+        guard let url = URL(string: "\(base)/shell/tabs") else { return }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        // Auth: session cookie is handled by the shared URLSession cookie store.
+        // For WKWebView JWT fallback, append the token as a query param.
+        if let token = authToken {
+            var components = URLComponents(url: url, resolvingAgainstBaseURL: false)
+            components?.queryItems = [URLQueryItem(name: "token", value: token)]
+            if let tokenURL = components?.url {
+                request.url = tokenURL
+            }
+        }
+
+        do {
+            let (data, response) = try await URLSession.shared.data(for: request)
+            guard let httpResponse = response as? HTTPURLResponse,
+                  httpResponse.statusCode == 200 else { return }
+
+            struct TabsResponse: Decodable {
+                let tabs: [String]
+            }
+
+            let decoded = try JSONDecoder().decode(TabsResponse.self, from: data)
+            let relayWindows = Set(decoded.tabs)
+
+            // If the relay has no windows at all (tmux not running, relay just
+            // started), skip reconciliation — our tabs will create windows on
+            // connect. Only prune when the relay has SOME windows but ours are
+            // missing from the set.
+            if relayWindows.isEmpty { return }
+
+            let before = tabs.count
+            tabs = tabs.filter { relayWindows.contains($0.tabId) }
+
+            // If all our tabs were pruned, create a fresh default.
+            if tabs.isEmpty {
+                let newTab = TerminalTab(title: "Terminal", isActive: true)
+                tabs = [newTab]
+            } else if !tabs.contains(where: { $0.isActive }) {
+                tabs[0].isActive = true
+            }
+
+            if tabs.count != before {
+                persistTabIds()
+            }
+        } catch {
+            // Network error — skip reconciliation, tabs will connect normally.
+            // The relay creates windows on demand so stale tab IDs just get
+            // fresh windows, which is acceptable.
+        }
     }
 
     // MARK: - Tab Management
@@ -143,6 +247,7 @@ final class TerminalViewModel {
 
         let newTab = TerminalTab(title: "Terminal", isActive: true)
         tabs.append(newTab)
+        persistTabIds()
 
         // Signal the web view to connect to the new tab.
         pendingTabSwitch = newTab.tabId
@@ -162,6 +267,7 @@ final class TerminalViewModel {
         if tabs.isEmpty {
             let newTab = TerminalTab(title: "Terminal", isActive: true)
             tabs.append(newTab)
+            persistTabIds()
             pendingTabSwitch = newTab.tabId
             return
         }
@@ -172,6 +278,7 @@ final class TerminalViewModel {
             tabs[newIndex].isActive = true
             pendingTabSwitch = tabs[newIndex].tabId
         }
+        persistTabIds()
     }
 
     /// Request to close a tab — shows confirmation dialog.
@@ -199,6 +306,7 @@ final class TerminalViewModel {
             tabs[i].isActive = false
         }
         tabs[targetIndex].isActive = true
+        persistTabIds()
 
         // Signal the web view to disconnect current and connect to the new tab.
         pendingTabSwitch = tabs[targetIndex].tabId

--- a/ios/MajorTom/Features/Terminal/ViewModels/TerminalViewModel.swift
+++ b/ios/MajorTom/Features/Terminal/ViewModels/TerminalViewModel.swift
@@ -187,14 +187,13 @@ final class TerminalViewModel {
 
         var request = URLRequest(url: url)
         request.httpMethod = "GET"
-        // Auth: session cookie is handled by the shared URLSession cookie store.
-        // For WKWebView JWT fallback, append the token as a query param.
+        // Auth: send the session JWT as a cookie header rather than a URL
+        // query parameter. Query-param auth exposes the token in logs,
+        // caches, and intermediaries — reserved for the WKWebView fallback
+        // path where cookie injection is unreliable. Native URLSession
+        // requests have full control over headers.
         if let token = authToken {
-            var components = URLComponents(url: url, resolvingAgainstBaseURL: false)
-            components?.queryItems = [URLQueryItem(name: "token", value: token)]
-            if let tokenURL = components?.url {
-                request.url = tokenURL
-            }
+            request.setValue("mt-session=\(token)", forHTTPHeaderField: "Cookie")
         }
 
         do {

--- a/ios/MajorTom/Features/Terminal/Views/TerminalView.swift
+++ b/ios/MajorTom/Features/Terminal/Views/TerminalView.swift
@@ -184,6 +184,11 @@ struct TerminalView: View {
             liveActivityTask?.cancel()
         }
         .task {
+            // Reconcile persisted tab IDs with the relay's actual tmux
+            // windows. Runs before the WebView connects so stale tabs
+            // are pruned before we attempt to attach to them.
+            await viewModel.reconcileWithRelay()
+
             await viewModel.keybarViewModel.syncFromRelay()
             // Wait for the JS terminal to initialize before applying synced preferences,
             // otherwise setFontSize/setTheme no-op because `term` is nil in the webview.

--- a/ios/MajorTom/Features/Terminal/Views/TerminalView.swift
+++ b/ios/MajorTom/Features/Terminal/Views/TerminalView.swift
@@ -185,8 +185,12 @@ struct TerminalView: View {
         }
         .task {
             // Reconcile persisted tab IDs with the relay's actual tmux
-            // windows. Runs before the WebView connects so stale tabs
-            // are pruned before we attempt to attach to them.
+            // windows so stale tabs are pruned early. Note: the WebView
+            // may already be connecting concurrently (SwiftUI does not
+            // guarantee .task ordering vs view body rendering). Stale
+            // tab IDs still work — the relay creates fresh windows on
+            // demand — so the race is benign; reconciliation just cleans
+            // up the local tab list for the next launch.
             await viewModel.reconcileWithRelay()
 
             await viewModel.keybarViewModel.syncFromRelay()

--- a/relay/src/adapters/window-reaper.ts
+++ b/relay/src/adapters/window-reaper.ts
@@ -1,0 +1,183 @@
+/**
+ * Window Reaper — prevents orphaned tmux windows from accumulating.
+ *
+ * Problem: every iOS app launch (or Xcode build cycle) creates a fresh
+ * random tab ID (e.g. `tab-a3bf91c2`). When the app is killed without
+ * explicitly closing the tab, the tmux window persists forever — no
+ * client will ever reconnect to that random ID. Over time these orphans
+ * pile up (26 windows observed in production from normal dev usage).
+ *
+ * Solution: two-tier reaping.
+ *
+ * **Tier 1 — Startup reaper:** after a grace period (default 60 s) for
+ * clients to reconnect, kill every tmux window with no active WebSocket
+ * client. Handles relay restarts and accumulated orphans.
+ *
+ * **Tier 2 — Disconnect reaper:** when a window's last client disconnects,
+ * start a per-window grace timer. If no client reconnects before it fires,
+ * kill the window. Handles app crashes, device sleep, new-tab-ID
+ * generation from un-upgraded clients. The default grace (5 min) is long
+ * enough for normal reconnects but short enough to prevent unbounded
+ * accumulation during active development.
+ *
+ * The bootstrap "bash" window (tmux index 0, created by
+ * `ensureMajorTomSession`) is also reaped — it's never used by any
+ * client. Killing the last window kills the session, which is fine:
+ * `tmuxBootstrap.ensure()` recreates it on the next client connect.
+ */
+import { listWindows, killWindow } from '../utils/tmux-cli.js';
+import type { SessionManager } from '../sessions/session-manager.js';
+import { logger } from '../utils/logger.js';
+
+/** Default grace period (ms) after relay startup before reaping unclaimed windows. */
+const STARTUP_GRACE_MS = 60_000;
+
+/**
+ * Default grace period (ms) after a window's last client disconnects
+ * before reaping it. 5 minutes is generous for reconnects but prevents
+ * unbounded accumulation during active dev cycles.
+ */
+const DISCONNECT_GRACE_MS = 5 * 60_000;
+
+export interface WindowReaperOptions {
+  /** Grace period after relay startup before the first reap (ms). */
+  startupGraceMs?: number;
+  /** Grace period after last-client disconnect before reaping a window (ms). */
+  disconnectGraceMs?: number;
+}
+
+export class WindowReaper {
+  private readonly startupGraceMs: number;
+  private readonly disconnectGraceMs: number;
+  private startupTimer: ReturnType<typeof setTimeout> | null = null;
+  /** Per-window disconnect grace timers, keyed by tabId. */
+  private disconnectTimers = new Map<string, ReturnType<typeof setTimeout>>();
+  private disposed = false;
+
+  constructor(
+    private readonly sessionManager: SessionManager,
+    options: WindowReaperOptions = {},
+  ) {
+    this.startupGraceMs = options.startupGraceMs ?? STARTUP_GRACE_MS;
+    this.disconnectGraceMs = options.disconnectGraceMs ?? DISCONNECT_GRACE_MS;
+  }
+
+  /**
+   * Start the startup reaper. Call once after tmux bootstrap succeeds.
+   * After `startupGraceMs`, any tmux window without an active WebSocket
+   * client is killed.
+   */
+  start(): void {
+    logger.info(
+      { startupGraceMs: this.startupGraceMs, disconnectGraceMs: this.disconnectGraceMs },
+      'Window reaper started — startup grace period running',
+    );
+    this.startupTimer = setTimeout(() => {
+      this.startupTimer = null;
+      void this.reap('startup');
+    }, this.startupGraceMs);
+  }
+
+  /**
+   * Notify the reaper that a window's last client disconnected.
+   * Starts a per-window grace timer. If no client reconnects before
+   * the timer fires, the window is killed.
+   *
+   * Call from the shell route's socket-close handler when
+   * `sessionManager.getTab(tabId)` returns undefined (last client gone).
+   */
+  onLastClientDisconnected(tabId: string): void {
+    if (this.disposed) return;
+    // Don't double-schedule
+    if (this.disconnectTimers.has(tabId)) return;
+
+    logger.info(
+      { tabId, graceMs: this.disconnectGraceMs },
+      'Window reaper: last client disconnected — grace timer started',
+    );
+
+    const timer = setTimeout(() => {
+      this.disconnectTimers.delete(tabId);
+      // Re-check: a client may have reconnected during the grace window
+      if (this.sessionManager.getTab(tabId)) {
+        logger.debug({ tabId }, 'Window reaper: client reconnected during grace — sparing window');
+        return;
+      }
+      logger.info({ tabId }, 'Window reaper: grace expired, no reconnect — killing orphan');
+      killWindow(tabId).catch((err) => {
+        logger.warn({ err, tabId }, 'Window reaper: failed to kill orphaned window');
+      });
+    }, this.disconnectGraceMs);
+
+    this.disconnectTimers.set(tabId, timer);
+  }
+
+  /**
+   * Notify the reaper that a client connected to a window.
+   * Cancels any pending disconnect grace timer for that window.
+   *
+   * Call from the shell route when a new PTY attaches.
+   */
+  onClientConnected(tabId: string): void {
+    const timer = this.disconnectTimers.get(tabId);
+    if (timer) {
+      clearTimeout(timer);
+      this.disconnectTimers.delete(tabId);
+      logger.debug({ tabId }, 'Window reaper: client reconnected — grace timer cancelled');
+    }
+  }
+
+  /**
+   * Scan all tmux windows and kill those with no active WebSocket client.
+   */
+  async reap(reason: string): Promise<{ reaped: string[]; spared: string[] }> {
+    const allWindows = await listWindows();
+    const activeTabs = new Set(
+      this.sessionManager.listTabs().map((t) => t.tabId),
+    );
+
+    const orphans = allWindows.filter((w) => !activeTabs.has(w));
+    const spared = allWindows.filter((w) => activeTabs.has(w));
+
+    if (orphans.length === 0) {
+      logger.info(
+        { reason, totalWindows: allWindows.length, activeClients: activeTabs.size },
+        'Window reaper: no orphans found',
+      );
+      return { reaped: [], spared };
+    }
+
+    logger.info(
+      { reason, orphanCount: orphans.length, totalWindows: allWindows.length, orphans },
+      'Window reaper: killing orphaned windows',
+    );
+
+    const reaped: string[] = [];
+    for (const windowName of orphans) {
+      try {
+        await killWindow(windowName);
+        reaped.push(windowName);
+        logger.info({ windowName, reason }, 'Window reaper: killed orphan');
+      } catch (err) {
+        logger.warn({ err, windowName, reason }, 'Window reaper: failed to kill orphan');
+      }
+    }
+
+    return { reaped, spared };
+  }
+
+  /** Stop all timers. Call on graceful shutdown. */
+  dispose(): void {
+    this.disposed = true;
+    if (this.startupTimer) {
+      clearTimeout(this.startupTimer);
+      this.startupTimer = null;
+    }
+    for (const [tabId, timer] of this.disconnectTimers) {
+      clearTimeout(timer);
+      logger.debug({ tabId }, 'Window reaper: cleared disconnect timer on dispose');
+    }
+    this.disconnectTimers.clear();
+    logger.info('Window reaper disposed');
+  }
+}

--- a/relay/src/app.ts
+++ b/relay/src/app.ts
@@ -338,9 +338,14 @@ export async function buildApp(config: AppConfig) {
   // after their last client disconnects and nobody reconnects within the
   // disconnect grace period. Configurable via REAPER_STARTUP_GRACE_MS
   // and REAPER_DISCONNECT_GRACE_MS env vars.
+  const parseGraceMs = (raw: string | undefined): number | undefined => {
+    if (raw === undefined) return undefined;
+    const n = Number(raw);
+    return Number.isFinite(n) && n >= 0 ? n : undefined;
+  };
   const windowReaper = new WindowReaper(sessionManager, {
-    startupGraceMs: Number(process.env['REAPER_STARTUP_GRACE_MS']) || undefined,
-    disconnectGraceMs: Number(process.env['REAPER_DISCONNECT_GRACE_MS']) || undefined,
+    startupGraceMs: parseGraceMs(process.env['REAPER_STARTUP_GRACE_MS']),
+    disconnectGraceMs: parseGraceMs(process.env['REAPER_DISCONNECT_GRACE_MS']),
   });
   try {
     await tmuxBootstrap.ensure();

--- a/relay/src/app.ts
+++ b/relay/src/app.ts
@@ -24,6 +24,7 @@ import { createShellRoute } from './routes/shell.js';
 import { createApiApprovalsRoutes } from './routes/api-approvals.js';
 import { createPreferencesRoutes } from './routes/preferences.js';
 import { tmuxBootstrap, TmuxMissingError, TmuxVersionError } from './adapters/tmux-bootstrap.js';
+import { WindowReaper } from './adapters/window-reaper.js';
 
 // Phase 13 Wave 2 — shell-side approval routing
 import { ApprovalQueue } from './hooks/approval-queue.js';
@@ -330,8 +331,22 @@ export async function buildApp(config: AppConfig) {
   // Eager tmux bootstrap so the first `/shell/:tabId` attach doesn't race.
   // Non-fatal: if tmux is missing on dev boxes without the shell experience,
   // we warn and continue. The shell route still rechecks lazily per connect.
+  //
+  // Window reaper: after a startup grace period, kills any tmux windows
+  // with no active WebSocket client (orphans from prior app launches,
+  // relay restarts, or iOS generating random tab IDs). Also reaps windows
+  // after their last client disconnects and nobody reconnects within the
+  // disconnect grace period. Configurable via REAPER_STARTUP_GRACE_MS
+  // and REAPER_DISCONNECT_GRACE_MS env vars.
+  const windowReaper = new WindowReaper(sessionManager, {
+    startupGraceMs: Number(process.env['REAPER_STARTUP_GRACE_MS']) || undefined,
+    disconnectGraceMs: Number(process.env['REAPER_DISCONNECT_GRACE_MS']) || undefined,
+  });
   try {
     await tmuxBootstrap.ensure();
+    // Bootstrap succeeded — start the startup reaper timer. After the
+    // grace period, any unclaimed windows are killed.
+    windowReaper.start();
   } catch (err) {
     if (err instanceof TmuxMissingError || err instanceof TmuxVersionError) {
       logger.warn({ err: (err as Error).message }, 'tmux unavailable — shell route will be degraded');
@@ -339,7 +354,7 @@ export async function buildApp(config: AppConfig) {
       logger.error({ err }, 'Unexpected tmux bootstrap error');
     }
   }
-  await app.register(createShellRoute({ sessionManager }));
+  await app.register(createShellRoute({ sessionManager, windowReaper }));
 
   // WebSocket (auth via session cookie on upgrade)
   await app.register(createWsRoute({
@@ -379,6 +394,7 @@ export async function buildApp(config: AppConfig) {
 
   app.addHook('onClose', async () => {
     logger.info('Shutting down services...');
+    windowReaper.dispose();
     healthMonitor.dispose();
     await achievementService.flush();
     await analyticsCollector.flush();

--- a/relay/src/routes/shell.ts
+++ b/relay/src/routes/shell.ts
@@ -189,6 +189,12 @@ export function createShellRoute(deps: ShellRouteDeps): FastifyPluginAsync {
     // Clients use this on launch to discover windows they can reconnect
     // to (iOS tab persistence) rather than blindly creating new ones.
     // Also useful for admin/debug tooling.
+    //
+    // Security note: in multi-user mode this returns ALL windows, not
+    // just the caller's. Multi-user scoping (per-user tab ownership)
+    // would require tagging tmux windows with owner identity — deferred
+    // until multi-user terminal isolation is built out. Single-user mode
+    // (the primary deployment) is unaffected.
     fastify.get<{ Querystring: { token?: string } }>(
       '/shell/tabs',
       async (request, reply) => {

--- a/relay/src/routes/shell.ts
+++ b/relay/src/routes/shell.ts
@@ -12,13 +12,15 @@
 import type { FastifyPluginAsync } from 'fastify';
 import { verifySessionToken, SESSION_COOKIE } from '../auth/session.js';
 import type { SessionManager } from '../sessions/session-manager.js';
+import type { WindowReaper } from '../adapters/window-reaper.js';
 import { attachPty } from '../adapters/pty-adapter.js';
 import { tmuxBootstrap } from '../adapters/tmux-bootstrap.js';
-import { killWindow } from '../utils/tmux-cli.js';
+import { killWindow, listWindows } from '../utils/tmux-cli.js';
 import { logger } from '../utils/logger.js';
 
 interface ShellRouteDeps {
   sessionManager: SessionManager;
+  windowReaper: WindowReaper;
 }
 
 /** Result of authenticating a shell request (WS upgrade or REST kill). */
@@ -94,7 +96,7 @@ function clampDim(raw: string | undefined): number | undefined {
 }
 
 export function createShellRoute(deps: ShellRouteDeps): FastifyPluginAsync {
-  const { sessionManager } = deps;
+  const { sessionManager, windowReaper } = deps;
 
   return async (fastify) => {
     fastify.get<{ Params: { tabId: string }; Querystring: { token?: string; cols?: string; rows?: string } }>(
@@ -155,8 +157,18 @@ export function createShellRoute(deps: ShellRouteDeps): FastifyPluginAsync {
             attachedAt: handle.createdAt,
           });
 
+          // Notify the window reaper that a client connected — cancels
+          // any pending disconnect grace timer for this window.
+          windowReaper.onClientConnected(tabId);
+
           const cleanup = () => {
             sessionManager.unregisterTab(tabId, ourPid);
+            // If this was the last client for this window, start the
+            // reaper's disconnect grace timer. After the grace period,
+            // the window is killed if nobody reconnects.
+            if (!sessionManager.getTab(tabId)) {
+              windowReaper.onLastClientDisconnected(tabId);
+            }
           };
           socket.on('close', cleanup);
           socket.on('error', cleanup);
@@ -169,6 +181,27 @@ export function createShellRoute(deps: ShellRouteDeps): FastifyPluginAsync {
           } catch { /* ignore */ }
           socket.close(1011, 'pty attach failed');
         }
+      },
+    );
+
+    // ── Tab discovery ─────────────────────────────────────────
+    // `GET /shell/tabs` — returns the list of existing tmux window names.
+    // Clients use this on launch to discover windows they can reconnect
+    // to (iOS tab persistence) rather than blindly creating new ones.
+    // Also useful for admin/debug tooling.
+    fastify.get<{ Querystring: { token?: string } }>(
+      '/shell/tabs',
+      async (request, reply) => {
+        const sessionCookie = request.cookies?.[SESSION_COOKIE];
+        const { token: queryToken } = request.query;
+
+        const { authed } = await authenticateShellRequest(sessionCookie, queryToken);
+        if (!authed) {
+          return reply.code(401).send({ error: 'Authentication required' });
+        }
+
+        const windows = await listWindows();
+        return { tabs: windows };
       },
     );
 


### PR DESCRIPTION
## Summary

- **Root cause**: iOS app generated random UUID tab IDs on every launch. Tab state was purely in-memory, so each app restart/rebuild created a new tmux window on the relay while old ones persisted forever. Observed **26 orphaned windows** from normal dev usage.
- **Relay: WindowReaper service** — two-tier cleanup: startup reaper (60s grace, kills unclaimed windows after relay boot) + disconnect reaper (5min grace per-window after last client drops). Configurable via env vars.
- **Relay: `GET /shell/tabs` endpoint** — returns existing tmux window names so clients can discover and reconnect instead of blindly creating new windows.
- **iOS: Tab ID persistence** — saves/restores tab IDs via UserDefaults so app relaunches reconnect to the SAME tmux windows.
- **iOS: Tab reconciliation** — on launch, fetches relay's window list and prunes any persisted tabs whose windows were reaped.

## Files Changed

| File | Change |
|------|--------|
| `relay/src/adapters/window-reaper.ts` | NEW — WindowReaper service with startup + disconnect reaping |
| `relay/src/routes/shell.ts` | Add `GET /shell/tabs`, wire reaper connect/disconnect hooks |
| `relay/src/app.ts` | Create and wire WindowReaper, add to shutdown cleanup |
| `ios/.../TerminalViewModel.swift` | Add tab persistence (UserDefaults) + relay reconciliation |
| `ios/.../TerminalView.swift` | Call reconcileWithRelay() on appear |

## Test plan

- [ ] Launch relay → verify "Window reaper started" log message
- [ ] Open iOS app → verify it connects with a stable tab ID (check tmux window name)
- [ ] Kill and relaunch iOS app → verify it reconnects to the SAME tmux window (no new window created)
- [ ] `tmux -L major-tom list-windows` should show only claimed windows after reaper fires
- [ ] Restart relay with iOS app open → verify reconnect claims the window within grace period
- [ ] Restart relay with iOS app closed → verify orphaned windows are reaped after 60s
- [ ] Create multiple tabs, close one → verify the closed tab's window is killed on relay
- [ ] Test `GET /shell/tabs` endpoint returns correct window list

🤖 Generated with [Claude Code](https://claude.com/claude-code)