### PR TITLE
feat(relay): sprite-agent wiring — Wave 2 data model + protocol

### DIFF
--- a/relay/src/adapters/adapter.interface.ts
+++ b/relay/src/adapters/adapter.interface.ts
@@ -23,6 +23,7 @@ export interface ToolResult {
 }
 
 export interface AgentEvent {
+  sessionId: string;
   agentId: string;
   event: 'spawn' | 'working' | 'idle' | 'complete' | 'dismissed';
   task?: string;

--- a/relay/src/adapters/claude-cli.adapter.ts
+++ b/relay/src/adapters/claude-cli.adapter.ts
@@ -244,6 +244,7 @@ export class ClaudeCliAdapter implements IAdapter {
                 const role = taskDesc ? classifyAgentRole(taskDesc) : agentType;
 
                 emitter.emit('agent-lifecycle', {
+                  sessionId: session.id,
                   agentId,
                   event: 'spawn',
                   task: label,
@@ -267,6 +268,7 @@ export class ClaudeCliAdapter implements IAdapter {
                 // agent-lifecycle switch) ignores `event.result` —
                 // only `complete` forwards it. Don't pass dead data.
                 emitter.emit('agent-lifecycle', {
+                  sessionId: session.id,
                   agentId,
                   event: 'dismissed',
                 } satisfies AgentEvent);

--- a/relay/src/app.ts
+++ b/relay/src/app.ts
@@ -52,6 +52,8 @@ import { ActivityFeed } from './users/activity-feed.js';
 import { SandboxGuard } from './security/sandbox-guard.js';
 import { AuditLog } from './security/audit-log.js';
 import { RateLimiter } from './security/rate-limiter.js';
+import { SpriteMappingPersistence } from './sprites/sprite-mapping-persistence.js';
+import { SpriteMapper } from './sprites/sprite-mapper.js';
 import { getSessionSecret } from './auth/session.js';
 import { readFile } from 'node:fs/promises';
 import { join } from 'node:path';
@@ -90,6 +92,8 @@ export async function buildApp(config: AppConfig) {
   const healthMonitor = new HealthMonitor(fleetManager, sessionManager);
   const analyticsCollector = new AnalyticsCollector();
   const achievementService = new AchievementService();
+  const spriteMappingPersistence = new SpriteMappingPersistence();
+  const spriteMapper = new SpriteMapper();
 
   // Multi-user services — only created when multi-user mode is enabled
   const userRegistry = config.multiUserEnabled ? new UserRegistry() : undefined;
@@ -370,6 +374,8 @@ export async function buildApp(config: AppConfig) {
     claudeWorkDir: config.claudeWorkDir,
     multiUserEnabled: config.multiUserEnabled,
     shellApprovalQueue,
+    spriteMappingPersistence,
+    spriteMapper,
   }));
 
   // Phase 13 Wave 2 — REST endpoints for approvals (cold-start fetch
@@ -409,6 +415,10 @@ export async function buildApp(config: AppConfig) {
       };
     });
     sessionPersistence.dispose();
+    // Sprite mapping cleanup: delete all mapping files on graceful shutdown
+    // (all sessions are gone, mappings are meaningless without live agents)
+    await spriteMappingPersistence.deleteAll();
+    spriteMappingPersistence.dispose();
     if (annotationStore) {
       await annotationStore.flush();
       annotationStore.dispose();

--- a/relay/src/events/agent-tracker.ts
+++ b/relay/src/events/agent-tracker.ts
@@ -4,6 +4,7 @@ import { eventBus } from './event-bus.js';
 // ── Agent state tracking for office visualization ───────────
 
 export interface AgentState {
+  sessionId: string;
   agentId: string;
   parentId?: string;
   role: string;
@@ -24,9 +25,15 @@ class AgentTracker {
     return this.agents.get(agentId);
   }
 
-  spawn(agentId: string, role: string, task: string, parentId?: string): void {
+  /** Get all agents for a specific session */
+  getBySession(sessionId: string): AgentState[] {
+    return [...this.agents.values()].filter(a => a.sessionId === sessionId);
+  }
+
+  spawn(agentId: string, role: string, task: string, sessionId: string, parentId?: string): void {
     const now = new Date().toISOString();
     const state: AgentState = {
+      sessionId,
       agentId,
       parentId,
       role,
@@ -36,10 +43,11 @@ class AgentTracker {
       updatedAt: now,
     };
     this.agents.set(agentId, state);
-    logger.info({ agentId, role, task }, 'Agent spawned');
+    logger.info({ agentId, role, task, sessionId }, 'Agent spawned');
 
     eventBus.emit('agent.spawn', {
       type: 'agent.spawn',
+      sessionId,
       agentId,
       parentId,
       task,
@@ -54,7 +62,7 @@ class AgentTracker {
     agent.task = task;
     agent.updatedAt = new Date().toISOString();
 
-    eventBus.emit('agent.working', { type: 'agent.working', agentId, task });
+    eventBus.emit('agent.working', { type: 'agent.working', sessionId: agent.sessionId, agentId, task });
   }
 
   idle(agentId: string): void {
@@ -63,7 +71,7 @@ class AgentTracker {
     agent.status = 'idle';
     agent.updatedAt = new Date().toISOString();
 
-    eventBus.emit('agent.idle', { type: 'agent.idle', agentId });
+    eventBus.emit('agent.idle', { type: 'agent.idle', sessionId: agent.sessionId, agentId });
   }
 
   complete(agentId: string, result: string): void {
@@ -72,7 +80,7 @@ class AgentTracker {
     agent.status = 'complete';
     agent.updatedAt = new Date().toISOString();
 
-    eventBus.emit('agent.complete', { type: 'agent.complete', agentId, result });
+    eventBus.emit('agent.complete', { type: 'agent.complete', sessionId: agent.sessionId, agentId, result });
   }
 
   dismiss(agentId: string): void {
@@ -82,7 +90,7 @@ class AgentTracker {
     agent.updatedAt = new Date().toISOString();
     this.agents.delete(agentId);
 
-    eventBus.emit('agent.dismissed', { type: 'agent.dismissed', agentId });
+    eventBus.emit('agent.dismissed', { type: 'agent.dismissed', sessionId: agent.sessionId, agentId });
   }
 }
 

--- a/relay/src/fleet/fleet-manager.ts
+++ b/relay/src/fleet/fleet-manager.ts
@@ -437,6 +437,7 @@ export class FleetManager {
 
       case 'ipc:agent.lifecycle':
         this.emitter.emit('agent-lifecycle', {
+          sessionId: msg.sessionId,
           agentId: msg.agentId,
           event: msg.event,
           task: msg.task,

--- a/relay/src/fleet/ipc-messages.ts
+++ b/relay/src/fleet/ipc-messages.ts
@@ -86,8 +86,7 @@ export type ParentToChildMessage =
   | IpcAgentMessage
   | IpcContextAdd
   | IpcContextRemove
-  | IpcPermissionMode
-  | IpcSpriteMessage;
+  | IpcPermissionMode;
 
 // ── Child → Parent Messages ────────────────────────────────
 
@@ -226,6 +225,5 @@ export function isParentToChildMessage(msg: unknown): msg is ParentToChildMessag
     'ipc:context.add',
     'ipc:context.remove',
     'ipc:permission.mode',
-    'ipc:sprite.message',
   ].includes(typed.type);
 }

--- a/relay/src/fleet/ipc-messages.ts
+++ b/relay/src/fleet/ipc-messages.ts
@@ -68,6 +68,15 @@ export interface IpcPermissionMode {
   godSubMode?: GodSubMode;
 }
 
+export interface IpcSpriteMessage {
+  type: 'ipc:sprite.message';
+  sessionId: string;
+  spriteHandle: string;
+  agentId: string;
+  text: string;
+  messageId: string;
+}
+
 export type ParentToChildMessage =
   | IpcSessionStart
   | IpcSessionDestroy
@@ -77,7 +86,8 @@ export type ParentToChildMessage =
   | IpcAgentMessage
   | IpcContextAdd
   | IpcContextRemove
-  | IpcPermissionMode;
+  | IpcPermissionMode
+  | IpcSpriteMessage;
 
 // ── Child → Parent Messages ────────────────────────────────
 
@@ -133,6 +143,7 @@ export interface IpcToolComplete {
 
 export interface IpcAgentLifecycle {
   type: 'ipc:agent.lifecycle';
+  sessionId: string;
   agentId: string;
   event: 'spawn' | 'working' | 'idle' | 'complete' | 'dismissed';
   task?: string;
@@ -215,5 +226,6 @@ export function isParentToChildMessage(msg: unknown): msg is ParentToChildMessag
     'ipc:context.add',
     'ipc:context.remove',
     'ipc:permission.mode',
+    'ipc:sprite.message',
   ].includes(typed.type);
 }

--- a/relay/src/fleet/worker.ts
+++ b/relay/src/fleet/worker.ts
@@ -237,6 +237,7 @@ async function startSession(sessionId: string, _workingDir: string): Promise<voi
 
                 sendToParent({
                   type: 'ipc:agent.lifecycle',
+                  sessionId,
                   agentId,
                   event: 'spawn',
                   task: label,
@@ -261,6 +262,7 @@ async function startSession(sessionId: string, _workingDir: string): Promise<voi
                 // only `complete` forwards it. Don't pass dead data.
                 sendToParent({
                   type: 'ipc:agent.lifecycle',
+                  sessionId,
                   agentId,
                   event: 'dismissed',
                 });

--- a/relay/src/hooks/hook-server.ts
+++ b/relay/src/hooks/hook-server.ts
@@ -282,8 +282,15 @@ export function createHookServer(
           'SubagentStart hook received',
         );
 
+        // session_id from the Claude hook payload — best-effort mapping to Major Tom sessionId.
+        // In fleet mode the worker knows the real sessionId; in PTY mode this is the Claude SDK
+        // session_id which the downstream handler uses for routing.
+        const hookSessionId =
+          typeof payload['session_id'] === 'string' ? (payload['session_id'] as string) : 'unknown';
+
         if (reportAgentLifecycle) {
           reportAgentLifecycle({
+            sessionId: hookSessionId,
             agentId,
             event: 'spawn',
             task: agentType,
@@ -334,8 +341,12 @@ export function createHookServer(
           'SubagentStop hook received',
         );
 
+        const stopSessionId =
+          typeof payload['session_id'] === 'string' ? (payload['session_id'] as string) : 'unknown';
+
         if (reportAgentLifecycle) {
           reportAgentLifecycle({
+            sessionId: stopSessionId,
             agentId,
             event: 'dismissed',
           });

--- a/relay/src/protocol/messages.ts
+++ b/relay/src/protocol/messages.ts
@@ -466,6 +466,16 @@ export interface SandboxClearUserPathsMessage {
   userId: string;
 }
 
+// ── Sprite messaging (client → server) ───────────────────────
+
+export interface SpriteMessageMessage {
+  type: 'sprite.message';
+  sessionId: string;
+  spriteHandle: string;
+  agentId: string;
+  text: string;
+  messageId: string;
+}
 
 export type ClientMessage =
   | PromptMessage
@@ -516,7 +526,8 @@ export type ClientMessage =
   | GitDiffMessage
   | GitLogMessage
   | GitBranchesMessage
-  | GitShowMessage;
+  | GitShowMessage
+  | SpriteMessageMessage;
 
 // ── Server → Client (Relay → iOS) ──────────────────────────
 
@@ -564,6 +575,7 @@ export interface ToolCompleteMessage {
 
 export interface AgentSpawnMessage {
   type: 'agent.spawn';
+  sessionId: string;
   agentId: string;
   parentId?: string;
   task: string;
@@ -572,23 +584,27 @@ export interface AgentSpawnMessage {
 
 export interface AgentWorkingMessage {
   type: 'agent.working';
+  sessionId: string;
   agentId: string;
   task: string;
 }
 
 export interface AgentIdleMessage {
   type: 'agent.idle';
+  sessionId: string;
   agentId: string;
 }
 
 export interface AgentCompleteMessage {
   type: 'agent.complete';
+  sessionId: string;
   agentId: string;
   result: string;
 }
 
 export interface AgentDismissedMessage {
   type: 'agent.dismissed';
+  sessionId: string;
   agentId: string;
 }
 
@@ -1092,6 +1108,53 @@ export interface GitErrorResponseMessage {
   message: string;
 }
 
+// ── Sprite wiring messages (server → client) ─────────────────
+
+export interface SpriteMappingEntry {
+  spriteHandle: string;
+  agentId: string;
+  role: string;
+  characterType: string;
+  deskIndex: number;
+  linkedAt: string;
+}
+
+export interface SpriteLinkMessage {
+  type: 'sprite.link';
+  sessionId: string;
+  spriteHandle: string;
+  agentId: string;
+  role: string;
+  characterType: string;
+  deskIndex?: number;
+}
+
+export interface SpriteUnlinkMessage {
+  type: 'sprite.unlink';
+  sessionId: string;
+  spriteHandle: string;
+  agentId: string;
+  reason: 'complete' | 'dismissed' | 'error' | 'session_ended';
+}
+
+export interface SpriteResponseMessage {
+  type: 'sprite.response';
+  sessionId: string;
+  spriteHandle: string;
+  agentId: string;
+  messageId: string;
+  text: string;
+  status: 'delivered' | 'queued' | 'dropped';
+  dropReason?: string;
+}
+
+export interface SpriteStateMessage {
+  type: 'sprite.state';
+  sessionId: string;
+  mappings: SpriteMappingEntry[];
+  roleBindings: Record<string, string>;
+}
+
 /** Base server message union (without envelope fields). */
 type ServerMessageBase =
   | OutputMessage
@@ -1157,7 +1220,11 @@ type ServerMessageBase =
   | GitLogResponseMessage
   | GitBranchesResponseMessage
   | GitShowResponseMessage
-  | GitErrorResponseMessage;
+  | GitErrorResponseMessage
+  | SpriteLinkMessage
+  | SpriteUnlinkMessage
+  | SpriteResponseMessage
+  | SpriteStateMessage;
 
 /**
  * Every outbound server message may carry an optional `seq` —

--- a/relay/src/protocol/messages.ts
+++ b/relay/src/protocol/messages.ts
@@ -1115,7 +1115,7 @@ export interface SpriteMappingEntry {
   agentId: string;
   role: string;
   characterType: string;
-  deskIndex: number;
+  deskIndex?: number;
   linkedAt: string;
 }
 

--- a/relay/src/routes/ws.ts
+++ b/relay/src/routes/ws.ts
@@ -36,6 +36,11 @@ import type { RateLimiter } from '../security/rate-limiter.js';
 import type { UserRole } from '../users/types.js';
 import { logger } from '../utils/logger.js';
 import type { ApprovalQueue } from '../hooks/approval-queue.js';
+import { SpriteMapper } from '../sprites/sprite-mapper.js';
+import {
+  SpriteMappingPersistence,
+  type PersistedSpriteMappingFile,
+} from '../sprites/sprite-mapping-persistence.js';
 
 interface WsDeps {
   sessionManager: SessionManager;
@@ -60,6 +65,10 @@ interface WsDeps {
    * The WS approval handler tries this queue first before falling back to fleet.
    */
   shellApprovalQueue: ApprovalQueue;
+  /** Sprite-agent wiring — persistence layer for sprite↔agent mappings */
+  spriteMappingPersistence: SpriteMappingPersistence;
+  /** Sprite-agent wiring — role classifier + mapping manager */
+  spriteMapper: SpriteMapper;
 }
 
 /**
@@ -85,12 +94,30 @@ export function createWsRoute(deps: WsDeps): FastifyPluginAsync {
     claudeWorkDir,
     multiUserEnabled,
     shellApprovalQueue,
+    spriteMappingPersistence,
+    spriteMapper,
   } = deps;
 
   const notificationDigest = new NotificationDigest(pushManager, notificationConfigManager);
   const eventBuffer = new EventBufferManager();
   const clients = new Set<WebSocket>();
   const presenceManager = new PresenceManager();
+
+  // ── Sprite mapping in-memory state (per session) ──────────
+  // In-memory cache of persisted sprite mapping files. Authoritative source
+  // is disk (via spriteMappingPersistence), but we keep a hot copy here for
+  // fast reads during agent spawn/dismiss and client reconnect.
+  const spriteMappings = new Map<string, PersistedSpriteMappingFile>();
+
+  /** Get or create the in-memory sprite mapping state for a session */
+  function getOrCreateSpriteState(sessionId: string): PersistedSpriteMappingFile {
+    let state = spriteMappings.get(sessionId);
+    if (!state) {
+      state = spriteMapper.createEmptyFile(sessionId);
+      spriteMappings.set(sessionId, state);
+    }
+    return state;
+  }
 
   // ── Per-client metadata for admin status endpoint ──────────
   interface ClientMeta { ip: string; userAgent: string; connectedAt: string }
@@ -250,6 +277,9 @@ export function createWsRoute(deps: WsDeps): FastifyPluginAsync {
       const data = buildPersistedSession(sessionId);
       if (data) sessionPersistence.save(data);
       sessionManager.destroy(sessionId);
+      // Clean up sprite mappings for the timed-out session
+      spriteMappings.delete(sessionId);
+      void spriteMappingPersistence.delete(sessionId);
     }, SESSION_TIMEOUT_MS);
 
     sessionTimeouts.set(sessionId, timeout);
@@ -592,6 +622,9 @@ export function createWsRoute(deps: WsDeps): FastifyPluginAsync {
         // so removing first would recreate a fresh (leaked) buffer for this session.
         broadcastToSession(message.sessionId, { type: 'session.ended', sessionId: message.sessionId });
         eventBuffer.removeSession(message.sessionId);
+        // ── Sprite cleanup: delete mapping file when session ends ──
+        spriteMappings.delete(message.sessionId);
+        void spriteMappingPersistence.delete(message.sessionId);
         break;
       }
 
@@ -678,6 +711,34 @@ export function createWsRoute(deps: WsDeps): FastifyPluginAsync {
           delaySeconds: modeState.delaySeconds,
           godSubMode: modeState.godSubMode,
         });
+
+        // ── Sprite state on reconnect ──────────────────────
+        // Load from in-memory cache or disk and send current sprite mappings
+        // so the iOS client can rebuild its Office scene.
+        let resumeSpriteState = spriteMappings.get(resumeSessionId);
+        if (!resumeSpriteState) {
+          // Try loading from disk (relay may have restarted)
+          const persisted = await spriteMappingPersistence.load(resumeSessionId);
+          if (persisted) {
+            spriteMappings.set(resumeSessionId, persisted);
+            resumeSpriteState = persisted;
+          }
+        }
+        if (resumeSpriteState && resumeSpriteState.mappings.length > 0) {
+          sendToClient(ws, {
+            type: 'sprite.state',
+            sessionId: resumeSessionId,
+            mappings: resumeSpriteState.mappings.map(m => ({
+              spriteHandle: m.spriteHandle,
+              agentId: m.agentId,
+              role: m.role,
+              characterType: m.characterType,
+              deskIndex: m.deskIndex,
+              linkedAt: m.linkedAt,
+            })),
+            roleBindings: resumeSpriteState.roleBindings,
+          });
+        }
 
         const currentSeq = eventBuffer.getCurrentSeq(resumeSessionId);
         sendToClient(ws, {
@@ -817,6 +878,45 @@ export function createWsRoute(deps: WsDeps): FastifyPluginAsync {
 
       case 'agent.message': {
         await fleetManager.sendAgentMessage(message.sessionId, message.agentId, message.text);
+        break;
+      }
+
+      // ── Sprite messaging (Wave 4 will implement actual queue/injection) ──
+      case 'sprite.message': {
+        // Validate the sprite mapping exists for this agent
+        const spriteState = spriteMappings.get(message.sessionId);
+        const mapping = spriteState?.mappings.find(m =>
+          m.agentId === message.agentId && m.spriteHandle === message.spriteHandle
+        );
+        if (!mapping) {
+          // Agent may have completed before message arrived (scenario #4 from spec)
+          sendToClient(ws, {
+            type: 'sprite.response',
+            sessionId: message.sessionId,
+            spriteHandle: message.spriteHandle,
+            agentId: message.agentId,
+            messageId: message.messageId,
+            text: '',
+            status: 'dropped',
+            dropReason: 'Agent not found or already completed',
+          });
+          break;
+        }
+        // Wave 2 acknowledge: confirm receipt. Wave 4 will implement
+        // turn-boundary queueing and actual injection.
+        sendToClient(ws, {
+          type: 'sprite.response',
+          sessionId: message.sessionId,
+          spriteHandle: message.spriteHandle,
+          agentId: message.agentId,
+          messageId: message.messageId,
+          text: '',
+          status: 'queued',
+        });
+        logger.info(
+          { sessionId: message.sessionId, agentId: message.agentId, spriteHandle: message.spriteHandle },
+          'Sprite message received — queued for Wave 4 delivery',
+        );
         break;
       }
 
@@ -1687,35 +1787,104 @@ export function createWsRoute(deps: WsDeps): FastifyPluginAsync {
     });
 
     fleetManager.on('agent-lifecycle', (event) => {
+      const sid = event.sessionId;
       switch (event.event) {
-        case 'spawn':
-          agentTracker.spawn(event.agentId, event.role ?? 'subagent', event.task ?? '', event.parentId);
+        case 'spawn': {
+          agentTracker.spawn(event.agentId, event.role ?? 'subagent', event.task ?? '', sid, event.parentId);
           // Track achievement: agent spawned
           achievementService.checkEvent('agent.spawn');
           broadcastToAll({
             type: 'agent.spawn',
+            sessionId: sid,
             agentId: event.agentId,
             parentId: event.parentId,
             task: event.task ?? '',
             role: event.role ?? 'subagent',
           });
+
+          // ── Sprite wiring: create mapping + emit sprite.link ──
+          const spriteState = getOrCreateSpriteState(sid);
+          const { mapping, role: classifiedRole, isNewBinding } = spriteMapper.createMapping(
+            event.agentId,
+            event.task ?? '',
+            spriteState.roleBindings,
+            spriteState.mappings,
+          );
+          // Lock role binding if this is a new one
+          if (isNewBinding) {
+            spriteState.roleBindings[classifiedRole] = mapping.characterType;
+          }
+          spriteState.mappings.push(mapping);
+          spriteState.updatedAt = new Date().toISOString();
+          spriteMappingPersistence.save(spriteState);
+
+          broadcastToSession(sid, {
+            type: 'sprite.link',
+            sessionId: sid,
+            spriteHandle: mapping.spriteHandle,
+            agentId: event.agentId,
+            role: mapping.role,
+            characterType: mapping.characterType,
+            deskIndex: mapping.deskIndex >= 0 ? mapping.deskIndex : undefined,
+          });
           break;
+        }
         case 'working':
           agentTracker.working(event.agentId, event.task ?? '');
-          broadcastToAll({ type: 'agent.working', agentId: event.agentId, task: event.task ?? '' });
+          broadcastToAll({ type: 'agent.working', sessionId: sid, agentId: event.agentId, task: event.task ?? '' });
           break;
         case 'idle':
           agentTracker.idle(event.agentId);
-          broadcastToAll({ type: 'agent.idle', agentId: event.agentId });
+          broadcastToAll({ type: 'agent.idle', sessionId: sid, agentId: event.agentId });
           break;
-        case 'complete':
+        case 'complete': {
           agentTracker.complete(event.agentId, event.result ?? '');
-          broadcastToAll({ type: 'agent.complete', agentId: event.agentId, result: event.result ?? '' });
+          broadcastToAll({ type: 'agent.complete', sessionId: sid, agentId: event.agentId, result: event.result ?? '' });
+
+          // ── Sprite wiring: remove mapping + emit sprite.unlink ���─
+          const completeState = spriteMappings.get(sid);
+          if (completeState) {
+            const idx = completeState.mappings.findIndex(m => m.agentId === event.agentId);
+            if (idx >= 0) {
+              const removed = completeState.mappings[idx];
+              completeState.mappings.splice(idx, 1);
+              completeState.updatedAt = new Date().toISOString();
+              spriteMappingPersistence.save(completeState);
+              broadcastToSession(sid, {
+                type: 'sprite.unlink',
+                sessionId: sid,
+                spriteHandle: removed.spriteHandle,
+                agentId: event.agentId,
+                reason: 'complete',
+              });
+            }
+          }
           break;
-        case 'dismissed':
+        }
+        case 'dismissed': {
           agentTracker.dismiss(event.agentId);
-          broadcastToAll({ type: 'agent.dismissed', agentId: event.agentId });
+          broadcastToAll({ type: 'agent.dismissed', sessionId: sid, agentId: event.agentId });
+
+          // ── Sprite wiring: remove mapping + emit sprite.unlink ──
+          const dismissState = spriteMappings.get(sid);
+          if (dismissState) {
+            const idx = dismissState.mappings.findIndex(m => m.agentId === event.agentId);
+            if (idx >= 0) {
+              const removed = dismissState.mappings[idx];
+              dismissState.mappings.splice(idx, 1);
+              dismissState.updatedAt = new Date().toISOString();
+              spriteMappingPersistence.save(dismissState);
+              broadcastToSession(sid, {
+                type: 'sprite.unlink',
+                sessionId: sid,
+                spriteHandle: removed.spriteHandle,
+                agentId: event.agentId,
+                reason: 'dismissed',
+              });
+            }
+          }
           break;
+        }
       }
     });
 
@@ -1766,6 +1935,23 @@ export function createWsRoute(deps: WsDeps): FastifyPluginAsync {
     });
 
     eventBus.on('server.message', serverMessageHandler);
+
+    // ── Cold boot cleanup: remove stale sprite mapping files ──
+    // On startup, scan for mapping files that don't correspond to a live
+    // session and delete them (relay crashed and left orphans).
+    spriteMappingPersistence.listStale((sid) => fleetManager.hasSession(sid))
+      .then(async (stale) => {
+        for (const sid of stale) {
+          await spriteMappingPersistence.delete(sid);
+          logger.info({ sessionId: sid }, 'Deleted stale sprite mapping file (cold boot cleanup)');
+        }
+        if (stale.length > 0) {
+          logger.info({ count: stale.length }, 'Cold boot sprite mapping cleanup complete');
+        }
+      })
+      .catch((err: unknown) => {
+        logger.warn({ err }, 'Failed to clean stale sprite mapping files on boot');
+      });
   }
 
   // ── Plugin Registration ──────────────────────────────────

--- a/relay/src/routes/ws.ts
+++ b/relay/src/routes/ws.ts
@@ -733,7 +733,7 @@ export function createWsRoute(deps: WsDeps): FastifyPluginAsync {
               agentId: m.agentId,
               role: m.role,
               characterType: m.characterType,
-              deskIndex: m.deskIndex,
+              ...(m.deskIndex !== undefined && m.deskIndex >= 0 ? { deskIndex: m.deskIndex } : {}),
               linkedAt: m.linkedAt,
             })),
             roleBindings: resumeSpriteState.roleBindings,
@@ -1845,8 +1845,8 @@ export function createWsRoute(deps: WsDeps): FastifyPluginAsync {
           const completeState = spriteMappings.get(sid);
           if (completeState) {
             const idx = completeState.mappings.findIndex(m => m.agentId === event.agentId);
-            if (idx >= 0) {
-              const removed = completeState.mappings[idx];
+            const removed = idx >= 0 ? completeState.mappings[idx] : undefined;
+            if (removed) {
               completeState.mappings.splice(idx, 1);
               completeState.updatedAt = new Date().toISOString();
               spriteMappingPersistence.save(completeState);
@@ -1869,8 +1869,8 @@ export function createWsRoute(deps: WsDeps): FastifyPluginAsync {
           const dismissState = spriteMappings.get(sid);
           if (dismissState) {
             const idx = dismissState.mappings.findIndex(m => m.agentId === event.agentId);
-            if (idx >= 0) {
-              const removed = dismissState.mappings[idx];
+            const removed = idx >= 0 ? dismissState.mappings[idx] : undefined;
+            if (removed) {
               dismissState.mappings.splice(idx, 1);
               dismissState.updatedAt = new Date().toISOString();
               spriteMappingPersistence.save(dismissState);
@@ -1939,7 +1939,7 @@ export function createWsRoute(deps: WsDeps): FastifyPluginAsync {
     // ── Cold boot cleanup: remove stale sprite mapping files ──
     // On startup, scan for mapping files that don't correspond to a live
     // session and delete them (relay crashed and left orphans).
-    spriteMappingPersistence.listStale((sid) => fleetManager.hasSession(sid))
+    spriteMappingPersistence.listStale((sid) => fleetManager.hasSession(sid) || sessionManager.isPersistedOnly(sid))
       .then(async (stale) => {
         for (const sid of stale) {
           await spriteMappingPersistence.delete(sid);

--- a/relay/src/sprites/sprite-mapper.ts
+++ b/relay/src/sprites/sprite-mapper.ts
@@ -1,0 +1,173 @@
+// SpriteMapper — Role classifier + mapping manager for sprite-agent wiring.
+//
+// Responsibilities:
+// 1. Classify agent task descriptions into canonical roles (8 roles)
+// 2. Resolve roles to CharacterTypes with per-session role-stable binding
+// 3. Allocate desk positions for working sprites
+//
+// The role classification regex table mirrors the one in claude-cli.adapter.ts
+// and fleet/worker.ts but is now the canonical source. Those will be updated
+// to delegate here in a future cleanup.
+
+import { randomUUID } from 'node:crypto';
+import { logger } from '../utils/logger.js';
+import type { PersistedSpriteMapping, PersistedSpriteMappingFile } from './sprite-mapping-persistence.js';
+
+// ── Canonical roles ────────────────────────────────────────
+
+export const CANONICAL_ROLES = [
+  'researcher',
+  'architect',
+  'qa',
+  'devops',
+  'frontend',
+  'backend',
+  'lead',
+  'engineer',
+] as const;
+
+export type CanonicalRole = typeof CANONICAL_ROLES[number];
+
+// ── Role → CharacterType mapping (locked in spec) ──────────
+// From the spec: "locked role→CharacterType table"
+// Each role maps to a specific human CharacterType sprite.
+// Dogs are NEVER used as agent sprites.
+
+const ROLE_CHARACTER_MAP: Record<CanonicalRole, string> = {
+  researcher: 'scientist',
+  architect: 'architect',
+  qa: 'inspector',
+  devops: 'mechanic',
+  frontend: 'frontendDev',
+  backend: 'backendDev',
+  lead: 'teamLead',
+  engineer: 'engineer',
+};
+
+// ── Role classification regex patterns ─────────────────────
+// Priority order: first match wins. More specific roles before generic.
+
+const ROLE_KEYWORDS: [RegExp, CanonicalRole][] = [
+  [/\b(explore|search|find|grep|look|read|glob|discover)\b/i, 'researcher'],
+  [/\b(plan|design|architect|strategy|blueprint)\b/i, 'architect'],
+  [/\b(test|validate|verify|assert|spec)\b/i, 'qa'],
+  [/\b(build|compile|deploy|docker|ci|infrastructure)\b/i, 'devops'],
+  [/\b(style|css|ui|ux|layout|component|svelte|react|frontend)\b/i, 'frontend'],
+  [/\b(api|server|database|backend|relay|endpoint|route)\b/i, 'backend'],
+  [/\b(review|refactor|fix|lint|cleanup)\b/i, 'lead'],
+  [/\b(write|implement|create|add|update|edit)\b/i, 'engineer'],
+];
+
+// ── Max desks per office ───────────────────────────────────
+
+const MAX_DESKS = 6;
+
+// ── SpriteMapper class ─────────────────────────────────────
+
+export class SpriteMapper {
+  /**
+   * Classify a task description into one of 8 canonical roles.
+   * Uses regex pattern matching against the task text.
+   * Falls back to 'engineer' if no patterns match.
+   */
+  classifyRole(task: string): CanonicalRole {
+    for (const [pattern, role] of ROLE_KEYWORDS) {
+      if (pattern.test(task)) return role;
+    }
+    return 'engineer';
+  }
+
+  /**
+   * Resolve a canonical role to a CharacterType string.
+   * Implements role-stable binding: the first spawn for a role in a session
+   * locks the CharacterType for that role for the session's lifetime.
+   *
+   * @param role - Canonical role (e.g. 'frontend')
+   * @param sessionBindings - Current role→CharacterType bindings for the session
+   * @returns The CharacterType to use and whether this is a new binding
+   */
+  resolveCharacterType(
+    role: string,
+    sessionBindings: Record<string, string>,
+  ): { characterType: string; isNew: boolean } {
+    // If we already have a binding for this role in this session, reuse it
+    const existing = sessionBindings[role];
+    if (existing) {
+      return { characterType: existing, isNew: false };
+    }
+
+    // Look up the canonical mapping. If the role isn't recognized (shouldn't happen
+    // if classifyRole was used, but defensive), fall back to 'engineer' CharacterType.
+    const canonicalRole = CANONICAL_ROLES.includes(role as CanonicalRole)
+      ? (role as CanonicalRole)
+      : 'engineer';
+    const characterType = ROLE_CHARACTER_MAP[canonicalRole];
+
+    return { characterType, isNew: true };
+  }
+
+  /**
+   * Allocate the next available desk index for a new agent sprite.
+   * Desks are numbered 0-5 (MAX_DESKS). Returns -1 if all desks are occupied
+   * (overflow -- sprite placed in open floor space by the iOS client).
+   */
+  allocateDesk(currentMappings: PersistedSpriteMapping[]): number {
+    const occupied = new Set(currentMappings.map(m => m.deskIndex));
+    for (let i = 0; i < MAX_DESKS; i++) {
+      if (!occupied.has(i)) return i;
+    }
+    return -1; // Overflow
+  }
+
+  /**
+   * Create a full sprite mapping for a newly spawned agent.
+   * Orchestrates role classification, character resolution, and desk allocation.
+   *
+   * @param agentId - The agent's unique ID
+   * @param task - The agent's task description
+   * @param sessionBindings - Current role→CharacterType bindings for the session
+   * @param currentMappings - Current active mappings for desk allocation
+   * @returns The new mapping and whether the role binding is new
+   */
+  createMapping(
+    agentId: string,
+    task: string,
+    sessionBindings: Record<string, string>,
+    currentMappings: PersistedSpriteMapping[],
+  ): { mapping: PersistedSpriteMapping; role: CanonicalRole; isNewBinding: boolean } {
+    const role = this.classifyRole(task);
+    const { characterType, isNew } = this.resolveCharacterType(role, sessionBindings);
+    const deskIndex = this.allocateDesk(currentMappings);
+    const spriteHandle = `sprite-${randomUUID().slice(0, 8)}`;
+
+    const mapping: PersistedSpriteMapping = {
+      spriteHandle,
+      agentId,
+      role,
+      characterType,
+      deskIndex,
+      linkedAt: new Date().toISOString(),
+    };
+
+    logger.info(
+      { agentId, role, characterType, deskIndex, spriteHandle, isNewBinding: isNew },
+      'Sprite mapping created',
+    );
+
+    return { mapping, role, isNewBinding: isNew };
+  }
+
+  /**
+   * Build an empty persisted mapping file for a new session.
+   */
+  createEmptyFile(sessionId: string): PersistedSpriteMappingFile {
+    return {
+      version: 1,
+      sessionId,
+      updatedAt: new Date().toISOString(),
+      roleBindings: {},
+      mappings: [],
+      nextDeskIndex: 0,
+    };
+  }
+}

--- a/relay/src/sprites/sprite-mapping-persistence.ts
+++ b/relay/src/sprites/sprite-mapping-persistence.ts
@@ -1,0 +1,173 @@
+// Sprite mapping persistence — saves/loads sprite-agent mappings to ~/.major-tom/sprite-mappings/
+// Mirrors the pattern in sessions/session-persistence.ts
+
+import { readdir, readFile, writeFile, unlink, mkdir } from 'node:fs/promises';
+import { join } from 'node:path';
+import { homedir } from 'node:os';
+import { logger } from '../utils/logger.js';
+
+// ── Persisted data schema ──────────────────────────────────
+
+export interface PersistedSpriteMapping {
+  spriteHandle: string;
+  agentId: string;
+  role: string;
+  characterType: string;
+  deskIndex: number;
+  linkedAt: string;
+}
+
+export interface PersistedSpriteMappingFile {
+  version: 1;
+  sessionId: string;
+  updatedAt: string;
+  roleBindings: Record<string, string>;
+  mappings: PersistedSpriteMapping[];
+  nextDeskIndex: number;
+}
+
+// ── Constants ──────────────────────────────────────────────
+
+const MAPPINGS_DIR = join(homedir(), '.major-tom', 'sprite-mappings');
+const DEBOUNCE_MS = 2000;
+
+// ── SpriteMappingPersistence ───────────────────────────────
+
+export class SpriteMappingPersistence {
+  private debounceTimers = new Map<string, ReturnType<typeof setTimeout>>();
+
+  constructor() {
+    void this.ensureDir();
+  }
+
+  private async ensureDir(): Promise<void> {
+    try {
+      await mkdir(MAPPINGS_DIR, { recursive: true });
+    } catch (err) {
+      logger.error({ err }, 'Failed to create sprite-mappings directory');
+    }
+  }
+
+  private filePath(sessionId: string): string {
+    // Sanitize sessionId to prevent path traversal (same as SessionPersistence)
+    const safe = sessionId.replace(/[^a-zA-Z0-9\-]/g, '');
+    if (!safe || safe !== sessionId) {
+      throw new Error(`Invalid session ID for sprite mapping: ${sessionId}`);
+    }
+    return join(MAPPINGS_DIR, `${safe}.json`);
+  }
+
+  /** Debounced save -- waits 2s after last call before writing */
+  save(data: PersistedSpriteMappingFile): void {
+    const existing = this.debounceTimers.get(data.sessionId);
+    if (existing) clearTimeout(existing);
+
+    const timer = setTimeout(() => {
+      this.debounceTimers.delete(data.sessionId);
+      void this.writeToDisk(data);
+    }, DEBOUNCE_MS);
+
+    this.debounceTimers.set(data.sessionId, timer);
+  }
+
+  /** Immediate save -- bypasses debounce (for shutdown / critical updates) */
+  async saveImmediate(data: PersistedSpriteMappingFile): Promise<void> {
+    const existing = this.debounceTimers.get(data.sessionId);
+    if (existing) {
+      clearTimeout(existing);
+      this.debounceTimers.delete(data.sessionId);
+    }
+    await this.writeToDisk(data);
+  }
+
+  private async writeToDisk(data: PersistedSpriteMappingFile): Promise<void> {
+    try {
+      await this.ensureDir();
+      const json = JSON.stringify(data, null, 2);
+      await writeFile(this.filePath(data.sessionId), json, 'utf-8');
+      logger.debug({ sessionId: data.sessionId, mappingCount: data.mappings.length }, 'Sprite mapping persisted to disk');
+    } catch (err) {
+      logger.error({ err, sessionId: data.sessionId }, 'Failed to persist sprite mapping');
+    }
+  }
+
+  async load(sessionId: string): Promise<PersistedSpriteMappingFile | null> {
+    try {
+      const raw = await readFile(this.filePath(sessionId), 'utf-8');
+      const parsed = JSON.parse(raw) as PersistedSpriteMappingFile;
+      // Basic schema validation
+      if (parsed.version !== 1 || !parsed.sessionId) {
+        logger.warn({ sessionId }, 'Sprite mapping file has invalid schema — ignoring');
+        return null;
+      }
+      return parsed;
+    } catch {
+      return null;
+    }
+  }
+
+  async delete(sessionId: string): Promise<void> {
+    // Cancel any pending debounced write for this session
+    const existing = this.debounceTimers.get(sessionId);
+    if (existing) {
+      clearTimeout(existing);
+      this.debounceTimers.delete(sessionId);
+    }
+    try {
+      await unlink(this.filePath(sessionId));
+      logger.info({ sessionId }, 'Sprite mapping file deleted');
+    } catch {
+      // File may not exist -- that's fine
+    }
+  }
+
+  /** Delete all mapping files (relay graceful shutdown) */
+  async deleteAll(): Promise<void> {
+    try {
+      await this.ensureDir();
+      const files = await readdir(MAPPINGS_DIR);
+      for (const file of files) {
+        if (!file.endsWith('.json')) continue;
+        try {
+          await unlink(join(MAPPINGS_DIR, file));
+        } catch {
+          // Best effort
+        }
+      }
+      logger.info('All sprite mapping files deleted (shutdown)');
+    } catch {
+      // Directory might not exist
+    }
+  }
+
+  /**
+   * List sessionIds that have persisted mapping files.
+   * Used on cold boot to cross-reference against live sessions
+   * and clean up stale files.
+   */
+  async listStale(isLiveSession: (sessionId: string) => boolean): Promise<string[]> {
+    const stale: string[] = [];
+    try {
+      await this.ensureDir();
+      const files = await readdir(MAPPINGS_DIR);
+      for (const file of files) {
+        if (!file.endsWith('.json')) continue;
+        const sessionId = file.replace('.json', '');
+        if (!isLiveSession(sessionId)) {
+          stale.push(sessionId);
+        }
+      }
+    } catch {
+      // Directory might not exist
+    }
+    return stale;
+  }
+
+  /** Cancel all pending debounced writes */
+  dispose(): void {
+    for (const timer of this.debounceTimers.values()) {
+      clearTimeout(timer);
+    }
+    this.debounceTimers.clear();
+  }
+}


### PR DESCRIPTION
## Summary

Implements Wave 2 (relay track) of the Sprite-Agent Wiring phase — the data model, protocol types, and lifecycle wiring that connects subagent spawns to persistent sprite mappings.

- **5 new protocol message types**: `sprite.link`, `sprite.unlink`, `sprite.message`, `sprite.response`, `sprite.state` — added to WS protocol and IPC protocol for fleet mode
- **sessionId on all agent events**: `agent.spawn`, `agent.working`, `agent.idle`, `agent.complete`, `agent.dismissed` now carry `sessionId` so the iOS app can route events to per-session Offices. Traced through adapter interface, agent tracker, fleet manager, worker IPC, and hook server.
- **SpriteMappingPersistence**: disk-backed JSON persistence to `~/.major-tom/sprite-mappings/` mirroring SessionPersistence (debounced writes, sanitized IDs, load/save/delete/deleteAll/listStale)
- **SpriteMapper**: role classifier (8 canonical roles via regex), role-stable CharacterType binding, desk allocation (0-5 with overflow)
- **Lifecycle wiring in ws.ts**: agent spawn creates mapping + emits `sprite.link`, agent complete/dismissed removes mapping + emits `sprite.unlink`, session.resume loads and emits `sprite.state` for reconnect, `sprite.message` handler acknowledges receipt (Wave 4 implements injection)
- **Cleanup lifecycle**: session end/timeout deletes mapping file, graceful shutdown deletes all, cold boot scans for stale orphans

### Files changed (relay only — no iOS changes)
- `relay/src/protocol/messages.ts` — new sprite message types + sessionId on agent events
- `relay/src/fleet/ipc-messages.ts` — sessionId on IpcAgentLifecycle + IpcSpriteMessage
- `relay/src/adapters/adapter.interface.ts` — sessionId on AgentEvent
- `relay/src/events/agent-tracker.ts` — sessionId on AgentState + all emitters
- `relay/src/fleet/fleet-manager.ts` — forward sessionId through agent lifecycle
- `relay/src/fleet/worker.ts` — send sessionId on agent IPC messages
- `relay/src/adapters/claude-cli.adapter.ts` — send sessionId from SDK hooks
- `relay/src/hooks/hook-server.ts` — extract session_id from hook payloads
- `relay/src/sprites/sprite-mapping-persistence.ts` — **new file**
- `relay/src/sprites/sprite-mapper.ts` — **new file**
- `relay/src/routes/ws.ts` — sprite lifecycle wiring + cleanup hooks
- `relay/src/app.ts` — instantiate + thread sprite deps + shutdown cleanup

## Test plan
- [ ] Verify `npm run build` produces no new errors (only pre-existing tsconfig pattern)
- [ ] Manual test: agent spawn creates sprite.link broadcast
- [ ] Manual test: agent dismiss/complete creates sprite.unlink broadcast
- [ ] Manual test: session.resume sends sprite.state with current mappings
- [ ] Manual test: sprite.message handler returns sprite.response with status 'queued'
- [ ] Manual test: session end deletes sprite mapping file from disk
- [ ] Manual test: relay restart cleans up stale mapping files

🤖 Generated with [Claude Code](https://claude.com/claude-code)