### PR TITLE
fix(ios,relay): stop terminal tab-switch crash-loop and content overlap

### DIFF
--- a/ios/MajorTom/Features/Terminal/Resources/terminal.html
+++ b/ios/MajorTom/Features/Terminal/Resources/terminal.html
@@ -270,12 +270,15 @@
 
     if (ws) {
       // Detach listeners BEFORE closing so the outgoing socket's async
-      // onclose can't poison the new flow. Default ws.close() sends code
-      // 1005, which falls through our 1000/1001 clean-close guard and
-      // would call scheduleReconnect() on the replaced socket — stacking
-      // phantom retries that fight the connection we're about to make.
-      // This bug surfaced as terminals crash-looping after a tab switch
-      // (two tabs each generating a fresh MajorTom.connect() call).
+      // onclose can't poison the new flow. ws.close() with no status
+      // yields CloseEvent.code 1005 on the receiving side (1005 is
+      // reserved — never transmitted on the wire, only reported when no
+      // code was received). That does NOT match our 1000/1001 clean-
+      // close guard, so the replaced socket's onclose would call
+      // scheduleReconnect(), stacking phantom retries that fight the
+      // connection we're about to make. Surfaced as terminals crash-
+      // looping after a tab switch (two tabs each generating a fresh
+      // MajorTom.connect() call).
       ws.onopen = null;
       ws.onclose = null;
       ws.onerror = null;

--- a/ios/MajorTom/Features/Terminal/Resources/terminal.html
+++ b/ios/MajorTom/Features/Terminal/Resources/terminal.html
@@ -260,7 +260,26 @@
   }
 
   function connectWS() {
+    // Cancel any pending auto-retry — we're initiating a fresh connection
+    // right now, so an enqueued reconnect would fire after us and close
+    // the socket we're about to open.
+    if (reconnectTimer) {
+      clearTimeout(reconnectTimer);
+      reconnectTimer = null;
+    }
+
     if (ws) {
+      // Detach listeners BEFORE closing so the outgoing socket's async
+      // onclose can't poison the new flow. Default ws.close() sends code
+      // 1005, which falls through our 1000/1001 clean-close guard and
+      // would call scheduleReconnect() on the replaced socket — stacking
+      // phantom retries that fight the connection we're about to make.
+      // This bug surfaced as terminals crash-looping after a tab switch
+      // (two tabs each generating a fresh MajorTom.connect() call).
+      ws.onopen = null;
+      ws.onclose = null;
+      ws.onerror = null;
+      ws.onmessage = null;
       try { ws.close(); } catch (e) { /* ignore */ }
     }
 
@@ -418,7 +437,18 @@
     connect: function(cfg) {
       if (cfg.url) config.relayURL = cfg.url;
       if (cfg.token) config.token = cfg.token;
-      if (cfg.tabId) config.tabId = cfg.tabId;
+      if (cfg.tabId) {
+        // Tab switch: wipe the xterm buffer so the previous tab's output
+        // doesn't stack under the new tab's fresh prompt. All tabs share
+        // one xterm instance; without a reset their content visibly
+        // overlaps on switch. Only reset on an actual tabId change so
+        // in-place reconnects (retry, foreground wake, initial load)
+        // preserve their scrollback.
+        if (config.tabId && config.tabId !== cfg.tabId && term) {
+          term.reset();
+        }
+        config.tabId = cfg.tabId;
+      }
       if (cfg.theme) {
         config.theme = cfg.theme;
         if (term) {

--- a/relay/src/adapters/__tests__/pty-adapter.test.ts
+++ b/relay/src/adapters/__tests__/pty-adapter.test.ts
@@ -101,6 +101,14 @@ describe('RingBuffer', () => {
     expect(r.size).toBe(60);
     expect(r.drain().toString()).toBe('b'.repeat(60));
   });
+
+  it('drain clears state so a subsequent drain returns empty', () => {
+    const r = new RingBuffer(100);
+    r.push(Buffer.alloc(40, 'a'));
+    expect(r.drain().length).toBe(40);
+    expect(r.size).toBe(0);
+    expect(r.drain().length).toBe(0);
+  });
 });
 
 // ── PtyAdapter behavior ─────────────────────────────────────
@@ -247,6 +255,39 @@ describe('PtyAdapter.detach + grace + ring buffer replay', () => {
       // they were streamed live to c1, and replaying them to c2 would
       // visibly duplicate content the prior viewer already rendered.
       expect(replay).not.toContain('attached-phase');
+    } finally {
+      a.dispose();
+    }
+  });
+
+  it('second reattach does not re-send bytes already drained on first reattach', async () => {
+    const a = makeAdapter({ graceMs: 10_000 });
+    try {
+      const c1 = makeClient();
+      a.attach('tab-1', c1, ATTACH_DEFAULTS);
+      a.detach('tab-1', c1);
+      a.write('tab-1', 'burst-one\n');
+      await new Promise((r) => setTimeout(r, 150));
+
+      // First reattach — should drain the ring and deliver 'burst-one'.
+      const c2 = makeClient();
+      a.attach('tab-1', c2, ATTACH_DEFAULTS);
+      const firstReplay = Buffer.concat(
+        c2.sent.filter((s) => s.binary).map((s) => s.data as Buffer),
+      ).toString('utf-8');
+      expect(firstReplay).toContain('burst-one');
+      a.detach('tab-1', c2);
+
+      // No new PTY output between c2 detach and c3 attach. The ring must
+      // be empty — re-replaying 'burst-one' would visibly duplicate what
+      // c2 already rendered. This covers the iOS foreground-wake case
+      // where the WebSocket drops and reconnects to the same tabId.
+      const c3 = makeClient();
+      a.attach('tab-1', c3, ATTACH_DEFAULTS);
+      const secondReplay = Buffer.concat(
+        c3.sent.filter((s) => s.binary).map((s) => s.data as Buffer),
+      ).toString('utf-8');
+      expect(secondReplay).not.toContain('burst-one');
     } finally {
       a.dispose();
     }

--- a/relay/src/adapters/__tests__/pty-adapter.test.ts
+++ b/relay/src/adapters/__tests__/pty-adapter.test.ts
@@ -293,31 +293,46 @@ describe('PtyAdapter.detach + grace + ring buffer replay', () => {
     }
   });
 
-  it('ring buffer caps at bufferBytes when over-pushed during DETACHED', async () => {
-    const small = makeAdapter({ bufferBytes: 64, graceMs: 10_000 });
+  it('ring buffer caps at bufferBytes when over-pushed during DETACHED', () => {
+    // Synthetic PTY so chunk sizes are deterministic. node-pty's flush
+    // behavior differs between macOS and Linux — on the Linux CI runner
+    // cat can emit its echo as one chunk larger than the 64-byte cap,
+    // which the ring evicts whole-chunk and leaves empty. That's valid
+    // ring behavior but makes the cat-based variant of this test flaky.
+    // With injected onData we control chunk granularity.
+    const onDataCbs: Array<(d: string | Buffer) => void> = [];
+    const fakePty = {
+      pid: 1, cols: 80, rows: 24,
+      onData(cb: (d: string | Buffer) => void) { onDataCbs.push(cb); },
+      onExit() {},
+      kill: vi.fn(), resize: vi.fn(), write: vi.fn(),
+    };
+    const a = new PtyAdapter({
+      spawn: (() => fakePty) as never,
+      bufferBytes: 64,
+      graceMs: 10_000,
+    });
     try {
       const client = makeClient();
-      small.attach('tab-1', client, ATTACH_DEFAULTS);
-      // Detach first — subsequent PTY output then buffers into the ring.
-      small.detach('tab-1', client);
+      a.attach('tab-1', client, ATTACH_DEFAULTS);
+      a.detach('tab-1', client);
 
-      // Push enough bytes through cat to overflow the 64-byte ring.
+      // Emit 10 × 30-byte chunks. Each is smaller than the 64-byte cap
+      // so eviction advances chunk-by-chunk; post-push the ring holds
+      // the newest chunks up to ~60 bytes total.
       for (let i = 0; i < 10; i++) {
-        small.write('tab-1', 'x'.repeat(50) + '\n');
+        onDataCbs[0]?.(Buffer.alloc(30, String.fromCharCode(97 + i)));
       }
 
-      // Give cat time to echo all chunks into the ring.
-      await new Promise((r) => setTimeout(r, 300));
-
       const c2 = makeClient();
-      small.attach('tab-1', c2, ATTACH_DEFAULTS);
+      a.attach('tab-1', c2, ATTACH_DEFAULTS);
       const replay = Buffer.concat(
         c2.sent.filter((s) => s.binary).map((s) => s.data as Buffer),
       );
       expect(replay.length).toBeGreaterThan(0);
       expect(replay.length).toBeLessThanOrEqual(64);
     } finally {
-      small.dispose();
+      a.dispose();
     }
   });
 });

--- a/relay/src/adapters/pty-adapter.ts
+++ b/relay/src/adapters/pty-adapter.ts
@@ -101,7 +101,13 @@ export class RingBuffer {
 
   drain(): Buffer {
     if (this.chunks.length === 0) return Buffer.alloc(0);
-    return Buffer.concat(this.chunks);
+    const buf = Buffer.concat(this.chunks);
+    // Clear after consumption. Without this, every reattach within grace
+    // re-sends the full ring — the prior viewer already rendered those
+    // bytes, so a second reattach visibly duplicates content in xterm.
+    this.chunks = [];
+    this.bytes = 0;
+    return buf;
   }
 
   get size(): number {


### PR DESCRIPTION
## Summary

Three tightly-related terminal bugs, all surfaced the moment a user opened a 2nd tab. Each one compounds the others into the "infinite reconnect + terminals render on top of each other" symptom.

### 1. `connectWS()` race condition — infinite reconnect loop

`terminal.html::connectWS()` closed the old WebSocket without detaching its handlers. The outgoing socket's async `onclose` fired **after** the new WS was already in flight, and because `ws.close()` defaults to code **1005** (falls through the 1000/1001 clean-close guard), the handler unconditionally called `scheduleReconnect()`.

Every user-triggered reconnect (tab create, tab switch) spawned a phantom one from the replaced socket. The phantom closed the new connection, triggered **another** phantom, and so on. The 3-attempt retry budget introduced in PR #131 was useless because `onopen` kept resetting the counter to 0 on each successful re-open.

**Fix:** null `onopen / onclose / onerror / onmessage` before `close()`, and cancel any pending retry timer so we don't race against an enqueued reconnect.

### 2. Shared xterm buffer — terminals rendering on top of each other

All tabs share one xterm instance. Tab switch never called `term.reset()`, so tab 1's full history stacked visibly under tab 2's fresh prompt. Combined with bug #1's repeated reconnects, this produced the "rendering on top of each other" symptom.

**Fix:** `term.reset()` in `MajorTom.connect()` when the `tabId` changes. Same-tab reconnects (retry, foreground wake, initial load) preserve their scrollback — only cross-tab switches wipe the screen.

### 3. `RingBuffer.drain()` never cleared its buffer — duplicate content on same-tab reconnect

`drain()` returned `Buffer.concat(this.chunks)` but left `chunks` and `bytes` untouched. Every reattach within the 30-min grace re-sent the full ring, visibly duplicating every byte the prior viewer already rendered. Triggered on foreground wake and any transient WS blip that the 3-attempt retry recovered from.

**Fix:** `drain()` now empties `chunks` and zeroes `bytes` after reading. Regression test covers drain-then-re-drain **and** the multi-reattach behavioral case (c1 → c2 reattach → c3 reattach sees nothing new).

## Files changed

- `ios/MajorTom/Features/Terminal/Resources/terminal.html` — handler detach + `term.reset()` on tab switch
- `relay/src/adapters/pty-adapter.ts` — `RingBuffer.drain()` clears state
- `relay/src/adapters/__tests__/pty-adapter.test.ts` — unit + behavioral regression tests

## Test plan

- [x] `npm test` in `relay/` — 43 tests pass (2 new)
- [x] Release build installed on device
- [ ] Create a 2nd tab — no reconnect loop
- [ ] Switch between tabs — each shows its own content, no overlap
- [ ] Rename tab — sticks, no regression
- [ ] Background + foreground the app — no duplicated content in scrollback (requires relay restart with the server fix)
- [ ] Normal terminal work (`ls`, `pwd`, editor) — no regression

## Why now

Blocks the iOS optimization phase — can't capture clean performance baselines while the terminal is crash-looping. Merge unblocks [`project_optimization_phase.md`](../tree/main) Wave 2 work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
