### PR TITLE
docs: Sprite-Agent Wiring Wave 1 research — all gates answered

### DIFF
--- a/docs/PHASE-SPRITE-AGENT-WIRING.md
+++ b/docs/PHASE-SPRITE-AGENT-WIRING.md
@@ -1,6 +1,6 @@
 # Phase: Sprite ↔ Agent Wiring
 
-> **Status:** Spec frozen. Research phase next, then implementation.
+> **Status:** Wave 1 (Research) COMPLETE. Wave 2 (Data Model + Protocol) in progress.
 > **Prerequisite:** Optimization phase (PR #135) merged. Idle Office at 60fps.
 > **Astronaut tile asset:** `assets/util/create_office_tile.png`
 
@@ -286,36 +286,69 @@ Sprite ↔ subagent mappings are persisted to disk (JSON file per session).
 
 ---
 
-## Research Gates (BEFORE implementation)
+## Research Gates — RESOLVED
 
-| Item | Question | Blocks |
+> Full research: `docs/SPRITE-WIRING-RESEARCH-RELAY.md` and `docs/SPRITE-WIRING-RESEARCH-IOS.md`
+
+| Item | Status | Finding |
 |---|---|---|
-| Agent SDK turn-boundary injection | Can we queue a message and inject at turn end? Does the SDK expose stream-end hooks? What's the API? | Wave 4 (messaging) |
-| Protocol message types | Define exact schemas for `sprite.link`, `sprite.unlink`, `sprite.message`, `sprite.response`, `sprite.state` | Wave 2 (protocol) |
-| Relay message queue design | How does relay hold /btw messages, detect turn boundaries, inject? | Wave 4 (messaging) |
-| Mapping persistence format | JSON file structure per session, cleanup hook points in existing session lifecycle | Wave 2 (data model) |
-| Office Manager SwiftUI | View hierarchy, card layout, SKScene lifecycle management (create/suspend/destroy) | Wave 3 (multi-session) |
-| Local notification setup | `UNNotificationAction` for "Cool Beans", background WebSocket handling, when to fire | Wave 5 (push) |
-| Role → sprite mapping table | Lock the 8 classifier roles → CharacterType assignments | Wave 2 (data model) |
+| Agent SDK turn-boundary injection | YELLOW | No direct subagent session handle. Viable: `PostToolUse` hook with `additionalContext` + queued `send()` at orchestrator turn boundary. **Spike needed before Wave 4.** |
+| Protocol message types | GREEN | 5 new `sprite.*` types fit cleanly into existing conventions |
+| Relay message queue design | YELLOW | Queue is simple. Response correlation via state machine (capture first text after injection). |
+| Mapping persistence format | GREEN | Mirrors `SessionPersistence` pattern. `~/.major-tom/sprite-mappings/{sessionId}.json` |
+| Office Manager SwiftUI | GREEN | NavigationStack, per-session OfficeViewModel, LRU scene cache (2-3 warm, ~50MB each) |
+| Local notification setup | YELLOW | Infra exists, "Cool Beans" action trivial. WebSocket dies ~10s after iOS background. **Compromise: relay queues responses, delivers on reconnect. Local push only during grace period.** |
+| Role → sprite mapping table | GREEN | 14 humans, 8 roles, clean 1:1 mapping with 6 extras for overflow |
+
+### Spec adjustments from research
+
+1. **Local push notifications** downgraded to best-effort during ~10s iOS suspension grace period. Relay queues responses for disconnected clients; delivered as in-app banners on reconnect. APNs deferred to future phase.
+2. **`/btw` injection** goes through orchestrator session (SDK exposes no subagent handle). Constraint framing tells Claude to relay to specific subagent.
+3. **Cross-cutting blockers** identified for Wave 2: agent events need `sessionId`, relay needs "get agents for session X" query, relay must queue `/btw` responses for disconnected clients.
+
+### Role → CharacterType mapping (LOCKED)
+
+| Canonical Role | CharacterType | Rationale |
+|---|---|---|
+| `researcher` | `.botanist` | Science/discovery vibe |
+| `architect` | `.captain` | Authority, big-picture |
+| `qa` | `.doctor` | Diagnostic precision |
+| `devops` | `.mechanic` | Infrastructure ops |
+| `frontend` | `.frontendDev` | Direct match |
+| `backend` | `.backendEngineer` | Direct match |
+| `lead` | `.pm` | Project leadership |
+| `engineer` | `.claudimusPrime` | Generic = ship's AI |
+
+Overflow pool (random fallback): `alienDiplomat`, `bowenYang`, `chef`, `dwight`, `kendrick`, `prince`
 
 ---
 
-## Proposed Waves (pending research)
+## Waves
 
-### Wave 1 — Spec Freeze + Research
-- Answer all research gates above
-- Produce protocol addendum (exact message schemas, sequence diagrams)
-- Technical spike for anything needing prototyping
-- Lock wave structure based on findings
+### Wave 1 — Spec Freeze + Research ✅ COMPLETE
+- All research gates answered
+- Protocol schemas defined (see research docs)
+- Spec adjustments locked
+- Wave structure confirmed
 
-### Wave 2 — Data Model + Protocol
-- Add `linkedSubagentId` to `AgentState` (iOS)
-- Persist `parentId` from `agent.spawn` events
-- New relay message types: `sprite.link`, `sprite.unlink`, `sprite.message`, `sprite.response`, `sprite.state`
-- Mapping persistence (JSON per session) with cleanup lifecycle
-- Hybrid role → sprite mapping (frontmatter → classifier → random)
-- Remove dog fallback in `OfficeViewModel` (duplicate humans instead)
+### Wave 2 — Data Model + Protocol ← IN PROGRESS
+**Two parallel tracks** (zero shared files):
+
+**Relay track** (`sprite-wiring/wave2-relay`):
+- New `sprite.*` protocol message types (5 types) in `messages.ts`
+- Add `sessionId` to all agent event messages
+- Add `sprite.state` query for cold scene rebuild
+- `SpriteMappingPersistence` class (`~/.major-tom/sprite-mappings/`)
+- Role classifier (regex on task description, 8 canonical roles)
+- Cleanup lifecycle hooks (session destroy, agent dismiss, shutdown, cold boot)
+
+**iOS track** (`sprite-wiring/wave2-ios`):
+- Add `linkedSubagentId` to `AgentState`
+- Role → CharacterType mapper (locked table above)
 - Clone-not-consume sprite allocation model
+- Remove dog fallback in `OfficeViewModel` (duplicate humans instead)
+- Per-session OfficeViewModel routing (prep for Wave 3)
+- Persist `parentId` from agent.spawn events
 
 ### Wave 3 — Office Manager + Multi-Session
 - Office Manager SwiftUI view (cards for active Offices + unlinked sessions)

--- a/docs/SPRITE-WIRING-RESEARCH-IOS.md
+++ b/docs/SPRITE-WIRING-RESEARCH-IOS.md
@@ -1,0 +1,298 @@
+# Sprite-Agent Wiring: iOS Feasibility Research
+
+## Gate 1: Office Manager SwiftUI + SKScene Lifecycle
+
+### What We Found
+
+**Current Architecture:**
+
+- **Entry point:** `OfficeView` is a plain `struct` SwiftUI view at `ios/MajorTom/Features/Office/Views/OfficeView.swift`.
+- **Tab wiring:** Directly embedded in the TabView at `MajorTomApp.swift:125`:
+  ```swift
+  OfficeView(viewModel: officeViewModel, relay: relay)
+      .tabItem { Label("Office", systemImage: "building.2") }
+      .tag(AppTab.office)
+  ```
+- **Single OfficeViewModel:** Created as `@State` in `MajorTomApp.swift:6`, passed directly to `OfficeView`. Only one exists.
+- **SKScene creation:** The `OfficeScene` is created inline as a `@State` property in `OfficeView` (line 31-36):
+  ```swift
+  @State private var scene: OfficeScene = {
+      let scene = OfficeScene()
+      scene.size = CGSize(width: StationLayout.sceneWidth, height: StationLayout.sceneHeight)
+      scene.scaleMode = .aspectFill
+      return scene
+  }()
+  ```
+- **Scene size:** Each OfficeScene is ~1240x2620 points (the full station layout). It contains: starfield parallax, 8 rooms, furniture, airlocks, grid movement engine, particle effects, camera system, weather engine.
+- **Scene lifecycle management:** `onAppear` unpauses the scene + wires engines; `onDisappear` pauses + stops all engines (lines 66-139). The `hasSetup` guard in `OfficeScene.didMove(to:)` prevents re-running setup if SpriteView re-hosts the scene (line 77-86).
+- **RelayService wiring:** `officeViewModel` is set on RelayService at `MajorTomApp.swift:29`. All agent events (spawn/working/idle/complete/dismissed) flow through this single ViewModel. There is NO session scoping -- all agent events go to the same OfficeViewModel regardless of session.
+- **Session awareness:** `RelayService` tracks `currentSession: RelaySession?` (single) and `sessionList: [SessionMetaInfo]` (multiple). The `sessionList` is populated from `SessionListResponseEvent`. However, agent events have NO session-level routing -- they all hit the single OfficeViewModel.
+
+**SKScene Multi-Instance Analysis:**
+
+1. **Can multiple SKScenes coexist in memory?** Yes. SKScene is a regular reference-type class. Multiple instances can exist simultaneously. Only the one attached to a visible `SpriteView` is actively rendering.
+2. **Scene pausing:** `scene.isPaused = true` stops the update/render loop. The node tree stays in memory. This is already used when the Office tab is not visible (line 131-133).
+3. **SpriteView lifecycle:** When `SpriteView` leaves the SwiftUI hierarchy, it does NOT automatically destroy the scene. The scene persists as long as something holds a strong reference. However, re-hosting a scene into a new SpriteView will call `didMove(to:)` again (which the `hasSetup` guard already handles).
+4. **Memory cost per scene:** Each OfficeScene is heavyweight. It contains: ~8 room modules with furniture nodes, parallax layers, cached window refs, airlock door animations, grid movement engine with pathfinding data, agent sprites (each with texture, label, status dot, mood overlay). Rough estimate: 30-60MB per scene depending on agent count and texture caching. The texture atlas (`CrewSprites`) is shared (loaded once by SpriteKit), so the cost is mainly node tree + engine state.
+5. **Warm vs cold tradeoff:** Keeping 2-3 scenes warm (paused in memory) is feasible on modern iPhones (4-8GB RAM). Beyond that, cold-destroying and rebuilding from relay state is the right call. Rebuild cost is dominated by `renderStationHull()`, `renderModuleFurniture()`, `buildMovementGrids()` -- probably 200-500ms.
+
+**Proposed View Hierarchy for Office Manager:**
+
+```
+TabView
+  -> OfficeTab (replaces current OfficeView in tab bar)
+      -> NavigationStack
+          -> OfficeManagerView (root -- cards for sessions)
+              -> OfficeView(sessionId:) (pushed on card tap)
+                  -> SpriteView(scene: scene)
+```
+
+- `NavigationStack` is the natural fit -- card tap pushes an Office, back button returns to manager. No sheet (sheets feel wrong for full-screen game views).
+- Each `OfficeView` gets its own `OfficeViewModel` scoped to a session. The current single `officeViewModel` at app level becomes a `[String: OfficeViewModel]` dictionary keyed by sessionId.
+- `OfficeManagerView` shows cards from `relay.sessionList` and a local `[String: OfficeScene]` cache.
+- Scene lifecycle: active (visible in SpriteView), warm (recently viewed, paused, held in the cache dict), cold (not in cache, rebuilt on next visit). A simple LRU with max 2-3 warm slots.
+
+### Feasibility: GREEN
+
+All building blocks exist. The main work is:
+1. Replace single `OfficeViewModel` with per-session instances
+2. Route agent events by sessionId (requires relay to include sessionId in agent events -- need to verify)
+3. Build `OfficeManagerView` card layout
+4. Add scene caching with warm/cold lifecycle
+
+### Recommended Approach
+
+1. Create `OfficeManagerView` as a new view that becomes the tab content.
+2. Use `NavigationStack` with `navigationDestination(for:)` keyed on session ID.
+3. Introduce an `OfficeSceneManager` (or similar) observable class that manages a `[String: (scene: OfficeScene, viewModel: OfficeViewModel)]` dictionary + LRU eviction.
+4. Wire `RelayService` to route agent events to the correct per-session `OfficeViewModel` using the event's sessionId (or parentId).
+5. When navigating to a cold session, rebuild the scene from relay state (request current agent list from relay).
+
+### Open Questions / Risks
+
+- **Agent events lack sessionId routing:** Currently, `AgentSpawnEvent` has `agentId`, `parentId`, `task`, `role` but no explicit `sessionId`. The relay will need to either (a) include `sessionId` in agent events, or (b) the iOS side tracks which agents belong to which session via the parentId chain. Option (a) is much simpler and should be done in Wave 2.
+- **Scene rebuild from relay state:** We need a relay endpoint or message to request "give me all current agents for session X" so cold scenes can rebuild. Currently there's no such message.
+- **Memory budget:** 3 warm scenes at ~50MB each = ~150MB. On an iPhone with 4GB RAM, this is acceptable but should be tested. May want to drop to 2 warm max on older devices.
+- **InspectorSpriteScene in AgentInspectorView** creates an additional mini SKScene per inspector opening (line 255-339 of AgentInspectorView.swift). These are tiny (80x80) and not a concern.
+
+---
+
+## Gate 2: Local Notification Setup
+
+### What We Found
+
+**Existing Infrastructure (NotificationService.swift):**
+
+- Full `UNUserNotificationCenter` setup already exists at `ios/MajorTom/Features/Notifications/Services/NotificationService.swift`.
+- Permission request flow is wired: `requestPermission()` called on pairing (MajorTomApp.swift:64).
+- Categories are registered: `APPROVAL_REQUEST` (with Allow/Deny actions) and `SESSION_EVENT`.
+- `UNUserNotificationCenterDelegate` is implemented with both `didReceive` (action handling) and `willPresent` (foreground display).
+- Local notification posting already works: `postApprovalNotification()`, `postAgentSpawnNotification()`, `postAgentCompleteNotification()`, `postSessionEndNotification()`.
+- Deep link handling is wired: `NotificationDeepLink` struct with `majortom://` URL scheme, consumed in `MajorTomApp.swift:72-76`.
+
+**"Cool Beans" Action Button:**
+
+Adding a custom notification category with a "Cool Beans" action button is straightforward:
+```swift
+let coolBeansAction = UNNotificationAction(
+    identifier: "COOL_BEANS_ACTION",
+    title: "Cool Beans",
+    options: []  // No destructive, no auth required
+)
+let btwyCategory = UNNotificationCategory(
+    identifier: "BTW_RESPONSE",
+    actions: [coolBeansAction],
+    intentIdentifiers: [],
+    options: [.customDismissAction]
+)
+```
+Register alongside existing categories. Handle in the existing `didReceive` delegate method.
+
+**App Foreground/Background Detection:**
+
+- `scenePhase` is already tracked in `MajorTomApp.swift:13` via `@Environment(\.scenePhase)`.
+- Currently used only for shortcut action check (line 107-112). Not yet used to gate notification firing.
+- Gating logic: check `scenePhase == .background` before posting a `/btw` response notification. Or more robustly, use `UIApplication.shared.applicationState` at the moment of posting (since scenePhase is an environment value, it's trickier to read from a service class).
+
+**WebSocket Background Behavior:**
+
+This is the critical risk area.
+
+- The WebSocket client (`WebSocketClient.swift`) uses `URLSessionWebSocketTask` with `URLSession(configuration: .default)`.
+- **iOS suspends apps ~5-10 seconds after backgrounding.** When suspended, the URLSessionWebSocketTask is suspended too -- no messages received.
+- **No background modes are configured.** There's no `UIBackgroundModes` in the Info.plist for `voip`, `fetch`, or `remote-notification`.
+- **The reconnect logic** (exponential backoff, max 10 attempts) handles disconnects but doesn't address iOS suspension.
+- **When the app returns to foreground:** If the WebSocket was not explicitly closed by the server, it may still be connected (TCP keepalive can survive short backgrounds). For longer backgrounds (>30s), the connection is likely dead and reconnect kicks in.
+
+**Notification Delivery When Backgrounded:**
+
+The core problem: if the WebSocket drops when backgrounded, the iOS app cannot receive the `/btw` response at all, so it cannot post a local notification.
+
+Options:
+1. **Short background window (~5-10s):** If the response arrives within the iOS suspension grace period, the app is still running and can post the notification. Works for fast responses.
+2. **Background URLSession:** Use `URLSession(configuration: .background)` for the WebSocket. However, `URLSessionWebSocketTask` does NOT support background sessions -- only download/upload tasks do.
+3. **Silent push notification from relay (APNs):** Relay detects iOS client is not responding, sends a silent push via APNs to wake the app. App wakes for ~30s, reconnects WebSocket, fetches response, posts local notification. This is the most reliable but requires APNs infrastructure (explicitly out of scope per spec).
+4. **Background fetch:** Register for background app refresh. iOS calls the app periodically (unpredictable timing, 15min-1hr). App reconnects, checks for pending responses. Too unreliable.
+5. **Relay holds response, iOS fetches on foreground return:** The relay queues the response. When the app returns to foreground and reconnects, the relay delivers all pending responses. iOS posts a "you missed this" banner in-app instead of a notification. This is the most practical no-infrastructure option.
+
+### Feasibility: YELLOW
+
+- Adding the notification category + "Cool Beans" action: GREEN, trivial.
+- Detecting foreground/background: GREEN, already wired.
+- Delivering notification when app is truly backgrounded (>10s): RED without APNs. The WebSocket dies and there's no way to wake the app.
+- **Practical compromise:** Local notification works for the brief iOS suspension window (~5-10s). For longer backgrounds, the relay queues responses and delivers them on reconnect. The app shows a "you missed N responses" badge/indicator instead of a push notification.
+
+### Recommended Approach
+
+1. Add a `BTW_RESPONSE` notification category with "Cool Beans" action to the existing `registerCategories()` method.
+2. Add a `postBtwResponseNotification(agentId:, response:)` method to NotificationService.
+3. Gate posting on `UIApplication.shared.applicationState != .active` (use UIApplication since services can't read scenePhase easily).
+4. For the background gap: relay must queue `/btw` responses and deliver them on reconnect. When iOS reconnects and receives a delayed `/btw` response, show it as an in-app banner (not a push notification, since the user is already in the app).
+5. Document the limitation: "push notifications for `/btw` responses work reliably only during the ~10s iOS suspension grace period. For longer backgrounds, responses are delivered on next app open." This is honest and matches what local-only notification can achieve.
+6. Consider a future phase for APNs if the limitation proves painful.
+
+### Open Questions / Risks
+
+- **BGTaskScheduler:** iOS 17+ has `BGAppRefreshTask`. Could schedule a background task that reconnects and checks for responses. But iOS controls scheduling (could be 15min+) so it's unreliable for timely delivery.
+- **WebSocket keepalive in background:** We could request `beginBackgroundTask(withName:)` when a `/btw` message is pending. This gives ~30s of execution time. If the response arrives in that window, we post the notification. Worth implementing.
+- **`URLSessionConfiguration.background` for HTTP polling:** Could add a periodic HTTP poll as a background-mode fallback. But this adds complexity and is still unreliable for timing.
+
+---
+
+## Gate 3: Role -> Sprite Mapping Table
+
+### What We Found
+
+**CharacterType Enum (AgentState.swift:17-52):**
+
+14 human types:
+| # | Case | Display Name | Visual Theme |
+|---|------|-------------|--------------|
+| 1 | `alienDiplomat` | Alien Diplomat | Mint green |
+| 2 | `backendEngineer` | Backend Engineer | Steel blue |
+| 3 | `botanist` | Botanist | Plant green |
+| 4 | `bowenYang` | Bowen Yang | Pink/coral (celebrity) |
+| 5 | `captain` | Captain | Navy blue |
+| 6 | `chef` | Space Chef | White |
+| 7 | `claudimusPrime` | Claudimus Prime | Silver/blue (android) |
+| 8 | `doctor` | Doctor | White+teal |
+| 9 | `dwight` | Dwight | Mustard yellow (The Office) |
+| 10 | `frontendDev` | Frontend Dev | Purple/magenta |
+| 11 | `kendrick` | Kendrick | Gold (celebrity) |
+| 12 | `mechanic` | Mechanic | Orange jumpsuit |
+| 13 | `pm` | Project Manager | Yellow/gold |
+| 14 | `prince` | Prince | Purple (celebrity) |
+
+7 dog types (never assigned as agent sprites per spec):
+`elvis`, `esteban`, `hoku`, `kai`, `senor`, `steve`, `zuckerbot`
+
+**Sprite Assets:**
+All 21 character types have full sprite sheets in `Assets.xcassets/CrewSprites.spriteatlas/`. Each has: front, back, left, right, walkLeft1/2, walkRight1/2, plus activity poses (sitting, sleeping, working, exercising for humans; running, sniffing for dogs). Every human type has a complete asset set -- no sharing needed.
+
+**Current Sprite Claiming Code (OfficeViewModel.swift:120-156):**
+
+```swift
+func handleAgentSpawn(id: String, role: String, task: String) {
+    // ...
+    let characterType: CharacterType
+    if let claimed = claimRandomSprite() {  // Random from availableSprites pool
+        // Consume idle sprite
+        characterType = claimed
+    } else {
+        // Overflow: unrendered human from crew roster
+        if let overflow = crewRoster.overflowHuman(excluding: claimedTypes, maxIdleCount: Self.maxIdleHumans) {
+            characterType = overflow
+        } else {
+            // FALLBACK TO DOG (spec says remove this)
+            characterType = CharacterType.allCases.filter(\.isDog).randomElement() ?? .elvis
+        }
+    }
+}
+```
+
+Key observations:
+- `claimRandomSprite()` picks randomly from `availableSprites` set. No role-based selection at all.
+- `parentId` is received in `AgentSpawnEvent` (Message.swift:765) but NEVER passed to `handleAgentSpawn()`. The relay call at line 716 only passes `event.agentId, event.role, event.task`.
+- Dog fallback at line 139 -- spec says REMOVE this and duplicate humans instead.
+- `availableSprites` is rebuilt on `populateIdleSprites()` from the currently-rendered idle sprites.
+
+**Proposed Role -> CharacterType Mapping:**
+
+With 14 humans and 8 canonical roles, we have room. Here's the proposed mapping based on visual/thematic fit:
+
+| Canonical Role | Primary CharacterType | Rationale |
+|---|---|---|
+| `researcher` | `.botanist` | Research/science vibe, plant-green fits discovery |
+| `architect` | `.captain` | Authority, big-picture planning, navy command look |
+| `qa` | `.doctor` | Diagnostic, testing, quality -- medical precision |
+| `devops` | `.mechanic` | Infrastructure, wrenches, orange jumpsuit = ops |
+| `frontend` | `.frontendDev` | Direct name match, purple/magenta = creative |
+| `backend` | `.backendEngineer` | Direct name match, steel blue = server-side |
+| `lead` | `.pm` | Project management, leadership, gold = authority |
+| `engineer` | `.claudimusPrime` | Generic engineer = the android (ship's AI = fitting for Claude agents) |
+
+**Remaining 6 humans for overflow / random:**
+- `alienDiplomat` -- good for unrecognized roles (alien = unusual)
+- `bowenYang` -- celebrity, fun wildcard
+- `chef` -- break-room character
+- `dwight` -- comic relief
+- `kendrick` -- celebrity, wildcard
+- `prince` -- celebrity, wildcard
+
+This gives every canonical role a unique human sprite, with 6 extras for:
+1. Random fallback when role is unrecognized
+2. Overflow when >8 agents of different roles spawn
+3. Idle cosmetic crew
+
+**Clone-Not-Consume Impact:**
+The spec's clone-not-consume model means idle sprites are separate from agent sprites. The mapping table only affects which CharacterType gets instantiated for an agent sprite. The idle pool is unaffected. This simplifies things -- we don't need to worry about "stealing" an idle sprite's type.
+
+### Feasibility: GREEN
+
+14 humans, 8 roles, all sprites have full asset sets. The mapping is clean with no gaps.
+
+### Recommended Approach
+
+1. Add a `RoleMapper` utility (or extend `CharacterType`) with:
+   ```swift
+   static func characterType(forCanonicalRole role: String) -> CharacterType {
+       switch role.lowercased() {
+       case "researcher": return .botanist
+       case "architect": return .captain
+       case "qa": return .doctor
+       case "devops": return .mechanic
+       case "frontend": return .frontendDev
+       case "backend": return .backendEngineer
+       case "lead": return .pm
+       case "engineer": return .claudimusPrime
+       default: return randomUnmappedHuman()
+       }
+   }
+   ```
+2. Replace `claimRandomSprite()` in `handleAgentSpawn()` with role-based lookup.
+3. Add role-stable binding: per-session `[String: CharacterType]` dict that remembers "frontend" -> `.frontendDev` for the session lifetime. First spawn for a role locks it.
+4. Remove dog fallback at line 138-139. Replace with human duplication (pick from unmapped humans, then duplicate if all exhausted).
+5. Pass `parentId` through from `AgentSpawnEvent` to `handleAgentSpawn()`.
+
+### Open Questions / Risks
+
+- **Relay classifier accuracy:** The 8 canonical roles need to be determined somehow. Options: (a) agent `.md` frontmatter `spriteCategory`, (b) relay regex on task description, (c) iOS-side regex. The spec says relay-side classifier with frontmatter override. This is a relay-side implementation task, not an iOS blocker.
+- **Role-stable binding vs session-scoped:** If the same role spawns twice in one session, both get the same CharacterType (by design). Visual differentiation is via desk position. This is fine for typical workflows (1-2 of the same role) but could look odd with 5+ identical sprites. The overflow pool (6 unmapped humans) provides variety for edge cases.
+- **Celebrity sprites (bowenYang, kendrick, prince, dwight):** These are fun but potentially confusing as "professional" agent representations. Consider whether they should be in the random overflow pool or excluded from agent assignment entirely (idle-only, like dogs). Recommend: keep them in the random pool -- they add personality.
+
+---
+
+## Summary
+
+| Gate | Feasibility | Blocking Issues |
+|------|------------|-----------------|
+| Office Manager + SKScene lifecycle | GREEN | Agent events need sessionId routing (relay change) |
+| Local notifications | YELLOW | WebSocket dies on background; local-only notification is unreliable beyond ~10s. Practical with queue-and-deliver-on-reconnect fallback. |
+| Role -> sprite mapping | GREEN | Clean mapping with surplus sprites. Relay classifier is the only dependency. |
+
+### Cross-Cutting Dependencies
+
+1. **Relay must include `sessionId` in agent events** (spawn, working, idle, complete, dismissed) -- currently missing. Without this, per-session Offices cannot route events correctly.
+2. **Relay must provide a "get current agents for session X" query** -- needed for cold scene rebuild.
+3. **Relay must queue `/btw` responses for disconnected clients** -- needed for the background notification gap and for reconnect scenarios.
+4. **Relay classifier for canonical roles** -- can be deferred to Wave 2 but must be designed with the mapping table above in mind.

--- a/docs/SPRITE-WIRING-RESEARCH-RELAY.md
+++ b/docs/SPRITE-WIRING-RESEARCH-RELAY.md
@@ -1,0 +1,596 @@
+# Sprite-Agent Wiring: Relay + SDK Research Gates
+
+> Research date: 2026-04-16
+> Branch: `docs/sprite-agent-wiring-spec`
+> Researcher: Claude Opus 4.6
+
+---
+
+## Gate 1: Agent SDK Turn-Boundary Injection
+
+### What We Found
+
+#### Current subagent spawn/lifecycle flow
+
+The relay spawns Claude sessions via the Agent SDK's `unstable_v2_createSession()` API. There are two parallel code paths:
+
+1. **Direct adapter** (`relay/src/adapters/claude-cli.adapter.ts:169-283`) -- used in single-worker mode. Creates an `SDKSession` with hooks for `PreToolUse`, `SubagentStart`, `SubagentStop`.
+
+2. **Fleet worker** (`relay/src/fleet/worker.ts:146-310`) -- used in multi-worker mode (child process). Structurally identical to the adapter, creates its own `SDKSession` with the same hooks.
+
+Both paths use `sdkSession.send(text)` to send user messages and `sdkSession.stream()` to consume responses.
+
+#### How turns work in the SDK
+
+The SDK's `stream()` method is an `AsyncGenerator<SDKMessage, void>` (sdk.d.ts:2695). The existing `consumeStream()` function at `claude-cli.adapter.ts:431-472` and `worker.ts:485-522` reveals the turn model:
+
+```typescript
+// The SDK's stream() generator exits after each turn's `result` message.
+// We must loop and call stream() again to consume subsequent turns.
+while (!signal.aborted) {
+  for await (const message of sdkSession.stream()) {
+    handleSdkMessage(sessionId, message);
+  }
+  // Turn complete (stream yielded `result` and returned).
+  // Loop back to call stream() again for the next turn.
+}
+```
+
+The `stream()` generator yields messages until a `result` message (type `SDKResultMessage`), then **returns** (the inner for-await-of loop completes). The outer while-loop then calls `stream()` again for the next turn. This is the definitive "turn boundary" -- the point between one `stream()` completing and the next `send()` call.
+
+#### Turn boundary signals available
+
+| Signal | When | SDK Support | File Reference |
+|--------|------|-------------|----------------|
+| `result` message | End of each turn (after all tool calls complete and Claude responds) | `SDKResultSuccess \| SDKResultError` (sdk.d.ts:2656) | `handleResultMessage()` at adapter:608, worker:662 |
+| `SubagentStop` hook | When a subagent finishes | First-class hook (sdk.d.ts:4463-4465) | adapter:257-278, worker:250-270 |
+| `TaskCompleted` hook | When a Task tool completes | First-class hook (sdk.d.ts:4496-4503) | **Not currently wired** |
+| `PostToolUse` hook | After any tool execution completes | First-class hook (sdk.d.ts:1621-1627) | **Not currently wired** |
+| `message_stop` stream event | When assistant message is complete | Via `stream_event.event.type === 'message_stop'` | **Not currently handled** |
+
+#### Can we inject a user message at turn boundary?
+
+**YES.** The key insight is in the `consumeStream` loop structure:
+
+```
+stream() yields messages -> result -> stream() returns
+                                         |
+                                    [TURN BOUNDARY - this is where we inject]
+                                         |
+                                    stream() called again for next turn
+```
+
+Between `stream()` returning and the next `stream()` call, we can call `sdkSession.send(text)`. The SDK's `send()` method (sdk.d.ts:2693) accepts `string | SDKUserMessage`. This is the natural injection point.
+
+However, there is a critical subtlety: **subagents do NOT have their own `SDKSession` handle.** The relay does not create separate SDK sessions per subagent. A subagent is spawned by Claude's internal `Task` tool within the orchestrator's session. The relay sees:
+- `PreToolUse(Task)` hook -> `SubagentStart` hook -> subagent runs -> `SubagentStop` hook -> `PostToolUse(Task)` / `TaskCompleted` hook
+
+The relay has **no direct communication channel to a subagent.** The current `sendAgentMessage()` at `worker.ts:351-361` just wraps the text and sends it to the **main session**:
+
+```typescript
+const wrappedText = `[Regarding agent ${agentId}]: ${text}`;
+await entry.sdkSession.send(wrappedText);
+```
+
+This sends a user-turn to the **orchestrator**, not the subagent. The orchestrator may or may not relay it.
+
+#### The real mechanism for /btw
+
+Since we cannot inject directly into a subagent's conversation, the spec's turn-boundary injection must work differently than initially conceived. Here are the options:
+
+**Option A: Orchestrator relay (current behavior, enhanced)**
+- Send `/btw` to the orchestrator session with the constraint framing
+- The orchestrator itself decides whether/how to relay to the subagent
+- Turn boundary = when the orchestrator's `stream()` returns (main session result)
+- Problem: The orchestrator might not relay the message, or might change its behavior
+
+**Option B: `PostToolUse` hook with `additionalContext` (recommended)**
+- Register a `PostToolUse` hook with matcher `'Task'` (or any tool)
+- When a subagent completes a tool call, the `PostToolUse` hook fires with `tool_use_id`
+- The hook can return `{ additionalContext: "User observation: ..." }` which gets appended to the tool result before Claude sees it
+- This injects text at the subagent's tool-call boundary without requiring a separate send()
+- The SDK already supports this: `PostToolUseHookSpecificOutput.additionalContext` (sdk.d.ts:1629-1633)
+
+**Option C: Queued send() between stream() turns**
+- Queue the /btw message on the relay
+- In the consumeStream loop, after `stream()` returns (turn boundary), check the queue
+- If a message is pending, call `sdkSession.send(constrainedMessage)` before the next `stream()`
+- This sends to the main session, but with careful constraint framing
+
+### Feasibility Assessment: YELLOW
+
+The spec's vision of "inject at subagent turn boundary" is not directly possible because the relay has no handle to the subagent's conversation. The SDK does not expose subagent sessions. However, two viable workarounds exist:
+
+1. **PostToolUse hook with additionalContext** -- injects at tool-call boundaries within the current session. This is clean but only works when tool calls happen (not between text turns).
+
+2. **Queued send() at orchestrator turn boundary** -- injects as a new user turn to the main session. The constraint framing tells Claude to relay to the specific subagent.
+
+### Recommended Approach
+
+**Hybrid: PostToolUse `additionalContext` for in-flight subagents + queued `send()` for between-turn injection.**
+
+1. Register a `PostToolUse` hook (any tool, not just Task) that checks the /btw queue for the owning subagent. If a message is queued, return `{ additionalContext: constrainedBtwMessage }`. This piggybacks on tool results the subagent already sees.
+
+2. For between-turn injection (when `stream()` returns), check the queue and call `send()` with the constraint framing directed at the specific subagent.
+
+3. Add `TaskCompleted` hook to detect subagent completion and drop undelivered messages (scenario 4 in the spec).
+
+### Open Questions / Risks
+
+- **PostToolUse fires on ALL tool calls, including subagent tool calls?** Need to verify that hooks fire for tools used within subagents, not just the orchestrator. The `parent_tool_use_id` field on stream events suggests subagent tool events ARE visible, but hook-level visibility needs testing.
+- **Can `additionalContext` in PostToolUse actually influence a subagent?** It appends to the tool result the model sees. If the hook fires for a subagent's tool call, the subagent would see it. If it only fires at the orchestrator level, Option B won't work for subagent injection.
+- **Race condition**: If `stream()` returns and we inject via `send()`, the orchestrator gets a new user turn. It might not relay to the subagent if the subagent already completed. The `SubagentStop` hook is the guard here.
+- **Constraint framing effectiveness**: The spec relies on Claude obeying "do NOT change your task." This is prompt engineering, not a hard guarantee.
+
+---
+
+## Gate 2: Protocol Message Types
+
+### What We Found
+
+#### Existing message conventions
+
+All protocol messages live in `relay/src/protocol/messages.ts` (1233 lines). Key conventions:
+
+1. **Discriminated union on `type` field** -- every message has `type: string` as the routing key
+2. **Naming**: dot-separated namespace (`agent.spawn`, `session.start`, `fs.ls`, `git.status`)
+3. **Request/response pairs**: client sends `type: 'X'`, server responds with `type: 'X.response'`
+4. **Server-initiated events**: no `.response` suffix (`agent.spawn`, `agent.dismissed`)
+5. **All messages carry `seq?: number`** via the `ServerMessage` type wrapper (messages.ts:1168)
+6. **Client union**: `ClientMessage` (messages.ts:470-519), Server union: `ServerMessageBase` (messages.ts:1096-1160)
+7. **IDs**: UUID v4, field names like `sessionId`, `agentId`, `requestId`
+
+#### Existing agent messages for reference
+
+```typescript
+// Client -> Server
+interface AgentMessageMessage {
+  type: 'agent.message';
+  sessionId: string;
+  agentId: string;
+  text: string;
+}
+
+// Server -> Client (existing)
+interface AgentSpawnMessage {
+  type: 'agent.spawn';
+  agentId: string;
+  parentId?: string;
+  task: string;
+  role: string;
+}
+```
+
+### Proposed Schemas
+
+Following existing conventions (dot-separated namespace, `sessionId` on session-scoped messages):
+
+```typescript
+// ── Sprite ↔ Agent Wiring Messages ──────────────────────────
+
+// Server → Client: a sprite has been linked to a subagent
+interface SpriteLinkMessage {
+  type: 'sprite.link';
+  sessionId: string;
+  spriteHandle: string;         // CharacterType or unique sprite instance ID
+  agentId: string;              // subagent's agent_id from SubagentStart
+  role: string;                 // classified role (researcher, architect, etc.)
+  characterType: string;        // resolved CharacterType for the sprite
+  deskIndex?: number;           // assigned desk position (0-5, or undefined for overflow)
+}
+
+// Server → Client: sprite unlinked (subagent completed/crashed)
+interface SpriteUnlinkMessage {
+  type: 'sprite.unlink';
+  sessionId: string;
+  spriteHandle: string;
+  agentId: string;
+  reason: 'completed' | 'failed' | 'dismissed' | 'session_ended';
+}
+
+// Client → Server: user sends /btw message to a sprite's linked subagent
+interface SpriteMessageMessage {
+  type: 'sprite.message';
+  sessionId: string;
+  spriteHandle: string;
+  agentId: string;
+  text: string;
+  messageId: string;            // client-generated UUID for tracking
+}
+
+// Server → Client: /btw response from the subagent
+interface SpriteResponseMessage {
+  type: 'sprite.response';
+  sessionId: string;
+  spriteHandle: string;
+  agentId: string;
+  messageId: string;            // correlates to the sprite.message
+  text: string;                 // the subagent's constrained response
+  status: 'delivered' | 'dropped';  // dropped = subagent completed before delivery
+  dropReason?: string;          // only set when status === 'dropped'
+}
+
+// Server → Client: full sprite-subagent mapping state (reconnect/sync)
+interface SpriteStateMessage {
+  type: 'sprite.state';
+  sessionId: string;
+  mappings: Array<{
+    spriteHandle: string;
+    agentId: string;
+    role: string;
+    characterType: string;
+    deskIndex?: number;
+    pendingBtw?: {              // if a /btw is in-flight
+      messageId: string;
+      text: string;
+      status: 'queued' | 'injected' | 'awaiting_response';
+    };
+  }>;
+  roleBindings: Record<string, string>;  // role -> CharacterType (session-stable)
+}
+```
+
+### Feasibility Assessment: GREEN
+
+These message types follow existing conventions perfectly. The `sprite.*` namespace is clean, no conflicts. Adding them requires:
+1. Interface definitions in `messages.ts`
+2. Adding to `ClientMessage` union (for `sprite.message`)
+3. Adding to `ServerMessageBase` union (for `sprite.link`, `sprite.unlink`, `sprite.response`, `sprite.state`)
+4. Case handler in `ws.ts` message switch
+5. IPC messages in `ipc-messages.ts` for fleet worker relay
+
+### Recommended Approach
+
+Add all five message types to `messages.ts`. Wire `sprite.message` handling into the WS route's message switch at `ws.ts` alongside the existing `agent.message` case (line 818). The server-initiated messages (`sprite.link`, `sprite.unlink`, `sprite.state`) are emitted from the fleet manager's agent-lifecycle handler (ws.ts:1689).
+
+### Open Questions
+
+- **`spriteHandle` identity**: Should this be the CharacterType string (e.g., `"frontendDev"`) or a unique per-instance UUID? The clone-not-consume model means multiple sprites of the same CharacterType can exist, so we need per-instance IDs. Recommend: relay generates a UUID `spriteHandle` on link, CharacterType is a separate field.
+- **`sprite.state` size**: For reconnect, we send the full mapping. With 6 max agents, this is tiny (~1-2 KB).
+- **Event buffering**: Should `sprite.link`/`sprite.unlink` be buffered in the `EventBufferManager` for replay? Yes -- they're session-scoped events and should be replayable on reconnect.
+
+---
+
+## Gate 3: Relay Message Queue Design
+
+### What We Found
+
+#### Current session/adapter architecture
+
+The relay has two modes:
+
+1. **Single-worker** (`ClaudeCliAdapter` at `adapters/claude-cli.adapter.ts`) -- one process, in-memory sessions map.
+2. **Fleet mode** (`FleetManager` at `fleet/fleet-manager.ts` + `fleet/worker.ts`) -- parent process forks child workers, communicates via IPC.
+
+In both modes:
+- Each SDK session has one `consumeStream` loop running
+- `sdkSession.send()` is the only way to inject user input
+- The stream loop structure is: `while -> for-await stream() -> handle result -> loop`
+
+The current `sendAgentMessage()` (worker.ts:351-361, adapter:333-347) just wraps text and sends to the main session. There is no queue, no turn boundary detection, no waiting.
+
+#### The approval queue pattern (reusable)
+
+The existing `ApprovalQueue` at `relay/src/hooks/approval-queue.ts` implements a promise-based wait pattern:
+
+```typescript
+waitForDecision(requestId, toolName, description, details, signal): Promise<ApprovalDecision>
+```
+
+This creates a pending promise that resolves when `resolve(requestId, decision)` is called. This same pattern can be adapted for the /btw queue.
+
+### Proposed Queue Structure
+
+```typescript
+interface BtwQueueEntry {
+  messageId: string;           // from sprite.message
+  spriteHandle: string;
+  agentId: string;
+  text: string;
+  constrainedText: string;     // pre-built injection text with system framing
+  queuedAt: number;
+  status: 'queued' | 'injected' | 'awaiting_response' | 'responded' | 'dropped';
+  responsePromise?: {
+    resolve: (response: string) => void;
+    reject: (reason: Error) => void;
+  };
+}
+
+class BtwQueue {
+  // One entry per agentId (spec: only 1 message at a time per sprite)
+  private pending = new Map<string, BtwQueueEntry>();
+
+  enqueue(entry: Omit<BtwQueueEntry, 'status' | 'queuedAt'>): void;
+  
+  // Called from consumeStream loop at turn boundary
+  getPendingForSession(): BtwQueueEntry[];
+  
+  // Called when subagent completes before delivery
+  dropForAgent(agentId: string, reason: string): BtwQueueEntry | undefined;
+  
+  // Called when response is extracted from stream
+  resolveResponse(agentId: string, response: string): void;
+  
+  // Called when agent is dismissed
+  clearAgent(agentId: string): void;
+}
+```
+
+### Injection Points in the Stream Loop
+
+The queue integrates into the existing `consumeStream()` at three points:
+
+```typescript
+async function consumeStream(sessionId, sdkSession, signal) {
+  while (!signal.aborted) {
+    for await (const message of sdkSession.stream()) {
+      handleSdkMessage(sessionId, message);
+      
+      // INJECTION POINT 1: PostToolUse hook
+      // (registered at session creation, not in this loop)
+      // If a /btw is queued for the subagent that owns this tool call,
+      // the PostToolUse hook returns additionalContext
+    }
+    
+    // INJECTION POINT 2: Between turns
+    // stream() returned -> turn boundary -> check queue
+    const pending = btwQueue.getPendingForSession();
+    if (pending.length > 0) {
+      const entry = pending[0]; // one at a time per spec
+      entry.status = 'injected';
+      await sdkSession.send(entry.constrainedText);
+      entry.status = 'awaiting_response';
+      // The next stream() iteration will carry the response
+    }
+    
+    // INJECTION POINT 3: SubagentStop hook
+    // (registered at session creation)
+    // Drops queued messages for the completed agent
+  }
+}
+```
+
+### Response Extraction
+
+When the subagent responds to a /btw, the response appears in the stream as an `assistant` message or `stream_event` text deltas. The challenge is **correlating the response to the /btw message**.
+
+Approach: After injecting the /btw via `send()`, the next text response from the stream is the /btw response. We track `btwEntry.status === 'awaiting_response'` and capture the next text output as the response, then emit `sprite.response` to the client.
+
+This is imprecise if the orchestrator does something else between injection and response. The constraint framing ("respond in 1-2 sentences about your current progress") should make the response immediate and identifiable.
+
+### Fleet Mode (worker process)
+
+In fleet mode, the queue lives in the worker process (same process as the SDK session). New IPC messages needed:
+
+```typescript
+// Parent -> Child: enqueue a /btw
+interface IpcSpriteMessage {
+  type: 'ipc:sprite.message';
+  sessionId: string;
+  spriteHandle: string;
+  agentId: string;
+  text: string;
+  messageId: string;
+}
+
+// Child -> Parent: /btw response
+interface IpcSpriteResponse {
+  type: 'ipc:sprite.response';
+  sessionId: string;
+  spriteHandle: string;
+  agentId: string;
+  messageId: string;
+  text: string;
+  status: 'delivered' | 'dropped';
+  dropReason?: string;
+}
+```
+
+### What Happens if Subagent Completes Before Delivery
+
+Scenario 4 from the spec. The `SubagentStop` hook fires, which:
+1. Checks the queue for pending entries with that `agentId`
+2. If found, sets status to `dropped`
+3. Emits `sprite.response` with `status: 'dropped'` and `dropReason: 'completed before delivery'`
+
+### Feasibility Assessment: YELLOW
+
+The queue design is straightforward. The tricky part is response correlation -- knowing which stream output is the /btw response vs. normal Claude output. This requires either:
+- A unique marker in the injection text that the response echoes (fragile)
+- Treating the first text response after injection as the /btw response (simple, imprecise)
+- Using `parent_tool_use_id` on stream events to identify subagent output (most robust if available)
+
+### Recommended Approach
+
+1. Build `BtwQueue` class alongside existing `ApprovalQueue` in `relay/src/hooks/`
+2. One queue per session (scoped to the worker or adapter's session entry)
+3. Inject at the `consumeStream` turn boundary (between `stream()` returns)
+4. Use `SubagentStop` hook for cleanup of undelivered messages
+5. For response detection, use a state machine: after injection, the next complete assistant text response from the stream is captured as the /btw response
+6. Add IPC messages for fleet mode relay
+
+### Open Questions / Risks
+
+- **Response extraction accuracy**: If Claude generates multiple messages before the /btw response, we might capture the wrong text. Mitigation: The constraint framing tells Claude to respond immediately in 1-2 sentences.
+- **Concurrent subagents**: If two subagents are active, /btw messages to different agents can only be injected one at a time (the spec enforces 1-at-a-time per sprite, but different sprites could be messaged simultaneously). The queue should serialize injection to avoid interleaving.
+- **Stream events vs. assistant messages**: The response might come as `stream_event` deltas (real-time) or a complete `assistant` message. We need to handle both paths.
+
+---
+
+## Gate 4: Mapping Persistence Format
+
+### What We Found
+
+#### Existing persistence infrastructure
+
+Session data is already persisted to `~/.major-tom/sessions/` via `SessionPersistence` at `relay/src/sessions/session-persistence.ts`:
+
+- Directory: `~/.major-tom/sessions/`
+- Format: JSON files, one per session (`{sessionId}.json`)
+- Features: debounced writes (2s), immediate save for shutdown, file listing, delete
+- Session ID sanitization (path traversal prevention) at line 44
+- The `SessionPersistence` class is injected into `SessionManager` at construction
+
+#### Session lifecycle hooks
+
+| Event | Code Location | Hook |
+|-------|--------------|------|
+| Session created | `session-manager.ts:38` | `create()` returns new `Session` |
+| Session closed | `session-manager.ts:100` | `close()` sets status to `closed` |
+| Session destroyed | `session-manager.ts:108` | `destroy()` removes from map |
+| Graceful shutdown | `session-persistence.ts:129` | `saveAllImmediate()` flushes pending writes |
+| Persistence disposal | `session-persistence.ts:144` | `dispose()` cancels all timers |
+
+The `ws.ts` route handles session lifecycle at the fleet manager level (line 1689+), including agent spawn/dismiss events. It's also where session end cleanup happens.
+
+#### Existing `AgentTracker` state
+
+The `AgentTracker` at `relay/src/events/agent-tracker.ts` holds in-memory `AgentState` objects:
+
+```typescript
+interface AgentState {
+  agentId: string;
+  parentId?: string;
+  role: string;
+  task: string;
+  status: 'spawned' | 'working' | 'idle' | 'complete' | 'dismissed';
+  spawnedAt: string;
+  updatedAt: string;
+}
+```
+
+This is a **global singleton** (line 89: `export const agentTracker = new AgentTracker()`). It does not track which session an agent belongs to. Agent dismiss at line 82 deletes the entry from the map.
+
+### Proposed Persistence Format
+
+#### File location
+
+`~/.major-tom/sprite-mappings/{sessionId}.json`
+
+Separate directory from session transcripts to keep concerns isolated and simplify cleanup.
+
+#### File structure
+
+```json
+{
+  "version": 1,
+  "sessionId": "uuid-here",
+  "updatedAt": "2026-04-16T12:00:00.000Z",
+  "roleBindings": {
+    "researcher": "spaceSuit_blue",
+    "frontend": "spaceSuit_pink",
+    "backend": "spaceSuit_green"
+  },
+  "mappings": [
+    {
+      "spriteHandle": "uuid-sprite-1",
+      "agentId": "uuid-agent-1",
+      "role": "researcher",
+      "characterType": "spaceSuit_blue",
+      "deskIndex": 0,
+      "linkedAt": "2026-04-16T12:00:00.000Z",
+      "status": "active"
+    },
+    {
+      "spriteHandle": "uuid-sprite-2",
+      "agentId": "uuid-agent-2",
+      "role": "frontend",
+      "characterType": "spaceSuit_pink",
+      "deskIndex": 1,
+      "linkedAt": "2026-04-16T12:01:00.000Z",
+      "status": "active"
+    }
+  ],
+  "nextDeskIndex": 2
+}
+```
+
+#### `SpriteMappingPersistence` class
+
+Follows the same pattern as `SessionPersistence`:
+
+```typescript
+class SpriteMappingPersistence {
+  private debounceTimers = new Map<string, ReturnType<typeof setTimeout>>();
+  private readonly dir = join(homedir(), '.major-tom', 'sprite-mappings');
+
+  save(sessionId: string, data: SpriteMappingFile): void;       // debounced 2s
+  saveImmediate(sessionId: string, data: SpriteMappingFile): Promise<void>;
+  load(sessionId: string): Promise<SpriteMappingFile | null>;
+  delete(sessionId: string): Promise<void>;
+  deleteAll(): Promise<void>;                                    // graceful shutdown
+  listStale(): Promise<string[]>;                                // cold boot cleanup
+  dispose(): void;
+}
+```
+
+### Cleanup Lifecycle Integration
+
+| Spec Event | Implementation |
+|-----------|----------------|
+| Relay graceful shutdown | `SpriteMappingPersistence.deleteAll()` in the app's `onClose` handler at `app.ts` |
+| Terminal session ended | `SpriteMappingPersistence.delete(sessionId)` when `SessionManager.destroy()` is called |
+| Background/disconnect | Keep file (30-min grace already exists in PTY adapter) |
+| Grace period expires | PTY adapter's grace timer fires -> kills session -> triggers delete |
+| Cold boot after crash | On startup: `listStale()` cross-references with live sessions, deletes orphans |
+
+#### Where to hook into existing lifecycle
+
+1. **Session destroy** (`session-manager.ts:108`): Add a call to delete the sprite mapping file. Or better -- listen to the `agent.dismissed` event on the eventBus (event-bus.ts) to remove individual mappings, and session destroy to delete the file.
+
+2. **App shutdown** (`app.ts`): The app already has a shutdown handler. Add `spriteMappingPersistence.deleteAll()` alongside the existing `sessionPersistence` flush.
+
+3. **Cold boot** (`app.ts` startup): After `sessionManager.restoreFromDisk()`, call `spriteMappingPersistence.listStale()` and cross-reference against live session IDs.
+
+4. **Agent lifecycle events** (`ws.ts:1689`): The `fleetManager.on('agent-lifecycle')` handler already processes spawn/dismiss. Add mapping persistence updates here:
+   - `spawn` -> create mapping entry, save
+   - `dismissed` -> remove mapping entry, save
+   
+### Feasibility Assessment: GREEN
+
+The persistence infrastructure is well-established. The sprite mapping files are small (< 1KB even with 6 agents). The cleanup lifecycle hooks are clearly identified and already exist in the codebase. This is a straightforward extension of the existing pattern.
+
+### Recommended Approach
+
+1. Create `SpriteMappingPersistence` class mirroring `SessionPersistence`
+2. Store files at `~/.major-tom/sprite-mappings/{sessionId}.json`
+3. Use debounced writes (2s) like session persistence
+4. Hook cleanup into: session destroy, app shutdown, agent dismiss, cold boot
+5. The `ws.ts` agent-lifecycle handler is the single point where mapping changes are triggered
+6. On iOS reconnect, relay sends `sprite.state` message reconstructed from disk file
+
+### Open Questions
+
+- **In-memory vs. disk**: During normal operation, the mapping is held in memory (either in the fleet worker or the adapter). Disk is only for crash recovery and reconnect. Should we also keep an in-memory mirror in the parent process (for fast `sprite.state` responses), or always delegate to the worker?
+  - Recommendation: Keep in-memory in the worker (or adapter), persist to disk on change. Parent process delegates `sprite.state` requests to the worker via IPC.
+- **Client-authoritative fallback**: The spec says iOS can re-send its mappings if relay loses state. This requires a `sprite.state` message from client -> server (not currently proposed). Add a `sprite.syncFromClient` message type?
+- **Concurrent writes**: Two rapid agent spawns could race on debounced writes. The debounce timer resets, so the second write includes both changes. This is correct behavior.
+
+---
+
+## Summary
+
+| Gate | Assessment | Key Finding | Blocking? |
+|------|-----------|-------------|-----------|
+| 1. Turn-boundary injection | YELLOW | SDK has no direct subagent session handle. Must inject via orchestrator's `send()` or `PostToolUse` `additionalContext`. Both are viable workarounds. | No -- workarounds exist |
+| 2. Protocol messages | GREEN | Clean `sprite.*` namespace, follows existing conventions exactly. 5 new message types. | No |
+| 3. Message queue design | YELLOW | Queue is simple but response correlation is imprecise. State machine approach works if constraint framing is effective. | No -- design is solid, needs spike for response extraction |
+| 4. Mapping persistence | GREEN | Mirrors existing `SessionPersistence` pattern. All cleanup hooks are identified. | No |
+
+### Recommended Technical Spike
+
+Before Wave 4 implementation, build a minimal spike to validate:
+
+1. **PostToolUse hook fires for subagent tool calls** (not just orchestrator). If it does, `additionalContext` injection is the cleanest path.
+2. **Response extraction after `send()` injection** -- send a constrained /btw message via `send()` and verify the response can be reliably captured from the stream.
+3. **Constraint framing effectiveness** -- does Claude reliably give a 1-2 sentence status response without changing its task?
+
+These three tests determine whether the /btw mechanism works as designed or needs a different approach.
+
+### Architecture Decision: Where the Queue Lives
+
+The `BtwQueue` should live in the same process as the `SDKSession`:
+- **Single-worker mode**: In the `ClaudeCliAdapter`, alongside the `SdkSessionEntry`
+- **Fleet mode**: In the worker process, alongside the `WorkerSession`
+
+The parent process (ws.ts) routes `sprite.message` to the correct worker via IPC, just like it routes `agent.message` today.


### PR DESCRIPTION
## Summary
- All 7 research gates answered (4 GREEN, 3 YELLOW — all viable)
- Two research docs added: relay/SDK findings + iOS/SwiftUI findings
- Spec updated with findings, role→CharacterType mapping locked, wave plan confirmed
- Key finding: `/btw` injection goes through orchestrator session (no direct subagent handle), needs Wave 4 spike

## Research docs
- `docs/SPRITE-WIRING-RESEARCH-RELAY.md` — turn-boundary injection, protocol schemas, queue design, persistence
- `docs/SPRITE-WIRING-RESEARCH-IOS.md` — Office Manager layout, local notifications, role mapping

## Test plan
- [ ] Spec reads coherently with research findings integrated
- [ ] No implementation changes — docs only

🤖 Generated with [Claude Code](https://claude.com/claude-code)