### PR TITLE
feat(ios): performance HUD + baseline — optimization Wave 1

### DIFF
--- a/docs/PERF-BASELINE.md
+++ b/docs/PERF-BASELINE.md
@@ -1,0 +1,108 @@
+# Performance Baseline — Optimization Phase Wave 1
+
+> Captured: _YYYY-MM-DD_ · Device: _iPhone ___ · Config: _Release/Debug_ · iOS _____
+>
+> Goal: lock down a baseline before Wave 2+ optimizations so we know if they actually moved the needle. User reported severe battery drain on-device; the theory from the 2026-04-14 audit is allocation churn + per-frame overhead, not texture format. This baseline is the "before."
+
+---
+
+## SpriteKit HUD
+
+Enable via **Settings → Developer → Performance HUD**. Overlay appears bottom-right of the Office scene.
+
+| Line | Meaning | Target |
+|---|---|---|
+| FPS | Frames per second | 60 (min ≥ 55) |
+| Nodes | SKNodes in scene | as low as possible |
+| Draws | Draw calls per frame | fewer = better (atlas packing wins) |
+| Quads | Textured quads drawn per frame | — |
+
+Toggle is persisted in `UserDefaults` under `sprite.perfHUD.enabled` — survives restarts, works in Release builds, flips live without leaving the Office tab.
+
+---
+
+## Instruments (Xcode)
+
+Open Xcode → Product → Profile (⌘I). Choose a template below.
+
+1. **Game Performance** — overall FPS + GPU/CPU frame budget. Best first look.
+2. **Time Profiler** — hot stacks. Watch for:
+    - `OfficeScene.update(_:)` children — `applyAgentMoods`, `updateParallax`, `scanForInteractions`
+    - `AgentSprite.startActivityAnimation(_:)` — SKAction churn
+3. **Allocations** — use "Generations" mode around a 30s window with active sprites. Focus on `SKAction` + closure allocations.
+4. **Energy Log** (on-device only) — the only real answer to "does it still kill the battery." Aim for **Low**.
+
+Record 60–120s per scenario below. Mark scenarios with signposts if possible so the trace is easy to navigate.
+
+---
+
+## Scenarios
+
+Run each scenario twice and average. Fill in the tables below.
+
+### A — Idle station (1 min)
+
+Launch app → Office tab → leave it alone. No swipes, no taps.
+
+| Metric | Run 1 | Run 2 |
+|---|---|---|
+| FPS (steady) | | |
+| FPS (min) | | |
+| Nodes | | |
+| Draws | | |
+| Quads | | |
+| Energy Impact | | |
+| CPU % (Instruments avg) | | |
+| Allocations/sec (SKAction) | | |
+
+### B — Populated & active (21 sprites, 1 min)
+
+Tap **Shuffle Crew** until 21 sprites are active. Let activity cycling run. No user input after that.
+
+| Metric | Run 1 | Run 2 |
+|---|---|---|
+| FPS (steady) | | |
+| FPS (min) | | |
+| Nodes | | |
+| Draws | | |
+| Quads | | |
+| Energy Impact | | |
+| CPU % (Instruments avg) | | |
+| Allocations/sec (SKAction) | | |
+
+### C — Parallax scroll (30s)
+
+Swipe-snap across all 8 rooms, twice. Focus on frame time during the snap transitions.
+
+| Metric | Run 1 | Run 2 |
+|---|---|---|
+| FPS (min during snap) | | |
+| Max frame time (ms) | | |
+| `updateParallax` cost (ms/frame) | | |
+| `applyAgentMoods` cost (ms/frame) | | |
+
+---
+
+## Suspected hotspots
+
+From the 2026-04-14 audit, ranked by suspected impact. Confirm each with Time Profiler during Scenario B.
+
+1. **`AgentSprite.startActivityAnimation(_:)`** — builds ~12 new SKAction objects per activity rotation, ~250 allocations/sec during idle. No pooling.
+2. **`OfficeScene.applyAgentMoods()`** — runs every frame across all 21 sprites, stacks `SKAction.repeatForever` on mood changes.
+3. **`OfficeScene.updateParallax()`** — `childNode(withName: "//starsFar")` per frame per window (~8 windows). `//` prefix = O(n) recursive.
+4. **`ActivityAnimator.startEmoteTimer(...)`** — Task-per-activity with `Task.sleep` loops, ~0.7 new Tasks/sec.
+5. **`OfficeScene.scanForInteractions()`** — 210 distance calcs + `sqrt()` every 8s, triggers closure-capturing SKActions.
+
+---
+
+## Acceptance — ready for Wave 2?
+
+Baseline is "accepted" when all three scenarios have two runs captured and Energy Impact is recorded for Scenario B on-device. At that point, proceed to:
+
+**Wave 2 — Cheap wins**
+- `view.ignoresSiblingOrder = true` + zPosition discipline
+- Cache parallax node refs (kill the `//` lookups)
+- Verify `.filteringMode = .nearest` on all character textures
+- Frame budget: move `applyAgentMoods` / `applyTheme` / `updateParallax` to every-Nth-frame or dirty-flagged
+
+Re-measure after Wave 2 and compare against this doc. Goal for end of Wave 5: Instruments Energy Impact = **Low**.

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -14,7 +14,7 @@ Research 2026-04-14 refuted the "PNG is killing us" hypothesis. Real hotspots ar
 
 | Wave | Scope | Status |
 |------|-------|--------|
-| 1 — Measurement | SpriteKit HUD + Instruments baseline | QUEUED |
+| 1 — Measurement | SpriteKit HUD + Instruments baseline | IN PROGRESS |
 | 2 — Cheap wins | ignoresSiblingOrder, cache parallax refs, frame budget | QUEUED |
 | 3 — SKAction pooling | Reuse action graphs in AgentSprite, dirty-flag mood | QUEUED |
 | 4 — Culling + atlas split + tile map | Pause offscreen, split CrewSprites, SKTileMapNode floor | QUEUED |

--- a/ios/MajorTom.xcodeproj/project.pbxproj
+++ b/ios/MajorTom.xcodeproj/project.pbxproj
@@ -86,6 +86,7 @@
 		7D680AE80F01D84BF6209698 /* CloseTabConfirm.swift in Sources */ = {isa = PBXBuildFile; fileRef = E104B2CEBAA36B9B97E254AA /* CloseTabConfirm.swift */; };
 		818FA51F81C18CFE08B3C097 /* PairingViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 526DF9EAD13F47F747C7ACC3 /* PairingViewModel.swift */; };
 		8294293F9EF30CBEED38BFC6 /* HapticService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7794C5813F5964F288D432AD /* HapticService.swift */; };
+		39E76A83321DEBACFD4BB7DE /* PerfHUDPreferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1972DF8FED85D9290EA3F331 /* PerfHUDPreferences.swift */; };
 		83C02DEBD2B6488A47A08A65 /* ModePickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66594811ED284A67510E10AE /* ModePickerView.swift */; };
 		85574E49192424FB81A91CA9 /* MarkdownText.swift in Sources */ = {isa = PBXBuildFile; fileRef = D91A9F673395FFFDE1E3A220 /* MarkdownText.swift */; };
 		855E5820EB1F99D820AFF91A /* SessionListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EE6178C1ADCC581A8CEDD6E /* SessionListView.swift */; };
@@ -307,6 +308,7 @@
 		7643A52E74C92A59EFA82ED7 /* OfficeScene.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OfficeScene.swift; sourceTree = "<group>"; };
 		765796A3C1DAD173DB56A1CC /* ThemeEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeEngine.swift; sourceTree = "<group>"; };
 		7794C5813F5964F288D432AD /* HapticService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HapticService.swift; sourceTree = "<group>"; };
+		1972DF8FED85D9290EA3F331 /* PerfHUDPreferences.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PerfHUDPreferences.swift; sourceTree = "<group>"; };
 		794D98FF20DC91F49542FE7D /* OfficeViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OfficeViewModel.swift; sourceTree = "<group>"; };
 		7A8199AB9D26A914D6633EF0 /* PermissionModeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionModeView.swift; sourceTree = "<group>"; };
 		7B0675DDA1DE8E757F72ECF0 /* AnalyticsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsViewModel.swift; sourceTree = "<group>"; };
@@ -827,6 +829,7 @@
 				10F013B10B2AA2CD96B19588 /* DangerScoring.swift */,
 				7794C5813F5964F288D432AD /* HapticService.swift */,
 				A9BD8A95DFAD6160FF41E83F /* KeychainService.swift */,
+				1972DF8FED85D9290EA3F331 /* PerfHUDPreferences.swift */,
 				28F93EA76007AD19338D6B61 /* PhoneWatchConnectivityService.swift */,
 				6EF58FBAC8341407F9E3E7A0 /* RelayService.swift */,
 			);
@@ -1667,6 +1670,7 @@
 				E8F577B5E74B036260C3633B /* GitStatusView.swift in Sources */,
 				C73A60CB24EFABD14D9C2A2F /* GodModeConfirmation.swift in Sources */,
 				8294293F9EF30CBEED38BFC6 /* HapticService.swift in Sources */,
+				39E76A83321DEBACFD4BB7DE /* PerfHUDPreferences.swift in Sources */,
 				8A47BE851B898A4D0899F183 /* KeySpec.swift in Sources */,
 				22A50E5C5D84EFE896C415FF /* KeybarCustomizer.swift in Sources */,
 				6894059C83BB1BFF450749C2 /* KeybarViewModel.swift in Sources */,

--- a/ios/MajorTom/Core/Services/PerfHUDPreferences.swift
+++ b/ios/MajorTom/Core/Services/PerfHUDPreferences.swift
@@ -1,21 +1,25 @@
 import Foundation
 
+extension Notification.Name {
+    /// Posted when `PerfHUDPreferences.isEnabled` actually changes.
+    static let perfHUDPreferencesDidChange = Notification.Name("com.majortom.perfHUD.didChange")
+}
+
 /// Dev-only toggle for the SpriteKit debug HUD (FPS + node/draw/quad counts).
 ///
 /// Persisted in UserDefaults so it survives app restarts without a rebuild, and
 /// can be flipped in Release builds too (measurement is the whole point of
-/// optimization Wave 1). Flipping posts `didChangeNotification` — `OfficeScene`
-/// observes that and re-applies the HUD flags live.
+/// optimization Wave 1). Flipping posts `.perfHUDPreferencesDidChange` —
+/// `OfficeScene` observes that and re-applies the HUD flags live.
 enum PerfHUDPreferences {
     private static let defaultsKey = "sprite.perfHUD.enabled"
-
-    static let didChangeNotification = Notification.Name("PerfHUDPreferencesDidChange")
 
     static var isEnabled: Bool {
         get { UserDefaults.standard.bool(forKey: defaultsKey) }
         set {
+            guard newValue != UserDefaults.standard.bool(forKey: defaultsKey) else { return }
             UserDefaults.standard.set(newValue, forKey: defaultsKey)
-            NotificationCenter.default.post(name: didChangeNotification, object: nil)
+            NotificationCenter.default.post(name: .perfHUDPreferencesDidChange, object: nil)
         }
     }
 }

--- a/ios/MajorTom/Core/Services/PerfHUDPreferences.swift
+++ b/ios/MajorTom/Core/Services/PerfHUDPreferences.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+/// Dev-only toggle for the SpriteKit debug HUD (FPS + node/draw/quad counts).
+///
+/// Persisted in UserDefaults so it survives app restarts without a rebuild, and
+/// can be flipped in Release builds too (measurement is the whole point of
+/// optimization Wave 1). Flipping posts `didChangeNotification` — `OfficeScene`
+/// observes that and re-applies the HUD flags live.
+enum PerfHUDPreferences {
+    private static let defaultsKey = "sprite.perfHUD.enabled"
+
+    static let didChangeNotification = Notification.Name("PerfHUDPreferencesDidChange")
+
+    static var isEnabled: Bool {
+        get { UserDefaults.standard.bool(forKey: defaultsKey) }
+        set {
+            UserDefaults.standard.set(newValue, forKey: defaultsKey)
+            NotificationCenter.default.post(name: didChangeNotification, object: nil)
+        }
+    }
+}

--- a/ios/MajorTom/Features/Office/Scenes/OfficeScene.swift
+++ b/ios/MajorTom/Features/Office/Scenes/OfficeScene.swift
@@ -73,6 +73,9 @@ final class OfficeScene: SKScene {
     /// Guard against `didMove(to:)` being invoked more than once (e.g. SpriteView re-hosting).
     private var hasSetup = false
 
+    /// NotificationCenter token for live Performance HUD toggle updates.
+    private var perfHUDObserver: NSObjectProtocol?
+
     // MARK: - Scene Lifecycle
 
     override func didMove(to view: SKView) {
@@ -86,6 +89,19 @@ final class OfficeScene: SKScene {
 
         // Enable multi-touch for pinch zoom
         view.isMultipleTouchEnabled = true
+
+        // Performance HUD — flipped via Settings → Developer → Performance HUD.
+        // Re-applied live when the preference changes so we don't need to
+        // leave/return to the Office tab while measuring.
+        applyPerfHUD(to: view)
+        perfHUDObserver = NotificationCenter.default.addObserver(
+            forName: PerfHUDPreferences.didChangeNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self, weak view] _ in
+            guard let view else { return }
+            self?.applyPerfHUD(to: view)
+        }
 
         // Setup camera — start at col1_top snap position
         cameraNode = SKCameraNode()
@@ -107,6 +123,22 @@ final class OfficeScene: SKScene {
         renderThemeOverlay()
         renderAmbientParticles()
         startAmbientAnimations()
+    }
+
+    deinit {
+        if let perfHUDObserver {
+            NotificationCenter.default.removeObserver(perfHUDObserver)
+        }
+    }
+
+    // MARK: - Performance HUD
+
+    private func applyPerfHUD(to view: SKView) {
+        let enabled = PerfHUDPreferences.isEnabled
+        view.showsFPS = enabled
+        view.showsNodeCount = enabled
+        view.showsDrawCount = enabled
+        view.showsQuadCount = enabled
     }
 
     // MARK: - Station Hull Rendering

--- a/ios/MajorTom/Features/Office/Scenes/OfficeScene.swift
+++ b/ios/MajorTom/Features/Office/Scenes/OfficeScene.swift
@@ -95,7 +95,7 @@ final class OfficeScene: SKScene {
         // leave/return to the Office tab while measuring.
         applyPerfHUD(to: view)
         perfHUDObserver = NotificationCenter.default.addObserver(
-            forName: PerfHUDPreferences.didChangeNotification,
+            forName: .perfHUDPreferencesDidChange,
             object: nil,
             queue: .main
         ) { [weak self, weak view] _ in

--- a/ios/MajorTom/Features/Settings/Views/SettingsView.swift
+++ b/ios/MajorTom/Features/Settings/Views/SettingsView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct SettingsView: View {
     @State private var viewModel: SettingsViewModel
+    @State private var showsPerfHUD: Bool = PerfHUDPreferences.isEnabled
 
     private let auth: AuthService
     private let relay: RelayService
@@ -22,6 +23,7 @@ struct SettingsView: View {
                 teamSection
                 notificationSection
                 sessionSection
+                developerSection
                 aboutSection
             }
             .scrollContentBackground(.hidden)
@@ -222,6 +224,24 @@ struct SettingsView: View {
             }
         } header: {
             Text("Session")
+        }
+    }
+
+    // MARK: - Developer
+
+    private var developerSection: some View {
+        Section {
+            Toggle(isOn: $showsPerfHUD) {
+                Label("Performance HUD", systemImage: "speedometer")
+            }
+            .onChange(of: showsPerfHUD) { _, newValue in
+                PerfHUDPreferences.isEnabled = newValue
+            }
+            .listRowBackground(MajorTomTheme.Colors.surface)
+        } header: {
+            Text("Developer")
+        } footer: {
+            Text("Overlays SpriteKit FPS + node/draw/quad counts on the Office scene. Use during Instruments profiling — see docs/PERF-BASELINE.md.")
         }
     }
 


### PR DESCRIPTION
## Summary
- Ship SpriteKit Performance HUD (FPS / node / draw / quad) gated by a Settings → Developer toggle
- Persisted in `UserDefaults`, works in Release builds, re-applies live via NotificationCenter
- `docs/PERF-BASELINE.md` — Instruments procedure + scenario capture tables for the Wave 1 baseline
- STATE.md: Wave 1 → IN PROGRESS

## Why
The 2026-04-14 audit refuted the "PNG is killing us" hypothesis — the real hotspots are SKAction allocation churn + per-frame overhead (see `project_optimization_phase` memory for the ranked list). Before we touch any of it, we need a measured baseline. This PR ships the measurement tooling only, no optimizations yet.

## Changes
- `PerfHUDPreferences` (`Core/Services`) — tiny `UserDefaults` helper, posts `didChangeNotification` on change
- `OfficeScene.didMove(to:)` — applies HUD flags from prefs, observes the notification for live updates, cleans up in `deinit`
- `SettingsView` — new Developer section with one toggle + a pointer to the baseline doc
- `docs/PERF-BASELINE.md` — Instruments walkthrough + 3 scenario capture tables (idle / populated / parallax scroll)

## Test plan
- [x] Simulator build passes (XcodeBuildMCP → `MajorTom` scheme on iPhone 17 Pro)
- [ ] On device: Settings → Developer → toggle Performance HUD. HUD appears bottom-right of Office scene
- [ ] Toggle off mid-session. HUD disappears live without leaving the tab
- [ ] Run Instruments (Game Performance) on device, capture Scenarios A/B/C in `docs/PERF-BASELINE.md`

## Wave 2 gate
All three scenario tables in `docs/PERF-BASELINE.md` filled in with two runs each. Then we start Wave 2 (cheap wins).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
