### PR TITLE
feat(ios): sprite-agent wiring Wave 2 -- data model + protocol + allocation

### DIFF
--- a/ios/MajorTom.xcodeproj/project.pbxproj
+++ b/ios/MajorTom.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		1FB9124E49F11A762382E6A9 /* SpecialtyKeyGrid.swift in Sources */ = {isa = PBXBuildFile; fileRef = 908E6CFCF4E1F5F05D0AE4C3 /* SpecialtyKeyGrid.swift */; };
 		2211645B8B3E1BF5093FE2CD /* MoodEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 579C4AF5EF7599467490F248 /* MoodEngine.swift */; };
 		3A1B2C4D5E6F78901234ABCD /* CrewRoster.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B7C8D9E0F1A23456789BCDE /* CrewRoster.swift */; };
+		87DD0EFFCB5F38F604D8E89D /* RoleMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35CE152195BD660297FCDF44 /* RoleMapper.swift */; };
 		4C3D2E1F0A9B87654321FEDC /* CrewPickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D8E9F0A1B2C34567890ABCD /* CrewPickerView.swift */; };
 		22A50E5C5D84EFE896C415FF /* KeybarCustomizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D14F27776863DA81864B0F1 /* KeybarCustomizer.swift */; };
 		236F9F1B1379B823DB4FD5DB /* MajorTomWidgetsBundle.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCBDA7E064D0179C4FD35A17 /* MajorTomWidgetsBundle.swift */; };
@@ -275,6 +276,7 @@
 		5795954485F00C86256F6533 /* LiveActivityManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveActivityManager.swift; sourceTree = "<group>"; };
 		579C4AF5EF7599467490F248 /* MoodEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MoodEngine.swift; sourceTree = "<group>"; };
 		6B7C8D9E0F1A23456789BCDE /* CrewRoster.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CrewRoster.swift; sourceTree = "<group>"; };
+		35CE152195BD660297FCDF44 /* RoleMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoleMapper.swift; sourceTree = "<group>"; };
 		591E0D4455AD31B2BBD8761C /* Session.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Session.swift; sourceTree = "<group>"; };
 		5A61BDDFAF4D3943E1355934 /* ToolActivityRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolActivityRow.swift; sourceTree = "<group>"; };
 		5ACD0D641EBD462C446D4C20 /* CIRunsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CIRunsView.swift; sourceTree = "<group>"; };
@@ -814,6 +816,7 @@
 				282E1D5B477D7DEE32C76B4B /* FurnitureRegistry.swift */,
 				6B7C8D9E0F1A23456789BCDE /* CrewRoster.swift */,
 				579C4AF5EF7599467490F248 /* MoodEngine.swift */,
+				35CE152195BD660297FCDF44 /* RoleMapper.swift */,
 				B2A5F6ECD6AEA9681C140DA3 /* OfficeLayout.swift */,
 				BB2C3D4E5F6A7B8C9D0E1F2A /* StationLayout.swift */,
 				765796A3C1DAD173DB56A1CC /* ThemeEngine.swift */,
@@ -1690,6 +1693,7 @@
 				3A1B2C4D5E6F78901234ABCD /* CrewRoster.swift in Sources */,
 				4C3D2E1F0A9B87654321FEDC /* CrewPickerView.swift in Sources */,
 				2211645B8B3E1BF5093FE2CD /* MoodEngine.swift in Sources */,
+				87DD0EFFCB5F38F604D8E89D /* RoleMapper.swift in Sources */,
 				5AC11640AB3C3745F3F00123 /* NativeKeybar.swift in Sources */,
 				1111499A6385A17E5806AC54 /* NotificationService.swift in Sources */,
 				092B9B0CD510CE78DD29F4E0 /* NotificationSettingsView.swift in Sources */,

--- a/ios/MajorTom/Core/Models/Message.swift
+++ b/ios/MajorTom/Core/Models/Message.swift
@@ -114,6 +114,12 @@ enum MessageType: String, Codable {
     case ciRunsResponse = "ci.runs.response"
     case ciRunDetailResponse = "ci.run.detail.response"
     case ciError = "ci.error"
+
+    // Sprite-Agent Wiring (Wave 2)
+    case spriteLink = "sprite.link"
+    case spriteUnlink = "sprite.unlink"
+    case spriteState = "sprite.state"
+
     case error
 }
 
@@ -789,6 +795,48 @@ struct AgentCompleteEvent: Codable {
 struct AgentDismissedEvent: Codable {
     let type: String
     let agentId: String
+}
+
+// MARK: - Sprite-Agent Wiring Events (Wave 2)
+
+/// Relay → iOS: link a sprite to a subagent.
+/// Creates or updates an agent sprite with the given link info.
+struct SpriteLinkEvent: Codable {
+    let type: String
+    let sessionId: String
+    let spriteHandle: String
+    let subagentId: String
+    let canonicalRole: String
+    let task: String
+    var parentId: String?
+}
+
+/// Relay → iOS: unlink a sprite from a subagent (agent completed/dismissed).
+/// Triggers despawn animation on the linked sprite.
+struct SpriteUnlinkEvent: Codable {
+    let type: String
+    let sessionId: String
+    let spriteHandle: String
+    let subagentId: String
+    let reason: String  // "complete", "dismissed", "error", "crashed"
+    var result: String?
+}
+
+/// Relay → iOS: bulk restore all sprite mappings (reconnect / session attach).
+/// Each entry represents one active sprite link.
+struct SpriteStateEvent: Codable {
+    let type: String
+    let sessionId: String
+    let mappings: [SpriteMapping]
+
+    struct SpriteMapping: Codable {
+        let spriteHandle: String
+        let subagentId: String
+        let canonicalRole: String
+        let task: String
+        var parentId: String?
+        let status: String  // "working", "idle", "spawning"
+    }
 }
 
 struct ConnectionStatusEvent: Codable {

--- a/ios/MajorTom/Core/Services/RelayService.swift
+++ b/ios/MajorTom/Core/Services/RelayService.swift
@@ -1105,6 +1105,26 @@ final class RelayService {
                 responseCounter &+= 1
             }
 
+        // MARK: Sprite-Agent Wiring (Wave 2)
+
+        case .spriteLink:
+            if let event = try? MessageCodec.decode(SpriteLinkEvent.self, from: data) {
+                // TODO: [Wave 3] Route to per-session OfficeViewModel using event.sessionId
+                officeViewModel?.handleSpriteLink(event)
+            }
+
+        case .spriteUnlink:
+            if let event = try? MessageCodec.decode(SpriteUnlinkEvent.self, from: data) {
+                // TODO: [Wave 3] Route to per-session OfficeViewModel using event.sessionId
+                officeViewModel?.handleSpriteUnlink(event)
+            }
+
+        case .spriteState:
+            if let event = try? MessageCodec.decode(SpriteStateEvent.self, from: data) {
+                // TODO: [Wave 3] Route to per-session OfficeViewModel using event.sessionId
+                officeViewModel?.handleSpriteState(event)
+            }
+
         case .error:
             if let event = try? MessageCodec.decode(ErrorEvent.self, from: data) {
                 let msg = ChatMessage(role: .system, content: "Error: \(event.message)")

--- a/ios/MajorTom/Core/Services/RelayService.swift
+++ b/ios/MajorTom/Core/Services/RelayService.swift
@@ -106,7 +106,10 @@ final class RelayService {
     // Auto-approved tools log
     var autoApprovedTools: [AutoApprovedTool] = []
 
-    /// Office view model — receives agent lifecycle events.
+    /// Office view model -- receives agent lifecycle events.
+    /// TODO: [Wave 3] Replace with `officeViewModels: [String: OfficeViewModel]` keyed by sessionId.
+    /// All agent.* and sprite.* events will route to the session-specific OfficeViewModel.
+    /// For now, all events go to this single shared instance (backwards compatible).
     var officeViewModel: OfficeViewModel?
 
     /// Auth service for token management
@@ -728,16 +731,19 @@ final class RelayService {
 
         case .agentWorking:
             if let event = try? MessageCodec.decode(AgentWorkingEvent.self, from: data) {
+                // TODO: [Wave 3] Route to per-session OfficeViewModel using sessionId
                 officeViewModel?.handleAgentWorking(id: event.agentId, task: event.task)
             }
 
         case .agentIdle:
             if let event = try? MessageCodec.decode(AgentIdleEvent.self, from: data) {
+                // TODO: [Wave 3] Route to per-session OfficeViewModel using sessionId
                 officeViewModel?.handleAgentIdle(id: event.agentId)
             }
 
         case .agentComplete:
             if let event = try? MessageCodec.decode(AgentCompleteEvent.self, from: data) {
+                // TODO: [Wave 3] Route to per-session OfficeViewModel using sessionId
                 officeViewModel?.handleAgentComplete(id: event.agentId, result: event.result)
                 notificationService?.postAgentCompleteNotification(
                     agentId: event.agentId,
@@ -751,6 +757,7 @@ final class RelayService {
 
         case .agentDismissed:
             if let event = try? MessageCodec.decode(AgentDismissedEvent.self, from: data) {
+                // TODO: [Wave 3] Route to per-session OfficeViewModel using sessionId
                 officeViewModel?.handleAgentDismissed(id: event.agentId)
                 if let sid = currentSession?.id {
                     liveActivityManager?.handleAgentComplete(sessionId: sid)

--- a/ios/MajorTom/Core/Services/RelayService.swift
+++ b/ios/MajorTom/Core/Services/RelayService.swift
@@ -713,7 +713,8 @@ final class RelayService {
 
         case .agentSpawn:
             if let event = try? MessageCodec.decode(AgentSpawnEvent.self, from: data) {
-                officeViewModel?.handleAgentSpawn(id: event.agentId, role: event.role, task: event.task)
+                // TODO: [Wave 3] Route to per-session OfficeViewModel using sessionId
+                officeViewModel?.handleAgentSpawn(id: event.agentId, role: event.role, task: event.task, parentId: event.parentId)
                 notificationService?.postAgentSpawnNotification(
                     agentId: event.agentId,
                     role: event.role,

--- a/ios/MajorTom/Features/Office/Models/AgentState.swift
+++ b/ios/MajorTom/Features/Office/Models/AgentState.swift
@@ -65,6 +65,23 @@ struct AgentState: Identifiable {
     var deskIndex: Int?
     let spawnedAt: Date
 
+    // MARK: - Sprite-Agent Wiring (Wave 2)
+
+    /// The subagent ID this sprite is linked to (nil for idle/cosmetic sprites).
+    var linkedSubagentId: String?
+
+    /// Unique instance ID from relay — supports clone-not-consume model
+    /// where multiple agent sprites can share the same CharacterType.
+    var spriteHandle: String?
+
+    /// The classified canonical role (researcher, architect, qa, devops,
+    /// frontend, backend, lead, engineer) used by RoleMapper.
+    var canonicalRole: String?
+
+    /// The parent agent ID from the spawn event (orchestrator that spawned this subagent).
+    /// Needed for future multi-session routing (Wave 3).
+    var parentId: String?
+
     init(
         id: String,
         name: String,
@@ -73,7 +90,11 @@ struct AgentState: Identifiable {
         status: AgentStatus = .spawning,
         currentTask: String? = nil,
         deskIndex: Int? = nil,
-        spawnedAt: Date = Date()
+        spawnedAt: Date = Date(),
+        linkedSubagentId: String? = nil,
+        spriteHandle: String? = nil,
+        canonicalRole: String? = nil,
+        parentId: String? = nil
     ) {
         self.id = id
         self.name = name
@@ -83,6 +104,10 @@ struct AgentState: Identifiable {
         self.currentTask = currentTask
         self.deskIndex = deskIndex
         self.spawnedAt = spawnedAt
+        self.linkedSubagentId = linkedSubagentId
+        self.spriteHandle = spriteHandle
+        self.canonicalRole = canonicalRole
+        self.parentId = parentId
     }
 
     /// Time since the agent was spawned, formatted for display.
@@ -105,6 +130,10 @@ extension AgentState: Equatable {
         lhs.name == rhs.name &&
         lhs.status == rhs.status &&
         lhs.currentTask == rhs.currentTask &&
-        lhs.deskIndex == rhs.deskIndex
+        lhs.deskIndex == rhs.deskIndex &&
+        lhs.linkedSubagentId == rhs.linkedSubagentId &&
+        lhs.spriteHandle == rhs.spriteHandle &&
+        lhs.canonicalRole == rhs.canonicalRole &&
+        lhs.parentId == rhs.parentId
     }
 }

--- a/ios/MajorTom/Features/Office/Models/RoleMapper.swift
+++ b/ios/MajorTom/Features/Office/Models/RoleMapper.swift
@@ -1,0 +1,102 @@
+import Foundation
+
+// MARK: - Role Mapper
+
+/// Maps canonical agent roles to CharacterTypes for sprite assignment.
+///
+/// Locked mapping (from Sprite-Agent Wiring spec):
+///   researcher  -> .botanist
+///   architect   -> .captain
+///   qa          -> .doctor
+///   devops      -> .mechanic
+///   frontend    -> .frontendDev
+///   backend     -> .backendEngineer
+///   lead        -> .pm
+///   engineer    -> .claudimusPrime
+///
+/// Role-stable binding: the first spawn for a given canonical role in a session
+/// locks the CharacterType for that role. All subsequent spawns with the same role
+/// reuse the same CharacterType. Different sessions bind independently.
+enum RoleMapper {
+
+    // MARK: - Canonical Role Mapping
+
+    /// The 8 canonical roles recognized by the classifier.
+    static let canonicalRoles: Set<String> = [
+        "researcher", "architect", "qa", "devops",
+        "frontend", "backend", "lead", "engineer"
+    ]
+
+    /// The overflow pool — used when a role doesn't map to any of the 8 primaries.
+    /// These human CharacterTypes are never assigned as primary role mappings.
+    static let overflowPool: [CharacterType] = [
+        .alienDiplomat, .bowenYang, .chef, .dwight, .kendrick, .prince
+    ]
+
+    /// Direct mapping from canonical role string to CharacterType.
+    static func characterType(forCanonicalRole role: String) -> CharacterType? {
+        switch role.lowercased() {
+        case "researcher": return .botanist
+        case "architect":  return .captain
+        case "qa":         return .doctor
+        case "devops":     return .mechanic
+        case "frontend":   return .frontendDev
+        case "backend":    return .backendEngineer
+        case "lead":       return .pm
+        case "engineer":   return .claudimusPrime
+        default:           return nil
+        }
+    }
+
+    // MARK: - Role-Stable Binding
+
+    /// Session-scoped bindings: maps canonical role -> locked CharacterType.
+    /// Passed in and returned so callers own the storage (per-session).
+    typealias SessionBindings = [String: CharacterType]
+
+    /// Resolve the CharacterType for a role, respecting session-stable bindings.
+    ///
+    /// 1. If `role` was already bound this session, return the bound CharacterType.
+    /// 2. If `role` maps to a canonical primary, bind and return it.
+    /// 3. Otherwise, pick a random CharacterType from the overflow pool (excluding
+    ///    already-bound types) and bind it.
+    ///
+    /// - Parameters:
+    ///   - role: The canonical role string from the relay classifier.
+    ///   - sessionBindings: Current session's role->CharacterType bindings.
+    /// - Returns: The resolved CharacterType and the (potentially updated) bindings.
+    static func resolveCharacterType(
+        role: String,
+        sessionBindings: SessionBindings
+    ) -> (CharacterType, SessionBindings) {
+        let normalizedRole = role.lowercased()
+
+        // Already bound this session — reuse
+        if let bound = sessionBindings[normalizedRole] {
+            return (bound, sessionBindings)
+        }
+
+        var updatedBindings = sessionBindings
+
+        // Try canonical mapping first
+        if let mapped = characterType(forCanonicalRole: normalizedRole) {
+            updatedBindings[normalizedRole] = mapped
+            return (mapped, updatedBindings)
+        }
+
+        // Overflow: pick from pool, excluding already-bound types
+        let boundTypes = Set(updatedBindings.values)
+        let available = overflowPool.filter { !boundTypes.contains($0) }
+
+        let picked: CharacterType
+        if let choice = available.randomElement() {
+            picked = choice
+        } else {
+            // All overflow exhausted — duplicate a random overflow character
+            picked = overflowPool.randomElement() ?? .alienDiplomat
+        }
+
+        updatedBindings[normalizedRole] = picked
+        return (picked, updatedBindings)
+    }
+}

--- a/ios/MajorTom/Features/Office/ViewModels/OfficeViewModel.swift
+++ b/ios/MajorTom/Features/Office/ViewModels/OfficeViewModel.swift
@@ -56,20 +56,14 @@ final class OfficeViewModel {
     // MARK: - Sprite Pool
 
     private static let idlePrefix = "idle-"
+
+    /// Tracks which CharacterTypes have rendered idle sprites on screen.
+    /// Used by populateIdleSprites() to manage the cosmetic idle crew.
+    /// NOT used for agent allocation (clone-not-consume model).
     private var availableSprites: Set<CharacterType> = Set(CharacterType.allCases)
 
     private func isIdleSprite(_ id: String) -> Bool {
         id.hasPrefix(Self.idlePrefix)
-    }
-
-    private func claimRandomSprite() -> CharacterType? {
-        guard let picked = availableSprites.randomElement() else { return nil }
-        availableSprites.remove(picked)
-        return picked
-    }
-
-    private func releaseSprite(_ type: CharacterType) {
-        availableSprites.insert(type)
     }
 
     func populateIdleSprites() {
@@ -126,29 +120,18 @@ final class OfficeViewModel {
     // MARK: - Agent Lifecycle Handlers
 
     /// Called when the relay broadcasts `agent.spawn`.
-    /// Creates a new agent, claims a sprite from the idle pool, assigns a desk, sets status to spawning.
-    func handleAgentSpawn(id: String, role: String, task: String) {
+    /// Clone-not-consume: creates a NEW agent sprite instance without consuming idle sprites.
+    /// Uses RoleMapper for deterministic role→CharacterType assignment with session-stable binding.
+    /// Dogs are NEVER assigned as agent sprites.
+    func handleAgentSpawn(id: String, role: String, task: String, parentId: String? = nil) {
         guard !agents.contains(where: { $0.id == id }) else { return }
 
-        let characterType: CharacterType
-        if let claimed = claimRandomSprite() {
-            // Remove the idle sprite for this character. Release its activity
-            // first so any occupied furniture (couch, treadmill, etc.) is freed
-            // — otherwise the engine leaks assignments for the removed sprite.
-            let idleSpriteId = "\(Self.idlePrefix)\(claimed.rawValue)"
-            activityEngine.releaseActivity(for: idleSpriteId)
-            agents.removeAll { $0.id == idleSpriteId }
-            characterType = claimed
-        } else {
-            // Overflow: pull an unrendered human from the crew roster
-            let claimedTypes = Set(agents.map(\.characterType))
-            if let overflow = crewRoster.overflowHuman(excluding: claimedTypes, maxIdleCount: Self.maxIdleHumans) {
-                characterType = overflow
-            } else {
-                // Absolute fallback — all humans exhausted, reuse a dog type
-                characterType = CharacterType.allCases.filter(\.isDog).randomElement() ?? .elvis
-            }
-        }
+        // Resolve CharacterType via role-stable binding (clone-not-consume)
+        let (characterType, updatedBindings) = RoleMapper.resolveCharacterType(
+            role: role,
+            sessionBindings: sessionRoleBindings
+        )
+        sessionRoleBindings = updatedBindings
 
         let deskIndex = assignNextAvailableDesk(to: id)
 
@@ -159,7 +142,10 @@ final class OfficeViewModel {
             characterType: characterType,
             status: .spawning,
             currentTask: task,
-            deskIndex: deskIndex
+            deskIndex: deskIndex,
+            linkedSubagentId: id,
+            canonicalRole: role,
+            parentId: parentId
         )
         agents.append(agent)
         moodEngine.addAgent(id)
@@ -192,53 +178,44 @@ final class OfficeViewModel {
     }
 
     /// Called when the relay broadcasts `agent.complete`.
-    /// Agent celebrates, then leaves and returns sprite to idle pool.
+    /// Clone-not-consume: agent sprite celebrates then despawns entirely.
+    /// Idle sprites are unaffected — no return-to-pool needed.
     func handleAgentComplete(id: String, result: String) {
         guard let index = agents.firstIndex(where: { $0.id == id }) else { return }
         guard !isIdleSprite(id) else { return }
 
-        let charType = agents[index].characterType
         agents[index].status = .celebrating
         agents[index].currentTask = result
         moodEngine.recordCompletion(id)
 
-        // After a brief celebration, transition to leaving
+        // After a brief celebration, transition to leaving, then despawn
         Task { @MainActor in
             try? await Task.sleep(for: .seconds(2))
             if let idx = agents.firstIndex(where: { $0.id == id }) {
                 agents[idx].status = .leaving
             }
-            // Remove after walking out via the centralized cleanup path
-            // (releases desk + activity station + mood + selection in one
-            // place), then return the sprite to the idle pool. The inline
-            // cleanup that lived here previously regressed away from
-            // calling `removeAgent(id:)` in the sprite-pool refactor —
-            // Copilot review on PR #89.
             try? await Task.sleep(for: .seconds(1.5))
             removeAgent(id: id)
-            returnToIdlePool(charType)
+            // Clone-not-consume: agent sprite simply despawns.
+            // Idle sprites were never consumed, so no return-to-pool.
         }
     }
 
     /// Called when the relay broadcasts `agent.dismissed`.
-    /// Agent immediately starts leaving, then returns sprite to idle pool.
+    /// Clone-not-consume: agent sprite leaves then despawns entirely.
     func handleAgentDismissed(id: String) {
-        guard let agent = agents.first(where: { $0.id == id }) else { return }
+        guard agents.contains(where: { $0.id == id }) else { return }
         guard !isIdleSprite(id) else { return }
-
-        let charType = agent.characterType
 
         guard let index = agents.firstIndex(where: { $0.id == id }) else { return }
         agents[index].status = .leaving
         agents[index].currentTask = nil
 
-        // Remove after walking out via the centralized cleanup path,
-        // then return the sprite to the idle pool. Same dedupe as
-        // handleAgentComplete (Copilot review on PR #89).
+        // Agent sprite despawns after walking out.
+        // Clone-not-consume: idle sprites were never consumed, so no return-to-pool.
         Task { @MainActor in
             try? await Task.sleep(for: .seconds(1.5))
             removeAgent(id: id)
-            returnToIdlePool(charType)
         }
     }
 
@@ -282,34 +259,6 @@ final class OfficeViewModel {
     }
 
     // MARK: - Private Helpers
-
-    /// Return a character type to the idle pool after an agent leaves.
-    /// Overflow humans (not part of the active crew) simply vanish — no re-rendering,
-    /// and crucially not added to `availableSprites` since there's nothing to claim.
-    private func returnToIdlePool(_ charType: CharacterType) {
-        // Overflow human — don't re-render, don't add to claimable pool.
-        if !charType.isDog && !crewRoster.isActiveCrew(charType, maxCount: Self.maxIdleHumans) {
-            return
-        }
-
-        let config = CharacterCatalog.config(for: charType)
-        let idleId = "\(Self.idlePrefix)\(charType.rawValue)"
-
-        // Don't re-create if already exists
-        guard !agents.contains(where: { $0.id == idleId }) else { return }
-
-        let idleAgent = AgentState(
-            id: idleId,
-            name: config.displayName,
-            role: charType.rawValue,
-            characterType: charType,
-            status: .idle,
-            currentTask: nil,
-            deskIndex: nil
-        )
-        agents.append(idleAgent)
-        releaseSprite(charType)  // now there's a rendered idle to claim
-    }
 
     /// Find the next available desk and assign it.
     /// Returns nil if all desks are occupied.

--- a/ios/MajorTom/Features/Office/ViewModels/OfficeViewModel.swift
+++ b/ios/MajorTom/Features/Office/ViewModels/OfficeViewModel.swift
@@ -43,6 +43,16 @@ final class OfficeViewModel {
     /// The crew roster — manages which humans are active and user preferences.
     let crewRoster = CrewRoster()
 
+    // MARK: - Sprite-Agent Wiring (Wave 2)
+
+    /// Session ID this Office is bound to.
+    /// TODO: [Wave 3] Each OfficeViewModel will be keyed by sessionId for per-session routing.
+    var sessionId: String?
+
+    /// Per-session role→CharacterType bindings (role-stable binding).
+    /// First spawn for a canonical role locks the CharacterType for the session.
+    var sessionRoleBindings: RoleMapper.SessionBindings = [:]
+
     // MARK: - Sprite Pool
 
     private static let idlePrefix = "idle-"
@@ -326,6 +336,142 @@ final class OfficeViewModel {
         agents.removeAll { $0.id == id }
         if selectedAgentId == id {
             selectedAgentId = nil
+        }
+    }
+
+    // MARK: - Sprite Protocol Handlers (Wave 2)
+
+    /// Handle `sprite.link` — create a new agent sprite linked to a subagent.
+    /// Clone-not-consume: idle sprites are NOT consumed. A new agent sprite instance
+    /// is created with the role-mapped CharacterType.
+    func handleSpriteLink(_ event: SpriteLinkEvent) {
+        // Don't double-create if we already have this sprite handle
+        guard !agents.contains(where: { $0.spriteHandle == event.spriteHandle }) else {
+            // Update existing link if needed
+            if let index = agents.firstIndex(where: { $0.spriteHandle == event.spriteHandle }) {
+                agents[index].linkedSubagentId = event.subagentId
+                agents[index].currentTask = event.task
+                agents[index].canonicalRole = event.canonicalRole
+                agents[index].parentId = event.parentId
+            }
+            return
+        }
+
+        // Resolve CharacterType via role-stable binding
+        let (characterType, updatedBindings) = RoleMapper.resolveCharacterType(
+            role: event.canonicalRole,
+            sessionBindings: sessionRoleBindings
+        )
+        sessionRoleBindings = updatedBindings
+
+        let deskIndex = assignNextAvailableDesk(to: event.spriteHandle)
+
+        let agent = AgentState(
+            id: event.spriteHandle,
+            name: event.canonicalRole.capitalized,
+            role: event.canonicalRole,
+            characterType: characterType,
+            status: .spawning,
+            currentTask: event.task,
+            deskIndex: deskIndex,
+            linkedSubagentId: event.subagentId,
+            spriteHandle: event.spriteHandle,
+            canonicalRole: event.canonicalRole,
+            parentId: event.parentId
+        )
+        agents.append(agent)
+        moodEngine.addAgent(event.spriteHandle)
+    }
+
+    /// Handle `sprite.unlink` — despawn the linked sprite.
+    func handleSpriteUnlink(_ event: SpriteUnlinkEvent) {
+        guard let index = agents.firstIndex(where: { $0.spriteHandle == event.spriteHandle }) else {
+            return
+        }
+
+        let agentId = agents[index].id
+
+        switch event.reason {
+        case "complete":
+            agents[index].status = .celebrating
+            agents[index].currentTask = event.result
+            moodEngine.recordCompletion(agentId)
+
+            Task { @MainActor in
+                try? await Task.sleep(for: .seconds(2))
+                if let idx = agents.firstIndex(where: { $0.id == agentId }) {
+                    agents[idx].status = .leaving
+                }
+                try? await Task.sleep(for: .seconds(1.5))
+                removeAgent(id: agentId)
+            }
+
+        case "error", "crashed":
+            agents[index].status = .leaving
+            agents[index].currentTask = event.result ?? "Error"
+            moodEngine.recordError(agentId)
+
+            Task { @MainActor in
+                try? await Task.sleep(for: .seconds(1.5))
+                removeAgent(id: agentId)
+            }
+
+        default:  // "dismissed" or unknown
+            agents[index].status = .leaving
+            agents[index].currentTask = nil
+
+            Task { @MainActor in
+                try? await Task.sleep(for: .seconds(1.5))
+                removeAgent(id: agentId)
+            }
+        }
+    }
+
+    /// Handle `sprite.state` — bulk restore all sprite mappings (reconnect).
+    /// Clears any existing agent sprites (non-idle) and rebuilds from relay state.
+    func handleSpriteState(_ event: SpriteStateEvent) {
+        // Remove all existing non-idle agent sprites
+        let nonIdleIds = agents.filter { !isIdleSprite($0.id) }.map(\.id)
+        for id in nonIdleIds {
+            removeAgent(id: id)
+        }
+
+        // Reset role bindings for this session
+        sessionRoleBindings = [:]
+
+        // Rebuild from relay mappings
+        for mapping in event.mappings {
+            let (characterType, updatedBindings) = RoleMapper.resolveCharacterType(
+                role: mapping.canonicalRole,
+                sessionBindings: sessionRoleBindings
+            )
+            sessionRoleBindings = updatedBindings
+
+            let status: AgentStatus
+            switch mapping.status {
+            case "working": status = .working
+            case "idle": status = .idle
+            case "spawning": status = .spawning
+            default: status = .working
+            }
+
+            let deskIndex = assignNextAvailableDesk(to: mapping.spriteHandle)
+
+            let agent = AgentState(
+                id: mapping.spriteHandle,
+                name: mapping.canonicalRole.capitalized,
+                role: mapping.canonicalRole,
+                characterType: characterType,
+                status: status,
+                currentTask: mapping.task,
+                deskIndex: deskIndex,
+                linkedSubagentId: mapping.subagentId,
+                spriteHandle: mapping.spriteHandle,
+                canonicalRole: mapping.canonicalRole,
+                parentId: mapping.parentId
+            )
+            agents.append(agent)
+            moodEngine.addAgent(mapping.spriteHandle)
         }
     }
 }

--- a/ios/MajorTom/Features/Office/ViewModels/OfficeViewModel.swift
+++ b/ios/MajorTom/Features/Office/ViewModels/OfficeViewModel.swift
@@ -290,19 +290,33 @@ final class OfficeViewModel {
 
     // MARK: - Sprite Protocol Handlers (Wave 2)
 
-    /// Handle `sprite.link` — create a new agent sprite linked to a subagent.
+    /// Handle `sprite.link` — create or upgrade an agent sprite linked to a subagent.
     /// Clone-not-consume: idle sprites are NOT consumed. A new agent sprite instance
     /// is created with the role-mapped CharacterType.
+    ///
+    /// De-duplication: if `agent.spawn` already created an AgentState for this subagentId,
+    /// we UPGRADE the existing agent with sprite link metadata instead of creating a duplicate.
+    /// Primary key is always `subagentId` so that `agent.*` lifecycle handlers find the agent.
     func handleSpriteLink(_ event: SpriteLinkEvent) {
-        // Don't double-create if we already have this sprite handle
-        guard !agents.contains(where: { $0.spriteHandle == event.spriteHandle }) else {
-            // Update existing link if needed
-            if let index = agents.firstIndex(where: { $0.spriteHandle == event.spriteHandle }) {
-                agents[index].linkedSubagentId = event.subagentId
-                agents[index].currentTask = event.task
-                agents[index].canonicalRole = event.canonicalRole
-                agents[index].parentId = event.parentId
+        // Latch sessionId on first sprite event (Wave 3 routing prep)
+        if sessionId == nil {
+            sessionId = event.sessionId
+        }
+
+        // De-dupe: if agent.spawn already created this agent, upgrade it with sprite link info
+        if let existingIndex = agents.firstIndex(where: { $0.id == event.subagentId }) {
+            agents[existingIndex].spriteHandle = event.spriteHandle
+            agents[existingIndex].linkedSubagentId = event.subagentId
+            agents[existingIndex].canonicalRole = event.canonicalRole
+            agents[existingIndex].parentId = event.parentId
+            if let task = Optional(event.task), !task.isEmpty {
+                agents[existingIndex].currentTask = task
             }
+            return
+        }
+
+        // Don't double-create if we already have this sprite handle linked
+        guard !agents.contains(where: { $0.spriteHandle == event.spriteHandle && !isIdleSprite($0.id) }) else {
             return
         }
 
@@ -313,10 +327,11 @@ final class OfficeViewModel {
         )
         sessionRoleBindings = updatedBindings
 
-        let deskIndex = assignNextAvailableDesk(to: event.spriteHandle)
+        // Use subagentId as primary ID so agent.* lifecycle handlers find this agent
+        let deskIndex = assignNextAvailableDesk(to: event.subagentId)
 
         let agent = AgentState(
-            id: event.spriteHandle,
+            id: event.subagentId,
             name: event.canonicalRole.capitalized,
             role: event.canonicalRole,
             characterType: characterType,
@@ -329,12 +344,15 @@ final class OfficeViewModel {
             parentId: event.parentId
         )
         agents.append(agent)
-        moodEngine.addAgent(event.spriteHandle)
+        moodEngine.addAgent(event.subagentId)
     }
 
     /// Handle `sprite.unlink` — despawn the linked sprite.
+    /// Looks up by subagentId first (primary key), falls back to spriteHandle metadata.
     func handleSpriteUnlink(_ event: SpriteUnlinkEvent) {
-        guard let index = agents.firstIndex(where: { $0.spriteHandle == event.spriteHandle }) else {
+        guard let index = agents.firstIndex(where: {
+            $0.id == event.subagentId || $0.spriteHandle == event.spriteHandle
+        }) else {
             return
         }
 
@@ -378,7 +396,13 @@ final class OfficeViewModel {
 
     /// Handle `sprite.state` — bulk restore all sprite mappings (reconnect).
     /// Clears any existing agent sprites (non-idle) and rebuilds from relay state.
+    /// Uses `subagentId` as the primary AgentState.id so agent.* handlers find them.
     func handleSpriteState(_ event: SpriteStateEvent) {
+        // Latch sessionId on reconnect sync (Wave 3 routing prep)
+        if sessionId == nil {
+            sessionId = event.sessionId
+        }
+
         // Remove all existing non-idle agent sprites
         let nonIdleIds = agents.filter { !isIdleSprite($0.id) }.map(\.id)
         for id in nonIdleIds {
@@ -388,7 +412,7 @@ final class OfficeViewModel {
         // Reset role bindings for this session
         sessionRoleBindings = [:]
 
-        // Rebuild from relay mappings
+        // Rebuild from relay mappings — primary key is subagentId
         for mapping in event.mappings {
             let (characterType, updatedBindings) = RoleMapper.resolveCharacterType(
                 role: mapping.canonicalRole,
@@ -404,10 +428,10 @@ final class OfficeViewModel {
             default: status = .working
             }
 
-            let deskIndex = assignNextAvailableDesk(to: mapping.spriteHandle)
+            let deskIndex = assignNextAvailableDesk(to: mapping.subagentId)
 
             let agent = AgentState(
-                id: mapping.spriteHandle,
+                id: mapping.subagentId,
                 name: mapping.canonicalRole.capitalized,
                 role: mapping.canonicalRole,
                 characterType: characterType,
@@ -420,7 +444,7 @@ final class OfficeViewModel {
                 parentId: mapping.parentId
             )
             agents.append(agent)
-            moodEngine.addAgent(mapping.spriteHandle)
+            moodEngine.addAgent(mapping.subagentId)
         }
     }
 }


### PR DESCRIPTION
## Summary

- **AgentState additions**: `linkedSubagentId`, `spriteHandle`, `canonicalRole`, `parentId` fields for bidirectional sprite-subagent linking
- **RoleMapper**: Static role-to-CharacterType mapper with the locked 8-role mapping (researcher->botanist, architect->captain, etc.) plus session-stable binding and overflow pool
- **Clone-not-consume allocation**: `handleAgentSpawn` creates new agent sprite instances via RoleMapper instead of consuming idle sprites from the pool. Idle sprites remain untouched throughout agent lifecycle.
- **Dog fallback removed**: Dogs are never assigned as agent sprites. Overflow pool humans (alienDiplomat, bowenYang, chef, dwight, kendrick, prince) handle exhaustion with duplicates.
- **parentId persisted**: `AgentSpawnEvent.parentId` is now passed through RelayService and stored on AgentState (was previously discarded)
- **sprite.* protocol messages**: `sprite.link`, `sprite.unlink`, `sprite.state` message types with Codable event structs and OfficeViewModel handlers
- **Per-session routing prep**: TODO markers at all agent/sprite event routing points for Wave 3 multi-session OfficeViewModel lookup

## Test plan

- [ ] Build succeeds with no new errors (verified via XcodeBuildMCP)
- [ ] Existing agent spawn/complete/dismiss lifecycle still works (idle sprites no longer consumed)
- [ ] RoleMapper returns correct CharacterType for all 8 canonical roles
- [ ] RoleMapper session-stable binding locks role->CharacterType on first spawn
- [ ] New sprite.* message types parse correctly from relay JSON
- [ ] Dogs are never selected as agent sprites regardless of spawn count

🤖 Generated with [Claude Code](https://claude.com/claude-code)