### PR TITLE
feat(relay): sprite.state.request query endpoint

### DIFF
--- a/relay/src/protocol/messages.ts
+++ b/relay/src/protocol/messages.ts
@@ -477,6 +477,11 @@ export interface SpriteMessageMessage {
   messageId: string;
 }
 
+export interface SpriteStateRequestMessage {
+  type: 'sprite.state.request';
+  sessionId: string;
+}
+
 export type ClientMessage =
   | PromptMessage
   | ApprovalMessage
@@ -527,7 +532,8 @@ export type ClientMessage =
   | GitLogMessage
   | GitBranchesMessage
   | GitShowMessage
-  | SpriteMessageMessage;
+  | SpriteMessageMessage
+  | SpriteStateRequestMessage;
 
 // ── Server → Client (Relay → iOS) ──────────────────────────
 

--- a/relay/src/routes/ws.ts
+++ b/relay/src/routes/ws.ts
@@ -21,7 +21,8 @@ import { encodeServerMessage, safeDecode } from '../protocol/codec.js';
 import { truncateMetaField } from '../sessions/session-transcript.js';
 import { EventBufferManager } from '../sessions/event-buffer.js';
 import { scanWorkspaceTree } from '../workspace/tree-scanner.js';
-import type { ClientMessage, ServerMessage, FileNode } from '../protocol/messages.js';
+import type { ClientMessage, ServerMessage, FileNode, SpriteMappingEntry } from '../protocol/messages.js';
+import type { PersistedSpriteMapping } from '../sprites/sprite-mapping-persistence.js';
 import { createFsHandlers, type FsServerMessage } from './fs.js';
 import { createGitHandlers, type GitServerMessage } from './git.js';
 import { createGitHubHandlers, type GitHubServerMessage } from './github.js';
@@ -198,6 +199,19 @@ export function createWsRoute(deps: WsDeps): FastifyPluginAsync {
     }
   });
 
+  // ── Sprite mapping wire-format helper ────────────────────
+  /** Convert persisted mapping to wire-format SpriteMappingEntry. */
+  function toWireMapping(m: PersistedSpriteMapping): SpriteMappingEntry {
+    return {
+      spriteHandle: m.spriteHandle,
+      agentId: m.agentId,
+      role: m.role,
+      characterType: m.characterType,
+      ...(m.deskIndex !== undefined && m.deskIndex >= 0 ? { deskIndex: m.deskIndex } : {}),
+      linkedAt: m.linkedAt,
+    };
+  }
+
   // ── Session keepalive: 10-minute timeout when all clients disconnect ──
   const SESSION_TIMEOUT_MS = 10 * 60 * 1000; // 10 minutes
   /** Maps sessionId → Set of WebSocket clients attached to that session */
@@ -345,6 +359,7 @@ export function createWsRoute(deps: WsDeps): FastifyPluginAsync {
     'session.attach', 'session.list', 'session.resume', 'achievement.list',
     'fleet.status', 'workspace.tree', 'fs.ls', 'fs.readFile', 'fs.cwd',
     'presence.watch', 'presence.unwatch', 'user.list', 'activity.list',
+    'sprite.state.request',
     'annotation.list',
     'git.status', 'git.diff', 'git.log', 'git.branches', 'git.show',
     'github.pullRequests', 'github.pullRequest.detail', 'github.issues', 'github.issue.detail',
@@ -728,14 +743,7 @@ export function createWsRoute(deps: WsDeps): FastifyPluginAsync {
           sendToClient(ws, {
             type: 'sprite.state',
             sessionId: resumeSessionId,
-            mappings: resumeSpriteState.mappings.map(m => ({
-              spriteHandle: m.spriteHandle,
-              agentId: m.agentId,
-              role: m.role,
-              characterType: m.characterType,
-              ...(m.deskIndex !== undefined && m.deskIndex >= 0 ? { deskIndex: m.deskIndex } : {}),
-              linkedAt: m.linkedAt,
-            })),
+            mappings: resumeSpriteState.mappings.map(toWireMapping),
             roleBindings: resumeSpriteState.roleBindings,
           });
         }
@@ -923,6 +931,18 @@ export function createWsRoute(deps: WsDeps): FastifyPluginAsync {
       // ── Sprite state query (cold scene rebuild) ──────────────
       case 'sprite.state.request': {
         const reqSessionId = message.sessionId;
+
+        // Verify the requesting client is attached to this session
+        const attachedSessionId = clientSessions.get(ws);
+        if (attachedSessionId !== reqSessionId) {
+          sendToClient(ws, {
+            type: 'error',
+            code: 'FORBIDDEN',
+            message: 'Cannot query sprite state for a session you are not attached to',
+          });
+          break;
+        }
+
         let state = spriteMappings.get(reqSessionId);
         if (!state) {
           // Try loading from disk (relay may have restarted since last seen)
@@ -936,14 +956,7 @@ export function createWsRoute(deps: WsDeps): FastifyPluginAsync {
           type: 'sprite.state',
           sessionId: reqSessionId,
           mappings: state?.mappings.length
-            ? state.mappings.map(m => ({
-                spriteHandle: m.spriteHandle,
-                agentId: m.agentId,
-                role: m.role,
-                characterType: m.characterType,
-                ...(m.deskIndex !== undefined && m.deskIndex >= 0 ? { deskIndex: m.deskIndex } : {}),
-                linkedAt: m.linkedAt,
-              }))
+            ? state.mappings.map(toWireMapping)
             : [],
           roleBindings: state?.roleBindings ?? {},
         });

--- a/relay/src/routes/ws.ts
+++ b/relay/src/routes/ws.ts
@@ -920,6 +920,40 @@ export function createWsRoute(deps: WsDeps): FastifyPluginAsync {
         break;
       }
 
+      // ── Sprite state query (cold scene rebuild) ──────────────
+      case 'sprite.state.request': {
+        const reqSessionId = message.sessionId;
+        let state = spriteMappings.get(reqSessionId);
+        if (!state) {
+          // Try loading from disk (relay may have restarted since last seen)
+          const persisted = await spriteMappingPersistence.load(reqSessionId);
+          if (persisted) {
+            spriteMappings.set(reqSessionId, persisted);
+            state = persisted;
+          }
+        }
+        sendToClient(ws, {
+          type: 'sprite.state',
+          sessionId: reqSessionId,
+          mappings: state?.mappings.length
+            ? state.mappings.map(m => ({
+                spriteHandle: m.spriteHandle,
+                agentId: m.agentId,
+                role: m.role,
+                characterType: m.characterType,
+                ...(m.deskIndex !== undefined && m.deskIndex >= 0 ? { deskIndex: m.deskIndex } : {}),
+                linkedAt: m.linkedAt,
+              }))
+            : [],
+          roleBindings: state?.roleBindings ?? {},
+        });
+        logger.debug(
+          { sessionId: reqSessionId, mappingCount: state?.mappings.length ?? 0 },
+          'Sprite state request fulfilled',
+        );
+        break;
+      }
+
       case 'workspace.tree': {
         const session = message.sessionId
           ? sessionManager.tryGet(message.sessionId)


### PR DESCRIPTION
## Summary
- Adds `sprite.state.request` client→relay message type for iOS cold scene rebuild
- Handler checks in-memory sprite mappings first, falls back to disk persistence (`SpriteMappingPersistence.load()`)
- Responds with existing `sprite.state` message format (mappings + roleBindings)
- Empty response if session has no state — no errors thrown

## Context
Wave 3 relay track of Sprite-Agent Wiring phase. iOS needs to request current sprite state when opening an Office for a session that was cold-destroyed (LRU eviction) or on reconnect.

## Files changed
- `relay/src/protocol/messages.ts` — `SpriteStateRequestMessage` interface + `ClientMessage` union
- `relay/src/routes/ws.ts` — `sprite.state.request` case handler

## Test plan
- [ ] Build: `cd relay && npm run build` passes clean
- [ ] Cold rebuild: iOS sends `sprite.state.request`, relay responds with current mappings
- [ ] Empty session: request for unknown sessionId returns empty mappings
- [ ] Disk fallback: relay restart → request loads from persisted file
- [ ] Memory hydration: disk load populates in-memory cache for subsequent requests

🤖 Generated with [Claude Code](https://claude.com/claude-code)