### PR TITLE
fix(sprite-wiring): review round fixes -- protocol alignment, session cleanup

### DIFF
--- a/ios/MajorTom/Core/Models/Message.swift
+++ b/ios/MajorTom/Core/Models/Message.swift
@@ -768,6 +768,7 @@ struct ToolCompleteEvent: Codable {
 
 struct AgentSpawnEvent: Codable, Identifiable {
     let type: String
+    let sessionId: String
     let agentId: String
     var parentId: String?
     let task: String
@@ -778,23 +779,27 @@ struct AgentSpawnEvent: Codable, Identifiable {
 
 struct AgentWorkingEvent: Codable {
     let type: String
+    let sessionId: String
     let agentId: String
     let task: String
 }
 
 struct AgentIdleEvent: Codable {
     let type: String
+    let sessionId: String
     let agentId: String
 }
 
 struct AgentCompleteEvent: Codable {
     let type: String
+    let sessionId: String
     let agentId: String
     let result: String
 }
 
 struct AgentDismissedEvent: Codable {
     let type: String
+    let sessionId: String
     let agentId: String
 }
 

--- a/ios/MajorTom/Core/Models/Message.swift
+++ b/ios/MajorTom/Core/Models/Message.swift
@@ -824,7 +824,7 @@ struct SpriteUnlinkEvent: Codable {
     let sessionId: String
     let spriteHandle: String
     let subagentId: String
-    let reason: String  // "complete", "dismissed", "error", "crashed"
+    let reason: String  // "completed", "dismissed", "failed", "session_ended"
     var result: String?
 }
 

--- a/ios/MajorTom/Core/Services/RelayService.swift
+++ b/ios/MajorTom/Core/Services/RelayService.swift
@@ -659,6 +659,8 @@ final class RelayService {
                     currentSession = nil
                     updateWidgetData()
                 }
+                // Clean up the office entry for this session
+                officeSceneManager?.closeOffice(for: event.sessionId)
             }
 
         case .sessionListResponse:
@@ -723,59 +725,41 @@ final class RelayService {
 
         case .agentSpawn:
             if let event = try? MessageCodec.decode(AgentSpawnEvent.self, from: data) {
-                // Route to per-session OfficeViewModel — ensureViewModel auto-creates a
-                // lightweight entry so agent state accumulates even before the user opens an Office.
-                if let sid = currentSession?.id {
-                    officeSceneManager?.ensureViewModel(for: sid).handleAgentSpawn(id: event.agentId, role: event.role, task: event.task, parentId: event.parentId)
-                }
+                officeSceneManager?.ensureViewModel(for: event.sessionId).handleAgentSpawn(id: event.agentId, role: event.role, task: event.task, parentId: event.parentId)
                 notificationService?.postAgentSpawnNotification(
                     agentId: event.agentId,
                     role: event.role,
                     task: event.task
                 )
-                if let sid = currentSession?.id {
-                    liveActivityManager?.handleAgentSpawn(sessionId: sid, role: event.role)
-                }
+                liveActivityManager?.handleAgentSpawn(sessionId: event.sessionId, role: event.role)
                 updateWidgetData()
             }
 
         case .agentWorking:
             if let event = try? MessageCodec.decode(AgentWorkingEvent.self, from: data) {
-                if let sid = currentSession?.id {
-                    officeSceneManager?.ensureViewModel(for: sid).handleAgentWorking(id: event.agentId, task: event.task)
-                }
+                officeSceneManager?.ensureViewModel(for: event.sessionId).handleAgentWorking(id: event.agentId, task: event.task)
             }
 
         case .agentIdle:
             if let event = try? MessageCodec.decode(AgentIdleEvent.self, from: data) {
-                if let sid = currentSession?.id {
-                    officeSceneManager?.ensureViewModel(for: sid).handleAgentIdle(id: event.agentId)
-                }
+                officeSceneManager?.ensureViewModel(for: event.sessionId).handleAgentIdle(id: event.agentId)
             }
 
         case .agentComplete:
             if let event = try? MessageCodec.decode(AgentCompleteEvent.self, from: data) {
-                if let sid = currentSession?.id {
-                    officeSceneManager?.ensureViewModel(for: sid).handleAgentComplete(id: event.agentId, result: event.result)
-                }
+                officeSceneManager?.ensureViewModel(for: event.sessionId).handleAgentComplete(id: event.agentId, result: event.result)
                 notificationService?.postAgentCompleteNotification(
                     agentId: event.agentId,
                     result: event.result
                 )
-                if let sid = currentSession?.id {
-                    liveActivityManager?.handleAgentComplete(sessionId: sid)
-                }
+                liveActivityManager?.handleAgentComplete(sessionId: event.sessionId)
                 updateWidgetData()
             }
 
         case .agentDismissed:
             if let event = try? MessageCodec.decode(AgentDismissedEvent.self, from: data) {
-                if let sid = currentSession?.id {
-                    officeSceneManager?.ensureViewModel(for: sid).handleAgentDismissed(id: event.agentId)
-                }
-                if let sid = currentSession?.id {
-                    liveActivityManager?.handleAgentComplete(sessionId: sid)
-                }
+                officeSceneManager?.ensureViewModel(for: event.sessionId).handleAgentDismissed(id: event.agentId)
+                liveActivityManager?.handleAgentComplete(sessionId: event.sessionId)
                 updateWidgetData()
             }
 

--- a/ios/MajorTom/Features/Office/Models/AgentState.swift
+++ b/ios/MajorTom/Features/Office/Models/AgentState.swift
@@ -134,6 +134,7 @@ extension AgentState: Equatable {
         lhs.linkedSubagentId == rhs.linkedSubagentId &&
         lhs.spriteHandle == rhs.spriteHandle &&
         lhs.canonicalRole == rhs.canonicalRole &&
-        lhs.parentId == rhs.parentId
+        lhs.parentId == rhs.parentId &&
+        lhs.characterType == rhs.characterType
     }
 }

--- a/ios/MajorTom/Features/Office/ViewModels/OfficeViewModel.swift
+++ b/ios/MajorTom/Features/Office/ViewModels/OfficeViewModel.swift
@@ -308,8 +308,8 @@ final class OfficeViewModel {
             agents[existingIndex].linkedSubagentId = event.subagentId
             agents[existingIndex].canonicalRole = event.canonicalRole
             agents[existingIndex].parentId = event.parentId
-            if let task = Optional(event.task), !task.isEmpty {
-                agents[existingIndex].currentTask = task
+            if !event.task.isEmpty {
+                agents[existingIndex].currentTask = event.task
             }
             return
         }

--- a/ios/MajorTom/Features/Office/ViewModels/OfficeViewModel.swift
+++ b/ios/MajorTom/Features/Office/ViewModels/OfficeViewModel.swift
@@ -358,7 +358,7 @@ final class OfficeViewModel {
         let agentId = agents[index].id
 
         switch event.reason {
-        case "complete":
+        case "completed":
             agents[index].status = .celebrating
             agents[index].currentTask = event.result
             moodEngine.recordCompletion(agentId)
@@ -372,7 +372,7 @@ final class OfficeViewModel {
                 removeAgent(id: agentId)
             }
 
-        case "error", "crashed":
+        case "failed":
             agents[index].status = .leaving
             agents[index].currentTask = event.result ?? "Error"
             moodEngine.recordError(agentId)

--- a/ios/MajorTom/Features/Office/Views/OfficeManagerView.swift
+++ b/ios/MajorTom/Features/Office/Views/OfficeManagerView.swift
@@ -97,7 +97,7 @@ struct OfficeManagerView: View {
     // MARK: - Active Office Card
 
     private func activeOfficeCard(session: SessionMetaInfo) -> some View {
-        let agentCount = sceneManager.viewModel(for: session.id)?.agents.count ?? 0
+        let agentCount = sceneManager.viewModel(for: session.id)?.agents.filter { !$0.id.hasPrefix("idle-") }.count ?? 0
 
         return Button {
             HapticService.selection()

--- a/ios/MajorTom/Features/Office/Views/OfficeManagerView.swift
+++ b/ios/MajorTom/Features/Office/Views/OfficeManagerView.swift
@@ -97,7 +97,7 @@ struct OfficeManagerView: View {
     // MARK: - Active Office Card
 
     private func activeOfficeCard(session: SessionMetaInfo) -> some View {
-        let agentCount = sceneManager.viewModel(for: session.id)?.agents.filter { !$0.id.hasPrefix("idle-") }.count ?? 0
+        let agentCount = sceneManager.viewModel(for: session.id)?.agents.filter { $0.linkedSubagentId != nil }.count ?? 0
 
         return Button {
             HapticService.selection()

--- a/relay/src/fleet/ipc-messages.ts
+++ b/relay/src/fleet/ipc-messages.ts
@@ -72,7 +72,7 @@ export interface IpcSpriteMessage {
   type: 'ipc:sprite.message';
   sessionId: string;
   spriteHandle: string;
-  agentId: string;
+  subagentId: string;
   text: string;
   messageId: string;
 }
@@ -86,7 +86,8 @@ export type ParentToChildMessage =
   | IpcAgentMessage
   | IpcContextAdd
   | IpcContextRemove
-  | IpcPermissionMode;
+  | IpcPermissionMode
+  | IpcSpriteMessage;
 
 // ── Child → Parent Messages ────────────────────────────────
 
@@ -225,5 +226,6 @@ export function isParentToChildMessage(msg: unknown): msg is ParentToChildMessag
     'ipc:context.add',
     'ipc:context.remove',
     'ipc:permission.mode',
+    'ipc:sprite.message',
   ].includes(typed.type);
 }

--- a/relay/src/protocol/messages.ts
+++ b/relay/src/protocol/messages.ts
@@ -472,7 +472,7 @@ export interface SpriteMessageMessage {
   type: 'sprite.message';
   sessionId: string;
   spriteHandle: string;
-  agentId: string;
+  subagentId: string;
   text: string;
   messageId: string;
 }
@@ -1118,9 +1118,12 @@ export interface GitErrorResponseMessage {
 
 export interface SpriteMappingEntry {
   spriteHandle: string;
-  agentId: string;
-  role: string;
+  subagentId: string;
+  canonicalRole: string;
   characterType: string;
+  task: string;
+  parentId?: string;
+  status?: string;
   deskIndex?: number;
   linkedAt: string;
 }
@@ -1129,9 +1132,11 @@ export interface SpriteLinkMessage {
   type: 'sprite.link';
   sessionId: string;
   spriteHandle: string;
-  agentId: string;
-  role: string;
+  subagentId: string;
+  canonicalRole: string;
   characterType: string;
+  task: string;
+  parentId?: string;
   deskIndex?: number;
 }
 
@@ -1139,15 +1144,15 @@ export interface SpriteUnlinkMessage {
   type: 'sprite.unlink';
   sessionId: string;
   spriteHandle: string;
-  agentId: string;
-  reason: 'complete' | 'dismissed' | 'error' | 'session_ended';
+  subagentId: string;
+  reason: 'completed' | 'dismissed' | 'failed' | 'session_ended';
 }
 
 export interface SpriteResponseMessage {
   type: 'sprite.response';
   sessionId: string;
   spriteHandle: string;
-  agentId: string;
+  subagentId: string;
   messageId: string;
   text: string;
   status: 'delivered' | 'queued' | 'dropped';

--- a/relay/src/protocol/messages.ts
+++ b/relay/src/protocol/messages.ts
@@ -1123,7 +1123,7 @@ export interface SpriteMappingEntry {
   characterType: string;
   task: string;
   parentId?: string;
-  status?: string;
+  status: 'working' | 'idle' | 'spawning';
   deskIndex?: number;
   linkedAt: string;
 }

--- a/relay/src/routes/ws.ts
+++ b/relay/src/routes/ws.ts
@@ -202,12 +202,17 @@ export function createWsRoute(deps: WsDeps): FastifyPluginAsync {
   // ── Sprite mapping wire-format helper ────────────────────
   /** Convert persisted mapping to wire-format SpriteMappingEntry. */
   function toWireMapping(m: PersistedSpriteMapping): SpriteMappingEntry {
+    // Look up live status from agent tracker; fall back to 'working' for persisted-only mappings
+    const liveAgent = agentTracker.get(m.subagentId);
+    const status = liveAgent?.status === 'idle' ? 'idle' : liveAgent?.status === 'spawned' ? 'spawning' : 'working';
     return {
       spriteHandle: m.spriteHandle,
       subagentId: m.subagentId,
       canonicalRole: m.canonicalRole,
       characterType: m.characterType,
-      task: '',
+      task: m.task,
+      parentId: m.parentId,
+      status,
       ...(m.deskIndex !== undefined && m.deskIndex >= 0 ? { deskIndex: m.deskIndex } : {}),
       linkedAt: m.linkedAt,
     };
@@ -625,8 +630,6 @@ export function createWsRoute(deps: WsDeps): FastifyPluginAsync {
           }
         }
 
-        sessionClients.delete(message.sessionId);
-
         const session = sessionManager.tryGet(message.sessionId);
         if (session) {
           // Record session end in analytics
@@ -650,13 +653,15 @@ export function createWsRoute(deps: WsDeps): FastifyPluginAsync {
           fleetManager.destroySession(message.sessionId);
         }
         healthMonitor.untrackSession(message.sessionId);
-        // Broadcast BEFORE removing buffer — broadcastToSession() records events by sessionId,
-        // so removing first would recreate a fresh (leaked) buffer for this session.
+        // Broadcast BEFORE removing clients or buffer — broadcastToSession() needs
+        // sessionClients to deliver, and eventBuffer to record.
         broadcastToSession(message.sessionId, { type: 'session.ended', sessionId: message.sessionId });
         eventBuffer.removeSession(message.sessionId);
         // Delete sprite state (unlinks already emitted above)
         spriteMappings.delete(message.sessionId);
         void spriteMappingPersistence.delete(message.sessionId);
+        // Remove client tracking LAST — after all session-scoped broadcasts
+        sessionClients.delete(message.sessionId);
         break;
       }
 
@@ -1873,6 +1878,7 @@ export function createWsRoute(deps: WsDeps): FastifyPluginAsync {
             event.task ?? '',
             spriteState.roleBindings,
             spriteState.mappings,
+            event.parentId,
           );
           // Lock role binding if this is a new one
           if (isNewBinding) {
@@ -1907,7 +1913,7 @@ export function createWsRoute(deps: WsDeps): FastifyPluginAsync {
           agentTracker.complete(event.agentId, event.result ?? '');
           broadcastToAll({ type: 'agent.complete', sessionId: sid, agentId: event.agentId, result: event.result ?? '' });
 
-          // ── Sprite wiring: remove mapping + emit sprite.unlink ���─
+          // ── Sprite wiring: remove mapping + emit sprite.unlink ──
           const completeState = spriteMappings.get(sid);
           if (completeState) {
             const idx = completeState.mappings.findIndex(m => m.subagentId === event.agentId);

--- a/relay/src/routes/ws.ts
+++ b/relay/src/routes/ws.ts
@@ -204,9 +204,10 @@ export function createWsRoute(deps: WsDeps): FastifyPluginAsync {
   function toWireMapping(m: PersistedSpriteMapping): SpriteMappingEntry {
     return {
       spriteHandle: m.spriteHandle,
-      agentId: m.agentId,
-      role: m.role,
+      subagentId: m.subagentId,
+      canonicalRole: m.canonicalRole,
       characterType: m.characterType,
+      task: '',
       ...(m.deskIndex !== undefined && m.deskIndex >= 0 ? { deskIndex: m.deskIndex } : {}),
       linkedAt: m.linkedAt,
     };
@@ -608,6 +609,22 @@ export function createWsRoute(deps: WsDeps): FastifyPluginAsync {
           clearTimeout(endTimeout);
           sessionTimeouts.delete(message.sessionId);
         }
+
+        // ── Sprite cleanup: emit unlink for remaining mappings, then delete ──
+        // Must happen BEFORE sessionClients.delete so broadcastToSession reaches clients.
+        const endSpriteState = spriteMappings.get(message.sessionId);
+        if (endSpriteState) {
+          for (const mapping of endSpriteState.mappings) {
+            broadcastToSession(message.sessionId, {
+              type: 'sprite.unlink',
+              sessionId: message.sessionId,
+              spriteHandle: mapping.spriteHandle,
+              subagentId: mapping.subagentId,
+              reason: 'session_ended',
+            });
+          }
+        }
+
         sessionClients.delete(message.sessionId);
 
         const session = sessionManager.tryGet(message.sessionId);
@@ -637,7 +654,7 @@ export function createWsRoute(deps: WsDeps): FastifyPluginAsync {
         // so removing first would recreate a fresh (leaked) buffer for this session.
         broadcastToSession(message.sessionId, { type: 'session.ended', sessionId: message.sessionId });
         eventBuffer.removeSession(message.sessionId);
-        // ── Sprite cleanup: delete mapping file when session ends ──
+        // Delete sprite state (unlinks already emitted above)
         spriteMappings.delete(message.sessionId);
         void spriteMappingPersistence.delete(message.sessionId);
         break;
@@ -894,7 +911,7 @@ export function createWsRoute(deps: WsDeps): FastifyPluginAsync {
         // Validate the sprite mapping exists for this agent
         const spriteState = spriteMappings.get(message.sessionId);
         const mapping = spriteState?.mappings.find(m =>
-          m.agentId === message.agentId && m.spriteHandle === message.spriteHandle
+          m.subagentId === message.subagentId && m.spriteHandle === message.spriteHandle
         );
         if (!mapping) {
           // Agent may have completed before message arrived (scenario #4 from spec)
@@ -902,7 +919,7 @@ export function createWsRoute(deps: WsDeps): FastifyPluginAsync {
             type: 'sprite.response',
             sessionId: message.sessionId,
             spriteHandle: message.spriteHandle,
-            agentId: message.agentId,
+            subagentId: message.subagentId,
             messageId: message.messageId,
             text: '',
             status: 'dropped',
@@ -916,13 +933,13 @@ export function createWsRoute(deps: WsDeps): FastifyPluginAsync {
           type: 'sprite.response',
           sessionId: message.sessionId,
           spriteHandle: message.spriteHandle,
-          agentId: message.agentId,
+          subagentId: message.subagentId,
           messageId: message.messageId,
           text: '',
           status: 'queued',
         });
         logger.info(
-          { sessionId: message.sessionId, agentId: message.agentId, spriteHandle: message.spriteHandle },
+          { sessionId: message.sessionId, subagentId: message.subagentId, spriteHandle: message.spriteHandle },
           'Sprite message received — queued for Wave 4 delivery',
         );
         break;
@@ -1869,9 +1886,11 @@ export function createWsRoute(deps: WsDeps): FastifyPluginAsync {
             type: 'sprite.link',
             sessionId: sid,
             spriteHandle: mapping.spriteHandle,
-            agentId: event.agentId,
-            role: mapping.role,
+            subagentId: event.agentId,
+            canonicalRole: mapping.canonicalRole,
             characterType: mapping.characterType,
+            task: event.task ?? '',
+            parentId: event.parentId,
             deskIndex: mapping.deskIndex >= 0 ? mapping.deskIndex : undefined,
           });
           break;
@@ -1891,7 +1910,7 @@ export function createWsRoute(deps: WsDeps): FastifyPluginAsync {
           // ── Sprite wiring: remove mapping + emit sprite.unlink ���─
           const completeState = spriteMappings.get(sid);
           if (completeState) {
-            const idx = completeState.mappings.findIndex(m => m.agentId === event.agentId);
+            const idx = completeState.mappings.findIndex(m => m.subagentId === event.agentId);
             const removed = idx >= 0 ? completeState.mappings[idx] : undefined;
             if (removed) {
               completeState.mappings.splice(idx, 1);
@@ -1901,8 +1920,8 @@ export function createWsRoute(deps: WsDeps): FastifyPluginAsync {
                 type: 'sprite.unlink',
                 sessionId: sid,
                 spriteHandle: removed.spriteHandle,
-                agentId: event.agentId,
-                reason: 'complete',
+                subagentId: event.agentId,
+                reason: 'completed',
               });
             }
           }
@@ -1915,7 +1934,7 @@ export function createWsRoute(deps: WsDeps): FastifyPluginAsync {
           // ── Sprite wiring: remove mapping + emit sprite.unlink ──
           const dismissState = spriteMappings.get(sid);
           if (dismissState) {
-            const idx = dismissState.mappings.findIndex(m => m.agentId === event.agentId);
+            const idx = dismissState.mappings.findIndex(m => m.subagentId === event.agentId);
             const removed = idx >= 0 ? dismissState.mappings[idx] : undefined;
             if (removed) {
               dismissState.mappings.splice(idx, 1);
@@ -1925,7 +1944,7 @@ export function createWsRoute(deps: WsDeps): FastifyPluginAsync {
                 type: 'sprite.unlink',
                 sessionId: sid,
                 spriteHandle: removed.spriteHandle,
-                agentId: event.agentId,
+                subagentId: event.agentId,
                 reason: 'dismissed',
               });
             }

--- a/relay/src/sprites/sprite-mapper.ts
+++ b/relay/src/sprites/sprite-mapper.ts
@@ -34,14 +34,14 @@ export type CanonicalRole = typeof CANONICAL_ROLES[number];
 // Dogs are NEVER used as agent sprites.
 
 const ROLE_CHARACTER_MAP: Record<CanonicalRole, string> = {
-  researcher: 'scientist',
-  architect: 'architect',
-  qa: 'inspector',
+  researcher: 'botanist',
+  architect: 'captain',
+  qa: 'doctor',
   devops: 'mechanic',
   frontend: 'frontendDev',
-  backend: 'backendDev',
-  lead: 'teamLead',
-  engineer: 'engineer',
+  backend: 'backendEngineer',
+  lead: 'pm',
+  engineer: 'claudimusPrime',
 };
 
 // ── Role classification regex patterns ─────────────────────
@@ -142,15 +142,15 @@ export class SpriteMapper {
 
     const mapping: PersistedSpriteMapping = {
       spriteHandle,
-      agentId,
-      role,
+      subagentId: agentId,
+      canonicalRole: role,
       characterType,
       deskIndex,
       linkedAt: new Date().toISOString(),
     };
 
     logger.info(
-      { agentId, role, characterType, deskIndex, spriteHandle, isNewBinding: isNew },
+      { subagentId: agentId, canonicalRole: role, characterType, deskIndex, spriteHandle, isNewBinding: isNew },
       'Sprite mapping created',
     );
 
@@ -167,7 +167,6 @@ export class SpriteMapper {
       updatedAt: new Date().toISOString(),
       roleBindings: {},
       mappings: [],
-      nextDeskIndex: 0,
     };
   }
 }

--- a/relay/src/sprites/sprite-mapper.ts
+++ b/relay/src/sprites/sprite-mapper.ts
@@ -134,6 +134,7 @@ export class SpriteMapper {
     task: string,
     sessionBindings: Record<string, string>,
     currentMappings: PersistedSpriteMapping[],
+    parentId?: string,
   ): { mapping: PersistedSpriteMapping; role: CanonicalRole; isNewBinding: boolean } {
     const role = this.classifyRole(task);
     const { characterType, isNew } = this.resolveCharacterType(role, sessionBindings);
@@ -145,6 +146,8 @@ export class SpriteMapper {
       subagentId: agentId,
       canonicalRole: role,
       characterType,
+      task,
+      parentId,
       deskIndex,
       linkedAt: new Date().toISOString(),
     };

--- a/relay/src/sprites/sprite-mapping-persistence.ts
+++ b/relay/src/sprites/sprite-mapping-persistence.ts
@@ -10,8 +10,8 @@ import { logger } from '../utils/logger.js';
 
 export interface PersistedSpriteMapping {
   spriteHandle: string;
-  agentId: string;
-  role: string;
+  subagentId: string;
+  canonicalRole: string;
   characterType: string;
   deskIndex: number;
   linkedAt: string;
@@ -23,7 +23,6 @@ export interface PersistedSpriteMappingFile {
   updatedAt: string;
   roleBindings: Record<string, string>;
   mappings: PersistedSpriteMapping[];
-  nextDeskIndex: number;
 }
 
 // ── Constants ──────────────────────────────────────────────

--- a/relay/src/sprites/sprite-mapping-persistence.ts
+++ b/relay/src/sprites/sprite-mapping-persistence.ts
@@ -13,6 +13,8 @@ export interface PersistedSpriteMapping {
   subagentId: string;
   canonicalRole: string;
   characterType: string;
+  task: string;
+  parentId?: string;
   deskIndex: number;
   linkedAt: string;
 }

--- a/relay/src/sprites/sprite-mapping-persistence.ts
+++ b/relay/src/sprites/sprite-mapping-persistence.ts
@@ -101,6 +101,19 @@ export class SpriteMappingPersistence {
         logger.warn({ sessionId }, 'Sprite mapping file has invalid schema — ignoring');
         return null;
       }
+      // Migrate old field names (agentId→subagentId, role→canonicalRole) + supply defaults
+      for (const m of parsed.mappings) {
+        const raw = m as unknown as Record<string, unknown>;
+        if (raw['agentId'] && !raw['subagentId']) {
+          raw['subagentId'] = raw['agentId'];
+          delete raw['agentId'];
+        }
+        if (raw['role'] && !raw['canonicalRole']) {
+          raw['canonicalRole'] = raw['role'];
+          delete raw['role'];
+        }
+        if (!raw['task']) raw['task'] = '';
+      }
       return parsed;
     } catch {
       return null;


### PR DESCRIPTION
## Summary

Review round audit of Sprite-Agent Wiring Waves 1-3 found a **critical protocol mismatch** plus several high/medium issues. This PR fixes them all.

### Critical: Protocol field name alignment (relay <-> iOS)
- Relay sent agentId/role, iOS expected subagentId/canonicalRole -- every sprite.link, sprite.unlink, and sprite.state event was **silently dropped** by iOS Codable decode
- Renamed all relay sprite interfaces and emit sites to match iOS naming
- Added missing task, parentId, status fields to SpriteMappingEntry and SpriteLinkMessage

### High: ROLE_CHARACTER_MAP corrected
- 6/8 relay character type strings did not match iOS CharacterType enum raw values
- Fixed: scientist->botanist, architect->captain, inspector->doctor, backendDev->backendEngineer, teamLead->pm, engineer->claudimusPrime

### High: session.end now emits sprite.unlink for remaining mappings
- Previously sprites silently vanished when sessions ended
- Now emits sprite.unlink(reason: session_ended) for each remaining mapping before sessionClients.delete

### High: Agent event routing uses event.sessionId (multi-session fix)
- Added sessionId to all 5 iOS agent event structs
- Routing now uses event.sessionId instead of currentSession?.id

### Medium fixes
- SpriteUnlinkMessage.reason: complete->completed, error->failed (spec alignment)
- AgentState.Equatable: now includes characterType comparison
- Session-end cleanup: closeOffice(for:) called to prevent orphaned entries
- IpcSpriteMessage added to ParentToChildMessage union (Wave 4 prep)
- Agent count in OfficeManagerView filters out idle sprites
- Removed Optional(event.task) no-op wrapper
- Removed dead nextDeskIndex field

## Test plan
- [ ] Relay TypeScript compiles clean (tsc --noEmit)
- [ ] iOS Xcode build succeeds
- [ ] Start relay + iOS, spawn agents -- verify sprite.link events arrive (previously silently dropped)
- [ ] Verify sprites show correct character types matching role
- [ ] End session -- verify sprite.unlink(session_ended) events fire
- [ ] Multi-session: spawn agents in Terminal 1 while viewing Terminal 2 -- agents should appear in correct Office