### PR TITLE
feat(ios): Office Manager + per-session scenes + multi-session routing

### DIFF
--- a/ios/MajorTom.xcodeproj/project.pbxproj
+++ b/ios/MajorTom.xcodeproj/project.pbxproj
@@ -23,6 +23,8 @@
 		1A22CF8ACA6F58DD4DE5C89D /* FleetDashboardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 606AFAAEB048B1DBCAEA1309 /* FleetDashboardView.swift */; };
 		1A9E5EAEF36B8610B9A0050F /* SessionTimelineProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7FA07A9DCD7F42613309990 /* SessionTimelineProvider.swift */; };
 		1ECF57AD1993033DCCF73DB5 /* OfficeViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 794D98FF20DC91F49542FE7D /* OfficeViewModel.swift */; };
+		1ECF57AE2993044ECCF73DC6 /* OfficeSceneManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 794D99002EDC92F59643FF8E /* OfficeSceneManager.swift */; };
+		1ECF57AF3993055FCCF73ED7 /* OfficeManagerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD5008821EC7350E4B0F1BCB /* OfficeManagerView.swift */; };
 		1FB9124E49F11A762382E6A9 /* SpecialtyKeyGrid.swift in Sources */ = {isa = PBXBuildFile; fileRef = 908E6CFCF4E1F5F05D0AE4C3 /* SpecialtyKeyGrid.swift */; };
 		2211645B8B3E1BF5093FE2CD /* MoodEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 579C4AF5EF7599467490F248 /* MoodEngine.swift */; };
 		3A1B2C4D5E6F78901234ABCD /* CrewRoster.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B7C8D9E0F1A23456789BCDE /* CrewRoster.swift */; };
@@ -312,6 +314,7 @@
 		7794C5813F5964F288D432AD /* HapticService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HapticService.swift; sourceTree = "<group>"; };
 		1972DF8FED85D9290EA3F331 /* PerfHUDPreferences.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PerfHUDPreferences.swift; sourceTree = "<group>"; };
 		794D98FF20DC91F49542FE7D /* OfficeViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OfficeViewModel.swift; sourceTree = "<group>"; };
+		794D99002EDC92F59643FF8E /* OfficeSceneManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OfficeSceneManager.swift; sourceTree = "<group>"; };
 		7A8199AB9D26A914D6633EF0 /* PermissionModeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionModeView.swift; sourceTree = "<group>"; };
 		7B0675DDA1DE8E757F72ECF0 /* AnalyticsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsViewModel.swift; sourceTree = "<group>"; };
 		7FF6122D7FFB5D6E1C71F943 /* GitLogView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitLogView.swift; sourceTree = "<group>"; };
@@ -359,6 +362,7 @@
 		BBDD93D05B7AFEA1D59E6331 /* NotificationSettingsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationSettingsViewModel.swift; sourceTree = "<group>"; };
 		BC0B8C7069C99E830703066D /* ToolMessageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolMessageView.swift; sourceTree = "<group>"; };
 		BD500881DC6249D63A9E0ACA /* OfficeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OfficeView.swift; sourceTree = "<group>"; };
+		BD5008821EC7350E4B0F1BCB /* OfficeManagerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OfficeManagerView.swift; sourceTree = "<group>"; };
 		7D8E9F0A1B2C34567890ABCD /* CrewPickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CrewPickerView.swift; sourceTree = "<group>"; };
 		BF0C705C7B75FC8AADBDC2F9 /* ModelDistributionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelDistributionView.swift; sourceTree = "<group>"; };
 		C0656AE4C6DEE802350E31BF /* MajorTomLiveActivityView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MajorTomLiveActivityView.swift; sourceTree = "<group>"; };
@@ -852,6 +856,7 @@
 		53A697AA7BC2945AF0AE4838 /* ViewModels */ = {
 			isa = PBXGroup;
 			children = (
+				794D99002EDC92F59643FF8E /* OfficeSceneManager.swift */,
 				794D98FF20DC91F49542FE7D /* OfficeViewModel.swift */,
 			);
 			path = ViewModels;
@@ -1089,6 +1094,7 @@
 				6A6B155FB1E10E586EFA12AC /* AgentInspectorView.swift */,
 				E176705EB6880868FE05573E /* CharacterGalleryView.swift */,
 				7D8E9F0A1B2C34567890ABCD /* CrewPickerView.swift */,
+				BD5008821EC7350E4B0F1BCB /* OfficeManagerView.swift */,
 				BD500881DC6249D63A9E0ACA /* OfficeView.swift */,
 			);
 			path = Views;
@@ -1700,7 +1706,9 @@
 				1016EDC3CDBD61DED804691E /* NotificationSettingsViewModel.swift in Sources */,
 				01CF88DD53BD425A8BB52F59 /* OfficeLayout.swift in Sources */,
 				6E4EDEA7EBF6C0B069F3654C /* OfficeScene.swift in Sources */,
+				1ECF57AF3993055FCCF73ED7 /* OfficeManagerView.swift in Sources */,
 				9F2F95450060416CA67BA3FB /* OfficeView.swift in Sources */,
+				1ECF57AE2993044ECCF73DC6 /* OfficeSceneManager.swift in Sources */,
 				1ECF57AD1993033DCCF73DB5 /* OfficeViewModel.swift in Sources */,
 				3320719E65C7D12EC787C929 /* PairingView.swift in Sources */,
 				818FA51F81C18CFE08B3C097 /* PairingViewModel.swift in Sources */,

--- a/ios/MajorTom/App/MajorTomApp.swift
+++ b/ios/MajorTom/App/MajorTomApp.swift
@@ -3,7 +3,7 @@ import SwiftUI
 @main
 struct MajorTomApp: App {
     @State private var relay = RelayService()
-    @State private var officeViewModel = OfficeViewModel()
+    @State private var officeSceneManager = OfficeSceneManager()
     @State private var auth = AuthService()
     @State private var notificationService = NotificationService()
     @State private var liveActivityManager = LiveActivityManager()
@@ -26,7 +26,8 @@ struct MajorTomApp: App {
             .onAppear {
                 let achievementsVM = AchievementsViewModel(auth: auth)
                 achievementsViewModel = achievementsVM
-                relay.officeViewModel = officeViewModel
+                relay.officeSceneManager = officeSceneManager
+                officeSceneManager.relay = relay
                 relay.authService = auth
                 relay.notificationService = notificationService
                 relay.liveActivityManager = liveActivityManager
@@ -122,7 +123,7 @@ struct MajorTomApp: App {
                 }
                 .tag(AppTab.terminal)
 
-            OfficeView(viewModel: officeViewModel, relay: relay)
+            OfficeManagerView(sceneManager: officeSceneManager, relay: relay)
                 .tabItem {
                     Label("Office", systemImage: "building.2")
                 }

--- a/ios/MajorTom/Core/Models/Message.swift
+++ b/ios/MajorTom/Core/Models/Message.swift
@@ -51,6 +51,7 @@ enum MessageType: String, Codable {
     case githubIssueDetail = "github.issue.detail"
     case ciRuns = "ci.runs"
     case ciRunDetail = "ci.run.detail"
+    case spriteStateRequest = "sprite.state.request"
 
     // Server → Client
     case output
@@ -837,6 +838,13 @@ struct SpriteStateEvent: Codable {
         var parentId: String?
         let status: String  // "working", "idle", "spawning"
     }
+}
+
+/// iOS → Relay: request current sprite mappings for a session.
+/// Relay responds with a `sprite.state` event containing all active links.
+struct SpriteStateRequestMessage: Codable {
+    let type: String = "sprite.state.request"
+    let sessionId: String
 }
 
 struct ConnectionStatusEvent: Codable {

--- a/ios/MajorTom/Core/Services/RelayService.swift
+++ b/ios/MajorTom/Core/Services/RelayService.swift
@@ -106,11 +106,9 @@ final class RelayService {
     // Auto-approved tools log
     var autoApprovedTools: [AutoApprovedTool] = []
 
-    /// Office view model -- receives agent lifecycle events.
-    /// TODO: [Wave 3] Replace with `officeViewModels: [String: OfficeViewModel]` keyed by sessionId.
-    /// All agent.* and sprite.* events will route to the session-specific OfficeViewModel.
-    /// For now, all events go to this single shared instance (backwards compatible).
-    var officeViewModel: OfficeViewModel?
+    /// Office scene manager — manages per-session OfficeViewModel + OfficeScene pairs.
+    /// Agent.* and sprite.* events are routed to the session-specific OfficeViewModel.
+    var officeSceneManager: OfficeSceneManager?
 
     /// Auth service for token management
     var authService: AuthService?
@@ -293,6 +291,15 @@ final class RelayService {
     func sendAgentMessage(sessionId: String, agentId: String, text: String) async throws {
         let message = AgentMessageMessage(sessionId: sessionId, agentId: agentId, text: text)
         try await webSocket.send(message)
+    }
+
+    /// Request current sprite mappings for a session from the relay.
+    /// The relay responds with a `sprite.state` event containing all active links.
+    func requestSpriteState(for sessionId: String) {
+        let message = SpriteStateRequestMessage(sessionId: sessionId)
+        Task {
+            try? await webSocket.send(message)
+        }
     }
 
     // MARK: - Workspace & Context
@@ -716,8 +723,10 @@ final class RelayService {
 
         case .agentSpawn:
             if let event = try? MessageCodec.decode(AgentSpawnEvent.self, from: data) {
-                // TODO: [Wave 3] Route to per-session OfficeViewModel using sessionId
-                officeViewModel?.handleAgentSpawn(id: event.agentId, role: event.role, task: event.task, parentId: event.parentId)
+                // Route to per-session OfficeViewModel (agent events use currentSession)
+                if let sid = currentSession?.id {
+                    officeSceneManager?.viewModel(for: sid)?.handleAgentSpawn(id: event.agentId, role: event.role, task: event.task, parentId: event.parentId)
+                }
                 notificationService?.postAgentSpawnNotification(
                     agentId: event.agentId,
                     role: event.role,
@@ -731,20 +740,23 @@ final class RelayService {
 
         case .agentWorking:
             if let event = try? MessageCodec.decode(AgentWorkingEvent.self, from: data) {
-                // TODO: [Wave 3] Route to per-session OfficeViewModel using sessionId
-                officeViewModel?.handleAgentWorking(id: event.agentId, task: event.task)
+                if let sid = currentSession?.id {
+                    officeSceneManager?.viewModel(for: sid)?.handleAgentWorking(id: event.agentId, task: event.task)
+                }
             }
 
         case .agentIdle:
             if let event = try? MessageCodec.decode(AgentIdleEvent.self, from: data) {
-                // TODO: [Wave 3] Route to per-session OfficeViewModel using sessionId
-                officeViewModel?.handleAgentIdle(id: event.agentId)
+                if let sid = currentSession?.id {
+                    officeSceneManager?.viewModel(for: sid)?.handleAgentIdle(id: event.agentId)
+                }
             }
 
         case .agentComplete:
             if let event = try? MessageCodec.decode(AgentCompleteEvent.self, from: data) {
-                // TODO: [Wave 3] Route to per-session OfficeViewModel using sessionId
-                officeViewModel?.handleAgentComplete(id: event.agentId, result: event.result)
+                if let sid = currentSession?.id {
+                    officeSceneManager?.viewModel(for: sid)?.handleAgentComplete(id: event.agentId, result: event.result)
+                }
                 notificationService?.postAgentCompleteNotification(
                     agentId: event.agentId,
                     result: event.result
@@ -757,8 +769,9 @@ final class RelayService {
 
         case .agentDismissed:
             if let event = try? MessageCodec.decode(AgentDismissedEvent.self, from: data) {
-                // TODO: [Wave 3] Route to per-session OfficeViewModel using sessionId
-                officeViewModel?.handleAgentDismissed(id: event.agentId)
+                if let sid = currentSession?.id {
+                    officeSceneManager?.viewModel(for: sid)?.handleAgentDismissed(id: event.agentId)
+                }
                 if let sid = currentSession?.id {
                     liveActivityManager?.handleAgentComplete(sessionId: sid)
                 }
@@ -853,9 +866,11 @@ final class RelayService {
         case .achievementUnlocked:
             if let event = try? MessageCodec.decode(AchievementUnlockedEvent.self, from: data) {
                 achievementsViewModel?.handleAchievementUnlocked(event)
-                // Trigger office celebration for a random agent
-                if let agentId = officeViewModel?.agents.filter({ $0.status == .working || $0.status == .idle }).randomElement()?.id {
-                    officeViewModel?.handleAgentCelebration(id: agentId)
+                // Trigger office celebration for a random agent in the current session
+                if let sid = currentSession?.id,
+                   let vm = officeSceneManager?.viewModel(for: sid),
+                   let agentId = vm.agents.filter({ $0.status == .working || $0.status == .idle }).randomElement()?.id {
+                    vm.handleAgentCelebration(id: agentId)
                 }
             }
 
@@ -1117,20 +1132,17 @@ final class RelayService {
 
         case .spriteLink:
             if let event = try? MessageCodec.decode(SpriteLinkEvent.self, from: data) {
-                // TODO: [Wave 3] Route to per-session OfficeViewModel using event.sessionId
-                officeViewModel?.handleSpriteLink(event)
+                officeSceneManager?.viewModel(for: event.sessionId)?.handleSpriteLink(event)
             }
 
         case .spriteUnlink:
             if let event = try? MessageCodec.decode(SpriteUnlinkEvent.self, from: data) {
-                // TODO: [Wave 3] Route to per-session OfficeViewModel using event.sessionId
-                officeViewModel?.handleSpriteUnlink(event)
+                officeSceneManager?.viewModel(for: event.sessionId)?.handleSpriteUnlink(event)
             }
 
         case .spriteState:
             if let event = try? MessageCodec.decode(SpriteStateEvent.self, from: data) {
-                // TODO: [Wave 3] Route to per-session OfficeViewModel using event.sessionId
-                officeViewModel?.handleSpriteState(event)
+                officeSceneManager?.viewModel(for: event.sessionId)?.handleSpriteState(event)
             }
 
         case .error:
@@ -1191,8 +1203,9 @@ final class RelayService {
 
     /// Push latest session state to the widget data store and watch.
     private func updateWidgetData() {
-        let agentCount = officeViewModel?.agents.count ?? 0
-        let activeAgents = officeViewModel?.agents.filter { $0.status == .working || $0.status == .spawning }.count ?? 0
+        let currentVM = currentSession.flatMap { officeSceneManager?.viewModel(for: $0.id) }
+        let agentCount = currentVM?.agents.count ?? 0
+        let activeAgents = currentVM?.agents.filter { $0.status == .working || $0.status == .spawning }.count ?? 0
 
         WidgetDataProvider.updateSessionStatus(.init(
             isActive: currentSession != nil,
@@ -1326,7 +1339,7 @@ final class RelayService {
         if let session = currentSession,
            !watchSessions.contains(where: { $0.id == session.id })
         {
-            let agentCount = officeViewModel?.agents.count ?? 0
+            let agentCount = officeSceneManager?.viewModel(for: session.id)?.agents.count ?? 0
             let watchSession = WatchSession(
                 id: session.id,
                 name: session.workingDir ?? "Session",

--- a/ios/MajorTom/Core/Services/RelayService.swift
+++ b/ios/MajorTom/Core/Services/RelayService.swift
@@ -1133,17 +1133,17 @@ final class RelayService {
 
         case .spriteLink:
             if let event = try? MessageCodec.decode(SpriteLinkEvent.self, from: data) {
-                officeSceneManager?.viewModel(for: event.sessionId)?.handleSpriteLink(event)
+                officeSceneManager?.ensureViewModel(for: event.sessionId).handleSpriteLink(event)
             }
 
         case .spriteUnlink:
             if let event = try? MessageCodec.decode(SpriteUnlinkEvent.self, from: data) {
-                officeSceneManager?.viewModel(for: event.sessionId)?.handleSpriteUnlink(event)
+                officeSceneManager?.ensureViewModel(for: event.sessionId).handleSpriteUnlink(event)
             }
 
         case .spriteState:
             if let event = try? MessageCodec.decode(SpriteStateEvent.self, from: data) {
-                officeSceneManager?.viewModel(for: event.sessionId)?.handleSpriteState(event)
+                officeSceneManager?.ensureViewModel(for: event.sessionId).handleSpriteState(event)
             }
 
         case .error:

--- a/ios/MajorTom/Core/Services/RelayService.swift
+++ b/ios/MajorTom/Core/Services/RelayService.swift
@@ -723,9 +723,10 @@ final class RelayService {
 
         case .agentSpawn:
             if let event = try? MessageCodec.decode(AgentSpawnEvent.self, from: data) {
-                // Route to per-session OfficeViewModel (agent events use currentSession)
+                // Route to per-session OfficeViewModel — ensureViewModel auto-creates a
+                // lightweight entry so agent state accumulates even before the user opens an Office.
                 if let sid = currentSession?.id {
-                    officeSceneManager?.viewModel(for: sid)?.handleAgentSpawn(id: event.agentId, role: event.role, task: event.task, parentId: event.parentId)
+                    officeSceneManager?.ensureViewModel(for: sid).handleAgentSpawn(id: event.agentId, role: event.role, task: event.task, parentId: event.parentId)
                 }
                 notificationService?.postAgentSpawnNotification(
                     agentId: event.agentId,
@@ -741,21 +742,21 @@ final class RelayService {
         case .agentWorking:
             if let event = try? MessageCodec.decode(AgentWorkingEvent.self, from: data) {
                 if let sid = currentSession?.id {
-                    officeSceneManager?.viewModel(for: sid)?.handleAgentWorking(id: event.agentId, task: event.task)
+                    officeSceneManager?.ensureViewModel(for: sid).handleAgentWorking(id: event.agentId, task: event.task)
                 }
             }
 
         case .agentIdle:
             if let event = try? MessageCodec.decode(AgentIdleEvent.self, from: data) {
                 if let sid = currentSession?.id {
-                    officeSceneManager?.viewModel(for: sid)?.handleAgentIdle(id: event.agentId)
+                    officeSceneManager?.ensureViewModel(for: sid).handleAgentIdle(id: event.agentId)
                 }
             }
 
         case .agentComplete:
             if let event = try? MessageCodec.decode(AgentCompleteEvent.self, from: data) {
                 if let sid = currentSession?.id {
-                    officeSceneManager?.viewModel(for: sid)?.handleAgentComplete(id: event.agentId, result: event.result)
+                    officeSceneManager?.ensureViewModel(for: sid).handleAgentComplete(id: event.agentId, result: event.result)
                 }
                 notificationService?.postAgentCompleteNotification(
                     agentId: event.agentId,
@@ -770,7 +771,7 @@ final class RelayService {
         case .agentDismissed:
             if let event = try? MessageCodec.decode(AgentDismissedEvent.self, from: data) {
                 if let sid = currentSession?.id {
-                    officeSceneManager?.viewModel(for: sid)?.handleAgentDismissed(id: event.agentId)
+                    officeSceneManager?.ensureViewModel(for: sid).handleAgentDismissed(id: event.agentId)
                 }
                 if let sid = currentSession?.id {
                     liveActivityManager?.handleAgentComplete(sessionId: sid)

--- a/ios/MajorTom/Features/Office/ViewModels/OfficeSceneManager.swift
+++ b/ios/MajorTom/Features/Office/ViewModels/OfficeSceneManager.swift
@@ -16,6 +16,9 @@ final class OfficeSceneManager {
         let viewModel: OfficeViewModel
         var scene: OfficeScene?
         var lastAccessed: Date
+        /// True when `createOffice` was called (full office with scene + idle sprites).
+        /// False for lightweight entries created by `ensureViewModel`.
+        var hasOffice: Bool = false
     }
 
     // MARK: - State
@@ -40,8 +43,25 @@ final class OfficeSceneManager {
     /// Returns the newly created entry. If an Office already exists, returns it.
     @discardableResult
     func createOffice(for sessionId: String) -> OfficeEntry {
-        if let existing = offices[sessionId] {
-            offices[sessionId]?.lastAccessed = Date()
+        if var existing = offices[sessionId] {
+            // If the entry already has a scene (full office), just touch LRU and return.
+            if existing.scene != nil {
+                offices[sessionId]?.lastAccessed = Date()
+                return existing
+            }
+
+            // Upgrade a lightweight ensureViewModel entry: create scene, populate idle sprites,
+            // request sprite state — everything a fresh createOffice would do.
+            let scene = makeScene()
+            existing.scene = scene
+            existing.lastAccessed = Date()
+            existing.hasOffice = true
+            offices[sessionId] = existing
+
+            existing.viewModel.populateIdleSprites()
+            relay?.requestSpriteState(for: sessionId)
+
+            evictIfNeeded(excluding: sessionId)
             return existing
         }
 
@@ -53,7 +73,8 @@ final class OfficeSceneManager {
         let entry = OfficeEntry(
             viewModel: vm,
             scene: scene,
-            lastAccessed: Date()
+            lastAccessed: Date(),
+            hasOffice: true
         )
         offices[sessionId] = entry
 
@@ -150,8 +171,9 @@ final class OfficeSceneManager {
     }
 
     /// Session IDs that have Offices created (for OfficeManagerView).
+    /// Excludes lightweight entries created by `ensureViewModel` that were never upgraded.
     var linkedSessionIds: Set<String> {
-        Set(offices.keys)
+        Set(offices.filter { $0.value.hasOffice }.keys)
     }
 
     // MARK: - Private

--- a/ios/MajorTom/Features/Office/ViewModels/OfficeSceneManager.swift
+++ b/ios/MajorTom/Features/Office/ViewModels/OfficeSceneManager.swift
@@ -1,0 +1,138 @@
+import Foundation
+import SpriteKit
+
+// MARK: - Office Scene Manager
+
+/// Manages per-session OfficeViewModel + OfficeScene pairs.
+/// Each active session can have its own Office with independent agent state and scene.
+/// Scenes are LRU-evicted beyond `maxWarmScenes` to control memory (~30-60MB each).
+@Observable
+@MainActor
+final class OfficeSceneManager {
+
+    // MARK: - Types
+
+    struct OfficeEntry {
+        let viewModel: OfficeViewModel
+        var scene: OfficeScene?
+        var lastAccessed: Date
+    }
+
+    // MARK: - State
+
+    /// Per-session offices keyed by sessionId.
+    private(set) var offices: [String: OfficeEntry] = [:]
+
+    /// Maximum number of warm (in-memory) scenes before LRU eviction kicks in.
+    static let maxWarmScenes = 2
+
+    /// Relay service reference for sending sprite.state.request on cold rebuild.
+    weak var relay: RelayService?
+
+    // MARK: - Public API
+
+    /// Returns the OfficeViewModel for a session, or nil if no Office exists.
+    func viewModel(for sessionId: String) -> OfficeViewModel? {
+        offices[sessionId]?.viewModel
+    }
+
+    /// Creates a new Office for a session (viewModel + scene).
+    /// Returns the newly created entry. If an Office already exists, returns it.
+    @discardableResult
+    func createOffice(for sessionId: String) -> OfficeEntry {
+        if let existing = offices[sessionId] {
+            offices[sessionId]?.lastAccessed = Date()
+            return existing
+        }
+
+        let vm = OfficeViewModel()
+        vm.sessionId = sessionId
+
+        let scene = makeScene()
+
+        let entry = OfficeEntry(
+            viewModel: vm,
+            scene: scene,
+            lastAccessed: Date()
+        )
+        offices[sessionId] = entry
+
+        // Populate idle sprites for the fresh office
+        vm.populateIdleSprites()
+
+        // Request current sprite state from relay for this session
+        relay?.requestSpriteState(for: sessionId)
+
+        evictIfNeeded(excluding: sessionId)
+        return entry
+    }
+
+    /// Returns the scene for a session. If the scene was evicted (cold), rebuilds it
+    /// from the viewModel's current agent state.
+    func scene(for sessionId: String) -> OfficeScene? {
+        guard var entry = offices[sessionId] else { return nil }
+
+        // Touch LRU timestamp
+        entry.lastAccessed = Date()
+        offices[sessionId] = entry
+
+        // If scene exists, return it
+        if let scene = entry.scene {
+            return scene
+        }
+
+        // Cold rebuild: create a new scene, restore from viewModel state
+        let scene = makeScene()
+        offices[sessionId]?.scene = scene
+
+        // If viewModel has existing agents, the scene will pick them up
+        // via OfficeView's onChange(of: viewModel.agents) sync.
+        // If viewModel has no agents (never received events), request state from relay.
+        if entry.viewModel.agents.filter({ !$0.id.hasPrefix("idle-") }).isEmpty {
+            relay?.requestSpriteState(for: sessionId)
+        }
+
+        evictIfNeeded(excluding: sessionId)
+        return scene
+    }
+
+    /// Closes an Office for a session. Destroys both scene and viewModel.
+    /// Does NOT affect the terminal session on the relay.
+    func closeOffice(for sessionId: String) {
+        guard let entry = offices[sessionId] else { return }
+        entry.scene?.isPaused = true
+        offices.removeValue(forKey: sessionId)
+    }
+
+    /// Session IDs that have Offices created (for OfficeManagerView).
+    var linkedSessionIds: Set<String> {
+        Set(offices.keys)
+    }
+
+    // MARK: - Private
+
+    /// Create a fresh OfficeScene with the standard dimensions.
+    private func makeScene() -> OfficeScene {
+        let scene = OfficeScene()
+        scene.size = CGSize(width: StationLayout.sceneWidth, height: StationLayout.sceneHeight)
+        scene.scaleMode = .aspectFill
+        return scene
+    }
+
+    /// LRU eviction: destroy scenes beyond maxWarmScenes (keep viewModel alive).
+    private func evictIfNeeded(excluding activeSessionId: String) {
+        let warmEntries = offices.filter { $0.value.scene != nil && $0.key != activeSessionId }
+
+        guard warmEntries.count >= Self.maxWarmScenes else { return }
+
+        // Sort by lastAccessed ascending (oldest first)
+        let sorted = warmEntries.sorted { $0.value.lastAccessed < $1.value.lastAccessed }
+
+        // Evict oldest entries until we're under the threshold
+        let evictCount = warmEntries.count - Self.maxWarmScenes + 1  // +1 for the active one
+        for entry in sorted.prefix(evictCount) {
+            offices[entry.key]?.scene?.isPaused = true
+            offices[entry.key]?.scene = nil
+        }
+    }
+}

--- a/ios/MajorTom/Features/Office/ViewModels/OfficeSceneManager.swift
+++ b/ios/MajorTom/Features/Office/ViewModels/OfficeSceneManager.swift
@@ -67,9 +67,18 @@ final class OfficeSceneManager {
         return entry
     }
 
-    /// Returns the scene for a session. If the scene was evicted (cold), rebuilds it
-    /// from the viewModel's current agent state.
-    func scene(for sessionId: String) -> OfficeScene? {
+    /// Side-effect-free scene peek — returns the current scene (or nil) without
+    /// touching LRU timestamps or triggering cold rebuilds.
+    /// Safe to call from SwiftUI computed properties / view body.
+    func peekScene(for sessionId: String) -> OfficeScene? {
+        offices[sessionId]?.scene
+    }
+
+    /// Activates an office for viewing: touches LRU, cold-rebuilds the scene if
+    /// evicted, and syncs existing agent state into a fresh scene.
+    /// Call from `.onAppear` or other imperative contexts — NOT from view body.
+    @discardableResult
+    func activateOffice(for sessionId: String) -> OfficeScene? {
         guard var entry = offices[sessionId] else { return nil }
 
         // Touch LRU timestamp
@@ -85,15 +94,51 @@ final class OfficeSceneManager {
         let scene = makeScene()
         offices[sessionId]?.scene = scene
 
-        // If viewModel has existing agents, the scene will pick them up
-        // via OfficeView's onChange(of: viewModel.agents) sync.
-        // If viewModel has no agents (never received events), request state from relay.
-        if entry.viewModel.agents.filter({ !$0.id.hasPrefix("idle-") }).isEmpty {
+        // Sync any existing agents into the fresh scene so they render immediately
+        // (onChange won't fire for the initial value on a newly created scene).
+        let vm = entry.viewModel
+        for agent in vm.agents {
+            scene.addAgent(id: agent.id, name: agent.name, characterType: agent.characterType)
+            if let deskIndex = agent.deskIndex {
+                scene.highlightDesk(deskIndex, occupied: true)
+                scene.moveAgentToDesk(id: agent.id, deskIndex: deskIndex)
+            }
+            switch agent.status {
+            case .working:
+                scene.updateAgentStatus(id: agent.id, status: .working)
+            case .idle:
+                scene.updateAgentStatus(id: agent.id, status: .idle)
+            default:
+                break
+            }
+        }
+
+        // If viewModel has no real agents, request state from relay.
+        if vm.agents.filter({ !$0.id.hasPrefix("idle-") }).isEmpty {
             relay?.requestSpriteState(for: sessionId)
         }
 
         evictIfNeeded(excluding: sessionId)
         return scene
+    }
+
+    /// Creates a lightweight OfficeViewModel entry (no scene) for a session so
+    /// agent events can accumulate before the user opens an Office.
+    @discardableResult
+    func ensureViewModel(for sessionId: String) -> OfficeViewModel {
+        if let existing = offices[sessionId] {
+            return existing.viewModel
+        }
+        let vm = OfficeViewModel()
+        vm.sessionId = sessionId
+
+        let entry = OfficeEntry(
+            viewModel: vm,
+            scene: nil,
+            lastAccessed: Date()
+        )
+        offices[sessionId] = entry
+        return vm
     }
 
     /// Closes an Office for a session. Destroys both scene and viewModel.

--- a/ios/MajorTom/Features/Office/ViewModels/OfficeViewModel.swift
+++ b/ios/MajorTom/Features/Office/ViewModels/OfficeViewModel.swift
@@ -45,8 +45,7 @@ final class OfficeViewModel {
 
     // MARK: - Sprite-Agent Wiring (Wave 2)
 
-    /// Session ID this Office is bound to.
-    /// TODO: [Wave 3] Each OfficeViewModel will be keyed by sessionId for per-session routing.
+    /// Session ID this Office is bound to (set by OfficeSceneManager on creation).
     var sessionId: String?
 
     /// Per-session role→CharacterType bindings (role-stable binding).
@@ -298,7 +297,7 @@ final class OfficeViewModel {
     /// we UPGRADE the existing agent with sprite link metadata instead of creating a duplicate.
     /// Primary key is always `subagentId` so that `agent.*` lifecycle handlers find the agent.
     func handleSpriteLink(_ event: SpriteLinkEvent) {
-        // Latch sessionId on first sprite event (Wave 3 routing prep)
+        // Latch sessionId if not already set (e.g. pre-Wave-3 compat)
         if sessionId == nil {
             sessionId = event.sessionId
         }
@@ -398,7 +397,7 @@ final class OfficeViewModel {
     /// Clears any existing agent sprites (non-idle) and rebuilds from relay state.
     /// Uses `subagentId` as the primary AgentState.id so agent.* handlers find them.
     func handleSpriteState(_ event: SpriteStateEvent) {
-        // Latch sessionId on reconnect sync (Wave 3 routing prep)
+        // Latch sessionId if not already set (e.g. pre-Wave-3 compat)
         if sessionId == nil {
             sessionId = event.sessionId
         }

--- a/ios/MajorTom/Features/Office/Views/OfficeManagerView.swift
+++ b/ios/MajorTom/Features/Office/Views/OfficeManagerView.swift
@@ -1,0 +1,212 @@
+import SwiftUI
+
+// MARK: - Office Manager View
+
+/// Root view for the Office tab. Displays a card grid of sessions,
+/// letting users create/navigate per-session Offices.
+/// Uses NavigationStack to push into individual OfficeViews.
+struct OfficeManagerView: View {
+    var sceneManager: OfficeSceneManager
+    var relay: RelayService
+
+    @State private var navigationPath = NavigationPath()
+
+    var body: some View {
+        NavigationStack(path: $navigationPath) {
+            scrollContent
+                .navigationTitle("Offices")
+                .navigationBarTitleDisplayMode(.large)
+                .background(MajorTomTheme.Colors.background)
+                .navigationDestination(for: String.self) { sessionId in
+                    OfficeView(
+                        sessionId: sessionId,
+                        sceneManager: sceneManager,
+                        relay: relay
+                    )
+                }
+        }
+    }
+
+    // MARK: - Content
+
+    @ViewBuilder
+    private var scrollContent: some View {
+        let activeIds = sceneManager.linkedSessionIds
+        let allSessions = relay.sessionList
+        let activeSessions = allSessions.filter { activeIds.contains($0.id) }
+        let unlinkedSessions = allSessions.filter { !activeIds.contains($0.id) }
+
+        if allSessions.isEmpty {
+            emptyState
+        } else {
+            ScrollView {
+                LazyVStack(alignment: .leading, spacing: MajorTomTheme.Spacing.lg) {
+                    // Active offices
+                    if !activeSessions.isEmpty {
+                        sectionHeader("Active Offices")
+                        ForEach(activeSessions) { session in
+                            activeOfficeCard(session: session)
+                        }
+                    }
+
+                    // Unlinked sessions
+                    if !unlinkedSessions.isEmpty {
+                        sectionHeader("Available Sessions")
+                        ForEach(unlinkedSessions) { session in
+                            unlinkedSessionCard(session: session)
+                        }
+                    }
+                }
+                .padding(.horizontal, MajorTomTheme.Spacing.lg)
+                .padding(.top, MajorTomTheme.Spacing.sm)
+                .padding(.bottom, MajorTomTheme.Spacing.xxl)
+            }
+        }
+    }
+
+    // MARK: - Empty State
+
+    private var emptyState: some View {
+        VStack(spacing: MajorTomTheme.Spacing.lg) {
+            Spacer()
+            Image(systemName: "antenna.radiowaves.left.and.right.slash")
+                .font(.system(size: 48))
+                .foregroundStyle(MajorTomTheme.Colors.textTertiary)
+            Text("No Active Sessions")
+                .font(.system(.title3, design: .monospaced, weight: .semibold))
+                .foregroundStyle(MajorTomTheme.Colors.textSecondary)
+            Text("Connect to a relay and start a session to create an office.")
+                .font(.system(.body, design: .monospaced))
+                .foregroundStyle(MajorTomTheme.Colors.textTertiary)
+                .multilineTextAlignment(.center)
+                .padding(.horizontal, MajorTomTheme.Spacing.xxl)
+            Spacer()
+        }
+        .frame(maxWidth: .infinity)
+    }
+
+    // MARK: - Section Header
+
+    private func sectionHeader(_ title: String) -> some View {
+        Text(title.uppercased())
+            .font(.system(.caption, design: .monospaced, weight: .bold))
+            .foregroundStyle(MajorTomTheme.Colors.textTertiary)
+            .padding(.top, MajorTomTheme.Spacing.sm)
+    }
+
+    // MARK: - Active Office Card
+
+    private func activeOfficeCard(session: SessionMetaInfo) -> some View {
+        let agentCount = sceneManager.viewModel(for: session.id)?.agents.count ?? 0
+
+        return Button {
+            HapticService.selection()
+            navigationPath.append(session.id)
+        } label: {
+            HStack(spacing: MajorTomTheme.Spacing.md) {
+                // Icon
+                Image(systemName: "building.2.fill")
+                    .font(.system(size: 24))
+                    .foregroundStyle(MajorTomTheme.Colors.accent)
+                    .frame(width: 44, height: 44)
+                    .background(MajorTomTheme.Colors.accentSubtle)
+                    .clipShape(RoundedRectangle(cornerRadius: MajorTomTheme.Radius.small))
+
+                // Info
+                VStack(alignment: .leading, spacing: MajorTomTheme.Spacing.xs) {
+                    Text(session.workingDirName)
+                        .font(.system(.body, design: .monospaced, weight: .semibold))
+                        .foregroundStyle(MajorTomTheme.Colors.textPrimary)
+                        .lineLimit(1)
+
+                    HStack(spacing: MajorTomTheme.Spacing.sm) {
+                        Label("\(agentCount)", systemImage: "person.fill")
+                            .font(.system(.caption, design: .monospaced))
+                            .foregroundStyle(MajorTomTheme.Colors.textSecondary)
+
+                        statusBadge(session.status)
+                    }
+                }
+
+                Spacer()
+
+                Image(systemName: "chevron.right")
+                    .font(.system(size: 14, weight: .semibold))
+                    .foregroundStyle(MajorTomTheme.Colors.textTertiary)
+            }
+            .padding(MajorTomTheme.Spacing.md)
+            .background(MajorTomTheme.Colors.surface)
+            .clipShape(RoundedRectangle(cornerRadius: MajorTomTheme.Radius.medium))
+            .overlay(
+                RoundedRectangle(cornerRadius: MajorTomTheme.Radius.medium)
+                    .stroke(MajorTomTheme.Colors.accent.opacity(0.3), lineWidth: 1)
+            )
+        }
+        .buttonStyle(.plain)
+    }
+
+    // MARK: - Unlinked Session Card
+
+    private func unlinkedSessionCard(session: SessionMetaInfo) -> some View {
+        Button {
+            HapticService.selection()
+            sceneManager.createOffice(for: session.id)
+            navigationPath.append(session.id)
+        } label: {
+            HStack(spacing: MajorTomTheme.Spacing.md) {
+                // Icon
+                Image(systemName: "plus.square.dashed")
+                    .font(.system(size: 24))
+                    .foregroundStyle(MajorTomTheme.Colors.textSecondary)
+                    .frame(width: 44, height: 44)
+                    .background(MajorTomTheme.Colors.surfaceElevated)
+                    .clipShape(RoundedRectangle(cornerRadius: MajorTomTheme.Radius.small))
+
+                // Info
+                VStack(alignment: .leading, spacing: MajorTomTheme.Spacing.xs) {
+                    Text(session.workingDirName)
+                        .font(.system(.body, design: .monospaced, weight: .medium))
+                        .foregroundStyle(MajorTomTheme.Colors.textSecondary)
+                        .lineLimit(1)
+
+                    Text("Tap to create office")
+                        .font(.system(.caption, design: .monospaced))
+                        .foregroundStyle(MajorTomTheme.Colors.textTertiary)
+                }
+
+                Spacer()
+
+                Image(systemName: "plus.circle")
+                    .font(.system(size: 18))
+                    .foregroundStyle(MajorTomTheme.Colors.textTertiary)
+            }
+            .padding(MajorTomTheme.Spacing.md)
+            .background(MajorTomTheme.Colors.surface.opacity(0.6))
+            .clipShape(RoundedRectangle(cornerRadius: MajorTomTheme.Radius.medium))
+            .overlay(
+                RoundedRectangle(cornerRadius: MajorTomTheme.Radius.medium)
+                    .stroke(Color.white.opacity(0.08), lineWidth: 1)
+            )
+        }
+        .buttonStyle(.plain)
+    }
+
+    // MARK: - Status Badge
+
+    private func statusBadge(_ status: String) -> some View {
+        let color: Color = switch status {
+        case "active": MajorTomTheme.Colors.allow
+        case "idle": MajorTomTheme.Colors.accent
+        default: MajorTomTheme.Colors.textTertiary
+        }
+
+        return HStack(spacing: 4) {
+            Circle()
+                .fill(color)
+                .frame(width: 6, height: 6)
+            Text(status)
+                .font(.system(.caption2, design: .monospaced))
+                .foregroundStyle(color)
+        }
+    }
+}

--- a/ios/MajorTom/Features/Office/Views/OfficeView.swift
+++ b/ios/MajorTom/Features/Office/Views/OfficeView.swift
@@ -22,18 +22,14 @@ private enum OfficeSheetType: Identifiable {
 
 /// SwiftUI wrapper for the SpriteKit office scene.
 /// Manages the bridge between OfficeViewModel state changes and the SKScene.
+/// Now session-aware: gets its viewModel and scene from OfficeSceneManager.
 struct OfficeView: View {
-    @Bindable var viewModel: OfficeViewModel
+    let sessionId: String
+    var sceneManager: OfficeSceneManager
     var relay: RelayService?
 
     @State private var activeSheet: OfficeSheetType?
     @State private var showMiniMap = false
-    @State private var scene: OfficeScene = {
-        let scene = OfficeScene()
-        scene.size = CGSize(width: StationLayout.sceneWidth, height: StationLayout.sceneHeight)
-        scene.scaleMode = .aspectFill
-        return scene
-    }()
 
     /// Space weather engine for cosmetic atmospheric events.
     @State private var spaceWeather = SpaceWeatherEngine()
@@ -42,36 +38,88 @@ struct OfficeView: View {
     @State private var previousAgentIds: Set<String> = []
     @State private var previousStatuses: [String: AgentStatus] = [:]
 
+    @Environment(\.dismiss) private var dismiss
+
+    /// Resolved viewModel from the scene manager.
+    private var viewModel: OfficeViewModel? {
+        sceneManager.viewModel(for: sessionId)
+    }
+
+    /// Resolved scene from the scene manager (triggers cold rebuild if needed).
+    private var currentScene: OfficeScene? {
+        sceneManager.scene(for: sessionId)
+    }
+
     var body: some View {
+        Group {
+            if let viewModel, let scene = currentScene {
+                officeContent(viewModel: viewModel, scene: scene)
+            } else {
+                // Office was closed or not yet created — show placeholder
+                VStack(spacing: MajorTomTheme.Spacing.lg) {
+                    Image(systemName: "building.2.slash")
+                        .font(.system(size: 48))
+                        .foregroundStyle(MajorTomTheme.Colors.textTertiary)
+                    Text("Office not available")
+                        .font(.system(.body, design: .monospaced))
+                        .foregroundStyle(MajorTomTheme.Colors.textSecondary)
+                }
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .background(MajorTomTheme.Colors.background)
+            }
+        }
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItem(placement: .principal) {
+                if let vm = viewModel {
+                    Text("\(vm.agents.count) agents")
+                        .font(.system(.caption, design: .monospaced, weight: .medium))
+                        .foregroundStyle(MajorTomTheme.Colors.textSecondary)
+                }
+            }
+            ToolbarItem(placement: .topBarTrailing) {
+                Button {
+                    sceneManager.closeOffice(for: sessionId)
+                    dismiss()
+                } label: {
+                    Label("Close Office", systemImage: "xmark.circle")
+                        .font(.system(size: 14))
+                        .foregroundStyle(MajorTomTheme.Colors.textTertiary)
+                }
+            }
+        }
+    }
+
+    // MARK: - Office Content
+
+    @ViewBuilder
+    private func officeContent(viewModel: OfficeViewModel, scene: OfficeScene) -> some View {
         ZStack {
             // SpriteKit scene
             SpriteView(scene: scene)
                 .ignoresSafeArea(.all, edges: .bottom)
                 .onChange(of: viewModel.agents) { _, newAgents in
-                    syncScene(with: newAgents)
+                    syncScene(with: newAgents, viewModel: viewModel, scene: scene)
                 }
 
             // Top overlay: agent count + controls
             VStack {
-                topBar
+                topBar(viewModel: viewModel, scene: scene)
                 Spacer()
             }
 
             // Mini-map overlay (shown on long-press of MAP button)
             if showMiniMap {
-                miniMapOverlay
+                miniMapOverlay(scene: scene)
             }
         }
         .onAppear {
             // Resume the SKScene update loop when the Office tab becomes visible.
-            // Paired with `scene.isPaused = true` in `.onDisappear` — idle tabs
-            // should not be running the 60fps SpriteKit render/update loop.
             scene.isPaused = false
             // Wire theme + mood engines and furniture registry to the scene
             scene.themeEngine = viewModel.themeEngine
             scene.moodEngine = viewModel.moodEngine
             // Wire scene's furniture registry into the activity engine
-            // (scene owns it because didMove runs before onAppear)
             viewModel.activityEngine.setFurnitureRegistry(scene.furnitureRegistry)
 
             // Start engines
@@ -85,13 +133,10 @@ struct OfficeView: View {
                 }
             }
 
-            // Start activity cycling — when an activity expires, reassign
+            // Start activity cycling
             viewModel.activityEngine.startCycling { [weak scene, weak viewModel] agentId, _ in
                 guard let viewModel, let scene else { return }
-
-                // Stop the outgoing activity's animation phase
                 viewModel.activityAnimator.stopPhase(for: agentId, furnitureNodes: scene.furnitureNodes)
-
                 guard let agent = viewModel.agents.first(where: { $0.id == agentId }) else { return }
                 let room = scene.currentRoom(for: agentId) ?? ModuleType.crewQuarters.rawValue
                 if let assignment = viewModel.activityEngine.assignActivity(
@@ -100,7 +145,6 @@ struct OfficeView: View {
                     currentRoom: room
                 ) {
                     scene.moveAgentToActivity(id: agentId, assignment: assignment) { sprite in
-                        // Start animation phase when agent arrives at new activity
                         if let definition = ActivityRegistry.shared.activity(byId: assignment.activityId) {
                             viewModel.activityAnimator.startPhase(
                                 agentId: agentId,
@@ -128,10 +172,9 @@ struct OfficeView: View {
             }
         }
         .onDisappear {
-            // Pause the SKScene update loop so a hidden Office tab does not burn
-            // CPU/battery running updateParallax, applyAgentMoods, etc.
+            // Pause the SKScene update loop
             scene.isPaused = true
-            // Stop engines + activity cycling when view disappears
+            // Stop engines + activity cycling
             viewModel.activityAnimator.stopAll(furnitureNodes: scene.furnitureNodes)
             viewModel.themeEngine.stop()
             viewModel.moodEngine.stop()
@@ -164,10 +207,11 @@ struct OfficeView: View {
                             scene.updateAgentName(id: agent.id, name: newName)
                         },
                         onSendMessage: relay != nil ? { message in
-                            guard let sessionId = relay?.currentSession?.id, !sessionId.isEmpty else { return }
+                            let sid = sessionId
+                            guard !sid.isEmpty else { return }
                             Task {
                                 try? await relay?.sendAgentMessage(
-                                    sessionId: sessionId,
+                                    sessionId: sid,
                                     agentId: agent.id,
                                     text: message
                                 )
@@ -188,14 +232,12 @@ struct OfficeView: View {
                     crewRoster: viewModel.crewRoster,
                     onDismiss: {
                         activeSheet = nil
-                        // Repopulate with new preferences
                         viewModel.shuffleCrew()
                     }
                 )
             }
         }
         .onChange(of: activeSheet) { _, newValue in
-            // Sync sheet dismissal back to view model state
             if newValue == nil {
                 if viewModel.selectedAgentId != nil {
                     viewModel.dismissInspector()
@@ -209,9 +251,9 @@ struct OfficeView: View {
 
     // MARK: - Top Bar
 
-    private var topBar: some View {
+    private func topBar(viewModel: OfficeViewModel, scene: OfficeScene) -> some View {
         HStack(spacing: MajorTomTheme.Spacing.sm) {
-            // Map button (opens full mini-map overlay)
+            // Map button
             Button {
                 HapticService.impact(.light)
                 showMiniMap = true
@@ -264,11 +306,8 @@ struct OfficeView: View {
 
     // MARK: - Mini-Map Overlay
 
-    /// Full-screen mini-map overlay showing the 2×4 station grid.
-    /// Tapping a room pair navigates there and dismisses the overlay.
-    private var miniMapOverlay: some View {
+    private func miniMapOverlay(scene: OfficeScene) -> some View {
         ZStack {
-            // Semi-transparent backdrop
             Color.black.opacity(0.75)
                 .ignoresSafeArea()
                 .onTapGesture {
@@ -280,21 +319,18 @@ struct OfficeView: View {
                     .font(.system(.headline, design: .monospaced, weight: .bold))
                     .foregroundStyle(MajorTomTheme.Colors.textSecondary)
 
-                // 2×4 grid of rooms — tap any room to navigate
                 HStack(spacing: 8) {
-                    // Column 1 (top to bottom = row 0 to row 3)
                     VStack(spacing: 4) {
-                        miniMapRoom(.commandBridge, column: 0, row: 0)
-                        miniMapRoom(.engineering, column: 0, row: 1)
-                        miniMapRoom(.crewQuarters, column: 0, row: 2)
-                        miniMapRoom(.galley, column: 0, row: 3)
+                        miniMapRoom(.commandBridge, column: 0, row: 0, scene: scene)
+                        miniMapRoom(.engineering, column: 0, row: 1, scene: scene)
+                        miniMapRoom(.crewQuarters, column: 0, row: 2, scene: scene)
+                        miniMapRoom(.galley, column: 0, row: 3, scene: scene)
                     }
-                    // Column 2
                     VStack(spacing: 4) {
-                        miniMapRoom(.bioDome, column: 1, row: 0)
-                        miniMapRoom(.arboretum, column: 1, row: 1)
-                        miniMapRoom(.trainingBay, column: 1, row: 2)
-                        miniMapRoom(.evaBay, column: 1, row: 3)
+                        miniMapRoom(.bioDome, column: 1, row: 0, scene: scene)
+                        miniMapRoom(.arboretum, column: 1, row: 1, scene: scene)
+                        miniMapRoom(.trainingBay, column: 1, row: 2, scene: scene)
+                        miniMapRoom(.evaBay, column: 1, row: 3, scene: scene)
                     }
                 }
 
@@ -306,33 +342,18 @@ struct OfficeView: View {
         .transition(.opacity)
     }
 
-    /// Camera center for showing two adjacent rows. Derives X from column,
-    /// Y from row pair midpoints using StationLayout dimensions.
     private func cameraCenter(column: Int, tappedRow: Int) -> CGPoint {
         let colX = column == 0 ? StationLayout.col1X : StationLayout.col2X
         let x = colX + StationLayout.roomWidth / 2
-
-        // Each row is roomHeight + corridorHeight. Row pair midpoint:
-        // rows N and N+1 → midY between bottom of N+1 and top of N
         let rh = StationLayout.roomHeight
         let ch = StationLayout.corridorHeight
-
-        // Tapped room becomes the top room, show it + the row below
-        // Exception: last row (3) → show rows 2+3 instead
-        let effectiveRow = min(tappedRow, 2) // Clamp so row 3 maps to pair 2+3
-
-        // Row 0 is at top (highest Y). Row pair N starts at:
-        // topY = sceneHeight - (N * (rh + ch))
-        // bottomY = topY - 2*rh - ch
-        // midY = (topY + bottomY) / 2 = topY - rh - ch/2
+        let effectiveRow = min(tappedRow, 2)
         let topOfPair = StationLayout.sceneHeight - CGFloat(effectiveRow) * (rh + ch)
         let pairY = topOfPair - rh - ch / 2
-
         return CGPoint(x: x, y: pairY)
     }
 
-    /// A single room cell in the mini-map overlay.
-    private func miniMapRoom(_ moduleType: ModuleType, column: Int, row: Int) -> some View {
+    private func miniMapRoom(_ moduleType: ModuleType, column: Int, row: Int, scene: OfficeScene) -> some View {
         return Button {
             let center = cameraCenter(column: column, tappedRow: row)
             scene.snapToCenter(center)
@@ -360,45 +381,36 @@ struct OfficeView: View {
 
     // MARK: - Scene Sync
 
-    /// Diff the current agent list against previous state and update the scene.
-    private func syncScene(with agents: [AgentState]) {
+    private func syncScene(with agents: [AgentState], viewModel: OfficeViewModel, scene: OfficeScene) {
         let currentIds = Set(agents.map(\.id))
 
-        // Add new agents
         for agent in agents where !previousAgentIds.contains(agent.id) {
             scene.addAgent(id: agent.id, name: agent.name, characterType: agent.characterType)
-
-            // Move to desk if assigned
             if let deskIndex = agent.deskIndex {
                 scene.highlightDesk(deskIndex, occupied: true)
                 scene.moveAgentToDesk(id: agent.id, deskIndex: deskIndex)
             }
         }
 
-        // Remove departed agents
         for id in previousAgentIds where !currentIds.contains(id) {
             viewModel.activityAnimator.stopPhase(for: id, furnitureNodes: scene.furnitureNodes)
             scene.removeAgent(id: id)
         }
 
-        // Update status changes
         for agent in agents {
             let previousStatus = previousStatuses[agent.id]
             if previousStatus != agent.status {
-                handleStatusChange(agent: agent, from: previousStatus)
+                handleStatusChange(agent: agent, from: previousStatus, viewModel: viewModel, scene: scene)
             }
         }
 
-        // Update tracking
         previousAgentIds = currentIds
         previousStatuses = Dictionary(uniqueKeysWithValues: agents.map { ($0.id, $0.status) })
     }
 
-    /// Handle an agent's status transition in the scene.
-    private func handleStatusChange(agent: AgentState, from previousStatus: AgentStatus?) {
+    private func handleStatusChange(agent: AgentState, from previousStatus: AgentStatus?, viewModel: OfficeViewModel, scene: OfficeScene) {
         switch agent.status {
         case .spawning:
-            // Already handled in addAgent
             break
 
         case .walking:
@@ -413,7 +425,7 @@ struct OfficeView: View {
             }
 
         case .idle:
-            assignIdleActivity(for: agent)
+            assignIdleActivity(for: agent, viewModel: viewModel, scene: scene)
 
         case .celebrating:
             scene.celebrateAgent(id: agent.id)
@@ -427,19 +439,13 @@ struct OfficeView: View {
         }
     }
 
-    /// Assign an activity to an idle agent. Idle-prefix sprites get a staggered
-    /// delay (0.5–2.5s) so they don't all start walking in the same frame.
-    private func assignIdleActivity(for agent: AgentState) {
+    private func assignIdleActivity(for agent: AgentState, viewModel: OfficeViewModel, scene: OfficeScene) {
         let isIdleSprite = agent.id.hasPrefix("idle-")
 
         let doAssign = { [viewModel, scene] in
-            // Re-verify agent still exists and is idle — staggered tasks can
-            // outlive the agent (remove/claim during the 0.5–2.5s delay would
-            // otherwise occupy furniture for a ghost sprite).
             guard let current = viewModel.agents.first(where: { $0.id == agent.id }),
                   current.status == .idle else { return }
 
-            // Stop any existing animation phase before reassigning
             viewModel.activityAnimator.stopPhase(for: agent.id, furnitureNodes: scene.furnitureNodes)
 
             let room = scene.currentRoom(for: agent.id) ?? ModuleType.crewQuarters.rawValue
@@ -476,14 +482,12 @@ struct OfficeView: View {
         }
 
         if isIdleSprite {
-            // Stagger idle sprites so they don't stampede
             let delay = Double.random(in: 0.5...2.5)
             Task { @MainActor in
                 try? await Task.sleep(for: .seconds(delay))
                 doAssign()
             }
         } else {
-            // Real agents assigned immediately
             doAssign()
         }
     }
@@ -501,5 +505,14 @@ struct OfficeView: View {
 }
 
 #Preview {
-    OfficeView(viewModel: OfficeViewModel())
+    NavigationStack {
+        OfficeView(
+            sessionId: "preview",
+            sceneManager: {
+                let mgr = OfficeSceneManager()
+                mgr.createOffice(for: "preview")
+                return mgr
+            }()
+        )
+    }
 }

--- a/ios/MajorTom/Features/Office/Views/OfficeView.swift
+++ b/ios/MajorTom/Features/Office/Views/OfficeView.swift
@@ -71,6 +71,12 @@ struct OfficeView: View {
                 .background(MajorTomTheme.Colors.background)
             }
         }
+        .task {
+            // Activate the scene at the top level so it runs regardless of which
+            // branch rendered (content vs placeholder). If the scene was LRU-evicted,
+            // this triggers a cold rebuild and populates @State so the view re-renders.
+            activatedScene = sceneManager.activateOffice(for: sessionId)
+        }
         .navigationBarTitleDisplayMode(.inline)
         .toolbar {
             ToolbarItem(placement: .principal) {
@@ -117,9 +123,6 @@ struct OfficeView: View {
             }
         }
         .onAppear {
-            // Activate the scene (cold rebuild if evicted) and store in @State.
-            // This avoids calling activateOffice from the view body (which would cause render loops).
-            activatedScene = sceneManager.activateOffice(for: sessionId)
             // Resume the SKScene update loop when the Office tab becomes visible.
             scene.isPaused = false
             // Wire theme + mood engines and furniture registry to the scene
@@ -518,7 +521,8 @@ struct OfficeView: View {
                 let mgr = OfficeSceneManager()
                 mgr.createOffice(for: "preview")
                 return mgr
-            }()
+            }(),
+            relay: nil
         )
     }
 }

--- a/ios/MajorTom/Features/Office/Views/OfficeView.swift
+++ b/ios/MajorTom/Features/Office/Views/OfficeView.swift
@@ -38,6 +38,9 @@ struct OfficeView: View {
     @State private var previousAgentIds: Set<String> = []
     @State private var previousStatuses: [String: AgentStatus] = [:]
 
+    /// Activated scene — populated in onAppear, avoids side effects in body.
+    @State private var activatedScene: OfficeScene?
+
     @Environment(\.dismiss) private var dismiss
 
     /// Resolved viewModel from the scene manager.
@@ -45,9 +48,9 @@ struct OfficeView: View {
         sceneManager.viewModel(for: sessionId)
     }
 
-    /// Resolved scene from the scene manager (triggers cold rebuild if needed).
+    /// Resolved scene — reads from @State (set in onAppear) or peeks without side effects.
     private var currentScene: OfficeScene? {
-        sceneManager.scene(for: sessionId)
+        activatedScene ?? sceneManager.peekScene(for: sessionId)
     }
 
     var body: some View {
@@ -98,7 +101,7 @@ struct OfficeView: View {
             // SpriteKit scene
             SpriteView(scene: scene)
                 .ignoresSafeArea(.all, edges: .bottom)
-                .onChange(of: viewModel.agents) { _, newAgents in
+                .onChange(of: viewModel.agents, initial: true) { _, newAgents in
                     syncScene(with: newAgents, viewModel: viewModel, scene: scene)
                 }
 
@@ -114,6 +117,9 @@ struct OfficeView: View {
             }
         }
         .onAppear {
+            // Activate the scene (cold rebuild if evicted) and store in @State.
+            // This avoids calling activateOffice from the view body (which would cause render loops).
+            activatedScene = sceneManager.activateOffice(for: sessionId)
             // Resume the SKScene update loop when the Office tab becomes visible.
             scene.isPaused = false
             // Wire theme + mood engines and furniture registry to the scene


### PR DESCRIPTION
## Summary
- **OfficeSceneManager** — `@Observable` class managing per-session `(OfficeViewModel, OfficeScene)` pairs with LRU eviction (2 warm scenes max, ~30-60MB each)
- **OfficeManagerView** — NavigationStack root for Office tab with active/unlinked session cards
- **OfficeView refactor** — now session-aware, gets viewModel/scene from OfficeSceneManager, "Close Office" toolbar button
- **RelayService routing** — all 10 `[Wave 3]` TODOs resolved, agent.* and sprite.* events route to per-session OfficeViewModels
- **MajorTomApp rewiring** — singleton officeViewModel replaced with OfficeSceneManager
- **Cold rebuild** — sends `sprite.state.request` to relay when opening a session with no cached state

## Context
Wave 3 iOS track of Sprite-Agent Wiring phase. Transforms the single-Office singleton into a multi-session Office system. Each terminal session can have its own independent Office with separate agent state, sprites, and scene.

## Architecture
```
TabView → OfficeManagerView (cards) → OfficeView(sessionId:)
                                          ↓
                                    OfficeSceneManager
                                    [sessionId: (VM, Scene)]
                                          ↓
                                    RelayService routes events
                                    by sessionId to correct VM
```

## New files
- `ios/MajorTom/Features/Office/ViewModels/OfficeSceneManager.swift`
- `ios/MajorTom/Features/Office/Views/OfficeManagerView.swift`

## Modified files
- `ios/MajorTom/Features/Office/Views/OfficeView.swift` — session-aware + Close Office
- `ios/MajorTom/Core/Services/RelayService.swift` — per-session routing
- `ios/MajorTom/App/MajorTomApp.swift` — OfficeSceneManager wiring
- `ios/MajorTom/Core/Models/Message.swift` — `SpriteStateRequestMessage`
- `ios/MajorTom/Features/Office/ViewModels/OfficeViewModel.swift` — removed Wave 3 TODO

## Test plan
- [ ] Xcode build passes clean
- [ ] Office tab shows OfficeManagerView with session cards
- [ ] Tapping unlinked session creates Office + pushes into OfficeView
- [ ] Tapping active Office card navigates to existing Office
- [ ] "Close Office" destroys scene, returns to manager, terminal unaffected
- [ ] Agent events route to correct per-session OfficeViewModel
- [ ] Sprite events (link/unlink/state) route by sessionId
- [ ] LRU eviction: 3rd warm scene evicts oldest (scene nil, VM preserved)
- [ ] Cold rebuild: re-entering evicted Office requests sprite.state from relay
- [ ] Widget/watch data helpers still resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)