### PR TITLE
feat(ios): sprite /btw modal + dogs + idle inspector (Wave 4)

### DIFF
--- a/ios/MajorTom.xcodeproj/project.pbxproj
+++ b/ios/MajorTom.xcodeproj/project.pbxproj
@@ -29,6 +29,10 @@
 		2211645B8B3E1BF5093FE2CD /* MoodEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 579C4AF5EF7599467490F248 /* MoodEngine.swift */; };
 		3A1B2C4D5E6F78901234ABCD /* CrewRoster.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B7C8D9E0F1A23456789BCDE /* CrewRoster.swift */; };
 		87DD0EFFCB5F38F604D8E89D /* RoleMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35CE152195BD660297FCDF44 /* RoleMapper.swift */; };
+		6FAAD79E27E62840B5B1C665 /* DogCannedResponses.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACBC098BB389E8F292B2EFC7 /* DogCannedResponses.swift */; };
+		E2515F6B841E4F68C14D0419 /* SpriteMessagingState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 433F8F4160504FECAA91BBC2 /* SpriteMessagingState.swift */; };
+		C113A701F7910BAD57011D40 /* SpriteInspectorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B96D3B2D8FF01E0187FC3DD /* SpriteInspectorView.swift */; };
+		78DC1DD071D269A3B9774687 /* SpriteResponseBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D425503318D6BF8ED3144A3 /* SpriteResponseBanner.swift */; };
 		4C3D2E1F0A9B87654321FEDC /* CrewPickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D8E9F0A1B2C34567890ABCD /* CrewPickerView.swift */; };
 		22A50E5C5D84EFE896C415FF /* KeybarCustomizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D14F27776863DA81864B0F1 /* KeybarCustomizer.swift */; };
 		236F9F1B1379B823DB4FD5DB /* MajorTomWidgetsBundle.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCBDA7E064D0179C4FD35A17 /* MajorTomWidgetsBundle.swift */; };
@@ -296,6 +300,10 @@
 		689B672DDD255A39492A755E /* TerminalViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalViewModel.swift; sourceTree = "<group>"; };
 		696B3D1600947ADCE81C436C /* StatusGlanceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusGlanceView.swift; sourceTree = "<group>"; };
 		6A6B155FB1E10E586EFA12AC /* AgentInspectorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentInspectorView.swift; sourceTree = "<group>"; };
+		ACBC098BB389E8F292B2EFC7 /* DogCannedResponses.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DogCannedResponses.swift; sourceTree = "<group>"; };
+		433F8F4160504FECAA91BBC2 /* SpriteMessagingState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpriteMessagingState.swift; sourceTree = "<group>"; };
+		0B96D3B2D8FF01E0187FC3DD /* SpriteInspectorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpriteInspectorView.swift; sourceTree = "<group>"; };
+		3D425503318D6BF8ED3144A3 /* SpriteResponseBanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpriteResponseBanner.swift; sourceTree = "<group>"; };
 		6C4FC6C7F8AA0ACAD27D5D54 /* DirectoryPermissionsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DirectoryPermissionsView.swift; sourceTree = "<group>"; };
 		6D14F27776863DA81864B0F1 /* KeybarCustomizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeybarCustomizer.swift; sourceTree = "<group>"; };
 		6DA07545B6E9F73EED9477FB /* SessionStatusWidget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionStatusWidget.swift; sourceTree = "<group>"; };
@@ -819,10 +827,12 @@
 				49975C50EF000FB470E30360 /* CharacterConfig.swift */,
 				282E1D5B477D7DEE32C76B4B /* FurnitureRegistry.swift */,
 				6B7C8D9E0F1A23456789BCDE /* CrewRoster.swift */,
+				ACBC098BB389E8F292B2EFC7 /* DogCannedResponses.swift */,
 				579C4AF5EF7599467490F248 /* MoodEngine.swift */,
 				35CE152195BD660297FCDF44 /* RoleMapper.swift */,
 				B2A5F6ECD6AEA9681C140DA3 /* OfficeLayout.swift */,
 				BB2C3D4E5F6A7B8C9D0E1F2A /* StationLayout.swift */,
+				433F8F4160504FECAA91BBC2 /* SpriteMessagingState.swift */,
 				765796A3C1DAD173DB56A1CC /* ThemeEngine.swift */,
 				BB1C2D3E4F607182939D0E1A /* WaypointPathfinder.swift */,
 			);
@@ -1096,6 +1106,8 @@
 				7D8E9F0A1B2C34567890ABCD /* CrewPickerView.swift */,
 				BD5008821EC7350E4B0F1BCB /* OfficeManagerView.swift */,
 				BD500881DC6249D63A9E0ACA /* OfficeView.swift */,
+				0B96D3B2D8FF01E0187FC3DD /* SpriteInspectorView.swift */,
+				3D425503318D6BF8ED3144A3 /* SpriteResponseBanner.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -1710,6 +1722,10 @@
 				9F2F95450060416CA67BA3FB /* OfficeView.swift in Sources */,
 				1ECF57AE2993044ECCF73DC6 /* OfficeSceneManager.swift in Sources */,
 				1ECF57AD1993033DCCF73DB5 /* OfficeViewModel.swift in Sources */,
+				6FAAD79E27E62840B5B1C665 /* DogCannedResponses.swift in Sources */,
+				E2515F6B841E4F68C14D0419 /* SpriteMessagingState.swift in Sources */,
+				C113A701F7910BAD57011D40 /* SpriteInspectorView.swift in Sources */,
+				78DC1DD071D269A3B9774687 /* SpriteResponseBanner.swift in Sources */,
 				3320719E65C7D12EC787C929 /* PairingView.swift in Sources */,
 				818FA51F81C18CFE08B3C097 /* PairingViewModel.swift in Sources */,
 				105DA16D4A98B26952BC1756 /* PermissionModeView.swift in Sources */,

--- a/ios/MajorTom/App/MajorTomApp.swift
+++ b/ios/MajorTom/App/MajorTomApp.swift
@@ -69,6 +69,13 @@ struct MajorTomApp: App {
                     }
                 }
             }
+            // Wave 4: flush queued /btw messages when the relay reconnects so
+            // any messages sent offline are delivered without user action.
+            .onChange(of: relay.connectionState) { _, newState in
+                if newState == .connected {
+                    relay.flushAllQueuedSpriteMessages()
+                }
+            }
             // Handle deep links from notifications
             .onChange(of: notificationService.pendingDeepLink) { _, deepLink in
                 guard let deepLink else { return }

--- a/ios/MajorTom/Core/Models/Message.swift
+++ b/ios/MajorTom/Core/Models/Message.swift
@@ -52,6 +52,7 @@ enum MessageType: String, Codable {
     case ciRuns = "ci.runs"
     case ciRunDetail = "ci.run.detail"
     case spriteStateRequest = "sprite.state.request"
+    case spriteMessage = "sprite.message"
 
     // Server → Client
     case output
@@ -120,6 +121,7 @@ enum MessageType: String, Codable {
     case spriteLink = "sprite.link"
     case spriteUnlink = "sprite.unlink"
     case spriteState = "sprite.state"
+    case spriteResponse = "sprite.response"
 
     case error
 }
@@ -850,6 +852,33 @@ struct SpriteStateEvent: Codable {
 struct SpriteStateRequestMessage: Codable {
     let type: String = "sprite.state.request"
     let sessionId: String
+}
+
+/// iOS → Relay: send a `/btw` observation to a linked sprite.
+/// Relay queues for the next subagent turn boundary, answers with
+/// `sprite.response` (`delivered`/`queued`/`dropped`).
+struct SpriteMessageMessage: Codable {
+    let type: String = "sprite.message"
+    let sessionId: String
+    let spriteHandle: String
+    let subagentId: String
+    let text: String
+    let messageId: String
+}
+
+/// Relay → iOS: response to a previously-sent `sprite.message`.
+/// - `delivered`: subagent replied; `text` is the reply body.
+/// - `queued`: accepted but not yet delivered (informational).
+/// - `dropped`: subagent completed/failed before delivery (`dropReason` optional).
+struct SpriteResponseEvent: Codable {
+    let type: String
+    let sessionId: String
+    let spriteHandle: String
+    let subagentId: String
+    let messageId: String
+    let text: String
+    let status: String  // "delivered" | "queued" | "dropped"
+    var dropReason: String?
 }
 
 struct ConnectionStatusEvent: Codable {

--- a/ios/MajorTom/Core/Services/RelayService.swift
+++ b/ios/MajorTom/Core/Services/RelayService.swift
@@ -302,6 +302,52 @@ final class RelayService {
         }
     }
 
+    // MARK: - Sprite Messaging (Wave 4)
+
+    /// Send a queued `/btw` sprite message to the relay.
+    func sendSpriteMessage(_ message: QueuedSpriteMessage) async {
+        let wire = SpriteMessageMessage(
+            sessionId: message.sessionId,
+            spriteHandle: message.spriteHandle,
+            subagentId: message.subagentId,
+            text: message.text,
+            messageId: message.id
+        )
+        try? await webSocket.send(wire)
+    }
+
+    /// Flush queued sprite messages for a session. Safe to call multiple
+    /// times — drain is atomic per session.
+    func flushQueuedSpriteMessages(for sessionId: String) {
+        guard let vm = officeSceneManager?.viewModel(for: sessionId) else { return }
+        let queued = vm.drainQueuedSpriteMessages()
+        guard !queued.isEmpty else { return }
+        Task {
+            for message in queued {
+                await sendSpriteMessage(message)
+            }
+        }
+    }
+
+    /// Flush queued messages across every active session (post-reconnect).
+    func flushAllQueuedSpriteMessages() {
+        guard let manager = officeSceneManager else { return }
+        for sessionId in manager.offices.keys {
+            flushQueuedSpriteMessages(for: sessionId)
+        }
+    }
+
+    /// Short preview of a `/btw` response for the cross-session banner.
+    /// Trims whitespace, drops newlines, truncates to 60 chars.
+    private func bannerPreview(_ text: String) -> String {
+        let cleaned = text
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .replacingOccurrences(of: "\n", with: " ")
+        if cleaned.count <= 60 { return cleaned }
+        let idx = cleaned.index(cleaned.startIndex, offsetBy: 57)
+        return String(cleaned[..<idx]) + "…"
+    }
+
     // MARK: - Workspace & Context
 
     func requestWorkspaceTree(path: String? = nil) async throws {
@@ -1128,6 +1174,38 @@ final class RelayService {
         case .spriteState:
             if let event = try? MessageCodec.decode(SpriteStateEvent.self, from: data) {
                 officeSceneManager?.ensureViewModel(for: event.sessionId).handleSpriteState(event)
+            }
+
+        case .spriteResponse:
+            if let event = try? MessageCodec.decode(SpriteResponseEvent.self, from: data) {
+                let vm = officeSceneManager?.ensureViewModel(for: event.sessionId)
+                vm?.handleSpriteResponse(event)
+
+                // Only `delivered`/`dropped` affect UI; `queued` is informational.
+                if event.status == "delivered" || event.status == "dropped" {
+                    if currentSession?.id == event.sessionId {
+                        HapticService.notification(.success)
+                    } else {
+                        // Cross-session (M2) — show banner unless the inspector
+                        // for this sprite is open elsewhere (can't happen in
+                        // our single-open-inspector model, so we just surface).
+                        let sessionName = sessionList
+                            .first(where: { $0.id == event.sessionId })?.workingDirName
+                            ?? "Terminal"
+                        let spriteId = vm?.agents.first(where: {
+                            $0.linkedSubagentId == event.subagentId
+                        })?.id ?? event.subagentId
+                        let spriteName = vm?.agents.first(where: { $0.id == spriteId })?.name
+                            ?? (event.subagentId.prefix(8) + "…")
+                        officeSceneManager?.showCrossSessionBanner(
+                            sessionId: event.sessionId,
+                            sessionName: sessionName,
+                            spriteId: spriteId,
+                            spriteName: String(spriteName),
+                            preview: bannerPreview(event.text)
+                        )
+                    }
+                }
             }
 
         case .error:

--- a/ios/MajorTom/Core/Services/RelayService.swift
+++ b/ios/MajorTom/Core/Services/RelayService.swift
@@ -1209,7 +1209,7 @@ final class RelayService {
                             $0.linkedSubagentId == event.subagentId
                         })?.id ?? event.subagentId
                         let spriteName = vm?.agents.first(where: { $0.id == spriteId })?.name
-                            ?? (event.subagentId.prefix(8) + "…")
+                            ?? "\(event.subagentId.prefix(8))…"
                         // Dropped responses have empty `text` on the wire — use the
                         // synthesized text (matches OfficeViewModel.handleSpriteResponse)
                         // so the banner preview isn't empty/misleading.

--- a/ios/MajorTom/Core/Services/RelayService.swift
+++ b/ios/MajorTom/Core/Services/RelayService.swift
@@ -305,6 +305,9 @@ final class RelayService {
     // MARK: - Sprite Messaging (Wave 4)
 
     /// Send a queued `/btw` sprite message to the relay.
+    /// On WebSocket send failure, re-enqueue into the session's local pending
+    /// queue so the next reconnect flush can retry — otherwise the sprite UI
+    /// stays stuck in `.pending` forever.
     func sendSpriteMessage(_ message: QueuedSpriteMessage) async {
         let wire = SpriteMessageMessage(
             sessionId: message.sessionId,
@@ -313,7 +316,17 @@ final class RelayService {
             text: message.text,
             messageId: message.id
         )
-        try? await webSocket.send(wire)
+        do {
+            try await webSocket.send(wire)
+        } catch {
+            // Send failed (socket closed mid-send, I/O error, etc.). Re-enqueue
+            // so the reconnect flush retries. Guard against duplicate enqueue
+            // in case it was already persisted by the offline path.
+            if let vm = officeSceneManager?.viewModel(for: message.sessionId),
+               !vm.queuedSpriteMessages.contains(where: { $0.id == message.id }) {
+                vm.queuedSpriteMessages.append(message)
+            }
+        }
     }
 
     /// Flush queued sprite messages for a session. Safe to call multiple
@@ -1197,12 +1210,19 @@ final class RelayService {
                         })?.id ?? event.subagentId
                         let spriteName = vm?.agents.first(where: { $0.id == spriteId })?.name
                             ?? (event.subagentId.prefix(8) + "…")
+                        // Dropped responses have empty `text` on the wire — use the
+                        // synthesized text (matches OfficeViewModel.handleSpriteResponse)
+                        // so the banner preview isn't empty/misleading.
+                        let previewSource: String = event.status == "dropped"
+                            ? (event.dropReason.map { "(Agent completed before delivery — \($0))" }
+                                ?? "(Agent completed before delivery)")
+                            : event.text
                         officeSceneManager?.showCrossSessionBanner(
                             sessionId: event.sessionId,
                             sessionName: sessionName,
                             spriteId: spriteId,
                             spriteName: String(spriteName),
-                            preview: bannerPreview(event.text)
+                            preview: bannerPreview(previewSource)
                         )
                     }
                 }

--- a/ios/MajorTom/Features/Office/Models/DogCannedResponses.swift
+++ b/ios/MajorTom/Features/Office/Models/DogCannedResponses.swift
@@ -1,0 +1,86 @@
+import Foundation
+
+// MARK: - Dog Canned Responses
+//
+// Client-side canned responses for dog sprites. Dogs never round-trip to the
+// relay — when the user sends them a message, we synthesize a reply from a
+// shared pool plus a character-specific pool.
+//
+// Future: Steve/Esteban and Elvis/Senor become outfit variants of the same
+// dog (wardrobe system). Until then, they share per-character pools.
+enum DogCannedResponses {
+
+    /// Pool shared across every dog.
+    static let shared: [String] = [
+        "*tail wagging intensifies*",
+        "*tilts head*",
+        "woof.",
+        "*rolls over for belly rubs*",
+        "*stares at you, then at the treat jar*",
+        "bork bork bork",
+    ]
+
+    /// Per-character pools — sampled alongside `shared` to add personality.
+    /// Dachshunds (elvis/senor), cattle dogs (steve/esteban), schnauzers
+    /// (kai/hoku), robot (zuckerbot).
+    static let perCharacter: [CharacterType: [String]] = [
+        // Cattle dogs
+        .steve: cattleDogPool,
+        .esteban: cattleDogPool,
+        // Dachshunds
+        .elvis: dachshundPool,
+        .senor: dachshundPool,
+        // Schnauzers
+        .kai: schnauzerPool,
+        .hoku: schnauzerPool,
+        // Robot dog
+        .zuckerbot: zuckerbotPool,
+    ]
+
+    /// Pick a random canned response for the given dog.
+    /// Weighted 50/50 between the character-specific pool and the shared pool
+    /// (falls back to shared if the character has no dedicated pool).
+    static func randomResponse(for character: CharacterType) -> String {
+        precondition(character.isDog, "DogCannedResponses only valid for dog characters")
+
+        let specific = perCharacter[character] ?? []
+        // 50% chance of character-specific if we have any; otherwise always shared.
+        if !specific.isEmpty, Bool.random() {
+            return specific.randomElement() ?? shared.randomElement() ?? "woof."
+        }
+        return shared.randomElement() ?? "woof."
+    }
+
+    // MARK: - Per-character pools
+
+    private static let cattleDogPool: [String] = [
+        "hello mama",
+        "I'm a tiny dancer!",
+        "Does mama need foot massage",
+        "me happy!",
+        "me looking for butt to sniff",
+    ]
+
+    private static let dachshundPool: [String] = [
+        "I'm hungry, where's my eggs?!",
+        "Hi mama",
+        "Keep my brother out of my butt!",
+        "I'm hungry, where's Steve's food?!",
+        "I'm making biscuits over here",
+        "Bury me in blanket please",
+    ]
+
+    private static let schnauzerPool: [String] = [
+        "Death to mailmen!",
+        "I love my mom and dad!",
+        "Where's dad?!",
+        "Is it greenie time yet?",
+    ]
+
+    private static let zuckerbotPool: [String] = [
+        "bleet bleet bleet",
+        "the metaverse is the future",
+        "do you like ju jitsu?",
+        "me hungry for money",
+    ]
+}

--- a/ios/MajorTom/Features/Office/Models/SpriteMessagingState.swift
+++ b/ios/MajorTom/Features/Office/Models/SpriteMessagingState.swift
@@ -1,0 +1,75 @@
+import Foundation
+
+// MARK: - Sprite Messaging State
+//
+// Per-sprite state machine for the `/btw` modal flow (Wave 4).
+//
+//   .idle                         — fresh input; no pending message
+//   .pending(messageId, question) — user sent; waiting for response
+//   .ready(messageId, question,   — response received; "Cool Beans" dismisses
+//            response, wasDropped)
+//
+// Transitions:
+//   idle + send   → pending
+//   pending + `sprite.response(delivered)` → ready
+//   pending + `sprite.response(dropped)`   → ready (synthetic text)
+//   ready + "Cool Beans"                    → idle
+//
+// Drafts are ephemeral per-sprite UI state (TextField @State in the view) and
+// are discarded whenever the inspector is closed / re-targeted.
+
+enum SpriteMessagingState: Equatable {
+    case idle
+    case pending(messageId: String, question: String)
+    case ready(messageId: String, question: String, response: String, wasDropped: Bool)
+
+    /// True while awaiting a response.
+    var isPending: Bool {
+        if case .pending = self { return true }
+        return false
+    }
+
+    /// True when there's a response waiting for the user to read.
+    var isReady: Bool {
+        if case .ready = self { return true }
+        return false
+    }
+
+    /// The question text currently being displayed (pending or ready state).
+    var question: String? {
+        switch self {
+        case .idle: return nil
+        case .pending(_, let q): return q
+        case .ready(_, let q, _, _): return q
+        }
+    }
+
+    /// The response text (only available in .ready).
+    var response: String? {
+        if case .ready(_, _, let r, _) = self { return r }
+        return nil
+    }
+
+    /// Message ID for correlating with `sprite.response` (pending or ready).
+    var messageId: String? {
+        switch self {
+        case .idle: return nil
+        case .pending(let id, _): return id
+        case .ready(let id, _, _, _): return id
+        }
+    }
+}
+
+// MARK: - Queued Sprite Message
+//
+// Buffered in OfficeViewModel when the relay is disconnected. Flushed in FIFO
+// order once the connection comes back (scenario #5).
+
+struct QueuedSpriteMessage: Identifiable, Equatable {
+    let id: String           // messageId — matches the one kept in .pending state
+    let sessionId: String
+    let spriteHandle: String
+    let subagentId: String
+    let text: String
+    let createdAt: Date
+}

--- a/ios/MajorTom/Features/Office/Scenes/OfficeScene.swift
+++ b/ios/MajorTom/Features/Office/Scenes/OfficeScene.swift
@@ -1769,6 +1769,23 @@ final class OfficeScene: SKScene {
     func updateAgentName(id: String, name: String) { agentSprites[id]?.updateName(name) }
     func updateAgentStatus(id: String, status: AgentStatus) { agentSprites[id]?.updateStatus(status) }
 
+    // MARK: - /btw Unread-response visuals (Wave 4)
+
+    /// Show the persistent green glow on a sprite (unread sprite.response).
+    func showUnreadResponseGlow(on agentId: String) {
+        agentSprites[agentId]?.showUnreadResponseGlow()
+    }
+
+    /// Remove the persistent green glow (Cool Beans / inspector opened).
+    func hideUnreadResponseGlow(on agentId: String) {
+        agentSprites[agentId]?.hideUnreadResponseGlow()
+    }
+
+    /// Show a 5-second speech-bubble preview above a sprite.
+    func showResponsePreviewBubble(on agentId: String, text: String) {
+        agentSprites[agentId]?.showResponsePreviewBubble(text)
+    }
+
     // MARK: - Desk Highlighting
 
     func highlightDesk(_ deskIndex: Int, occupied: Bool) {

--- a/ios/MajorTom/Features/Office/Sprites/AgentSprite.swift
+++ b/ios/MajorTom/Features/Office/Sprites/AgentSprite.swift
@@ -45,6 +45,10 @@ final class AgentSprite: SKSpriteNode {
     /// The character type determines the sprite texture set.
     let characterType: CharacterType
 
+    /// Green "unread /btw response" glow — set when an unread sprite.response
+    /// is waiting. Overrides default working auras.
+    private var unreadGlowNode: SKNode?
+
     /// The texture-based crew sprite body node.
     private let bodySprite: SKSpriteNode
 
@@ -649,6 +653,49 @@ final class AgentSprite: SKSpriteNode {
     }
 
     // MARK: - Emote System
+
+    // MARK: - Unread /btw Response Glow (Wave 4)
+
+    /// Attach the green "unread /btw response" glow.
+    func showUnreadResponseGlow() {
+        guard unreadGlowNode == nil else { return }
+        let spriteSize = CrewSpriteBuilder.size(for: characterType)
+        let radius = max(spriteSize.width, spriteSize.height) * 0.8
+
+        let glow = SKShapeNode(circleOfRadius: radius)
+        glow.fillColor = SKColor(red: 0.25, green: 0.9, blue: 0.45, alpha: 0.35)
+        glow.strokeColor = SKColor(red: 0.30, green: 1.0, blue: 0.55, alpha: 0.7)
+        glow.lineWidth = 2
+        glow.name = "unreadResponseGlow"
+        glow.zPosition = -0.5
+        glow.alpha = 0
+
+        let fadeIn = SKAction.fadeAlpha(to: 0.85, duration: 0.25)
+        let pulse = SKAction.repeatForever(SKAction.sequence([
+            SKAction.fadeAlpha(to: 0.45, duration: 0.9),
+            SKAction.fadeAlpha(to: 0.85, duration: 0.9),
+        ]))
+        glow.run(SKAction.sequence([fadeIn, pulse]))
+
+        addChild(glow)
+        unreadGlowNode = glow
+    }
+
+    /// Remove the unread glow.
+    func hideUnreadResponseGlow() {
+        guard let glow = unreadGlowNode else { return }
+        glow.removeAllActions()
+        glow.run(SKAction.sequence([
+            SKAction.fadeOut(withDuration: 0.25),
+            SKAction.removeFromParent(),
+        ]))
+        unreadGlowNode = nil
+    }
+
+    /// Preview a /btw response as a speech bubble over the sprite.
+    func showResponsePreviewBubble(_ text: String, duration: TimeInterval = 5.0) {
+        showSpeechBubble(text, duration: duration)
+    }
 
     /// Show an animated emote above the sprite.
     /// The emote pops in, floats upward, then fades out.

--- a/ios/MajorTom/Features/Office/ViewModels/OfficeSceneManager.swift
+++ b/ios/MajorTom/Features/Office/ViewModels/OfficeSceneManager.swift
@@ -32,6 +32,60 @@ final class OfficeSceneManager {
     /// Relay service reference for sending sprite.state.request on cold rebuild.
     weak var relay: RelayService?
 
+    // MARK: - Cross-session Banner (Wave 4 M2)
+
+    /// Descriptor for a cross-session `/btw` response banner.
+    struct CrossSessionBanner: Identifiable, Equatable {
+        let id: UUID
+        let sessionId: String
+        let sessionName: String
+        let spriteId: String
+        let spriteName: String
+        let preview: String
+
+        init(
+            id: UUID = UUID(),
+            sessionId: String,
+            sessionName: String,
+            spriteId: String,
+            spriteName: String,
+            preview: String
+        ) {
+            self.id = id
+            self.sessionId = sessionId
+            self.sessionName = sessionName
+            self.spriteId = spriteId
+            self.spriteName = spriteName
+            self.preview = preview
+        }
+    }
+
+    /// The banner currently surfaced to the user (nil = hidden). Consumed by
+    /// OfficeManagerView's overlay. Auto-hides on a 3-second task.
+    var pendingCrossSessionBanner: CrossSessionBanner?
+
+    /// Surface a banner for a response that arrived in a non-active session.
+    func showCrossSessionBanner(
+        sessionId: String,
+        sessionName: String,
+        spriteId: String,
+        spriteName: String,
+        preview: String
+    ) {
+        pendingCrossSessionBanner = CrossSessionBanner(
+            sessionId: sessionId,
+            sessionName: sessionName,
+            spriteId: spriteId,
+            spriteName: spriteName,
+            preview: preview
+        )
+    }
+
+    /// Dismiss the banner (tap or auto-hide).
+    func dismissCrossSessionBanner() {
+        pendingCrossSessionBanner = nil
+    }
+
     // MARK: - Public API
 
     /// Returns the OfficeViewModel for a session, or nil if no Office exists.

--- a/ios/MajorTom/Features/Office/ViewModels/OfficeViewModel.swift
+++ b/ios/MajorTom/Features/Office/ViewModels/OfficeViewModel.swift
@@ -52,6 +52,25 @@ final class OfficeViewModel {
     /// First spawn for a canonical role locks the CharacterType for the session.
     var sessionRoleBindings: RoleMapper.SessionBindings = [:]
 
+    // MARK: - Sprite Messaging (Wave 4)
+
+    /// Per-sprite `/btw` modal state, keyed by the sprite's `AgentState.id`
+    /// (which is the `subagentId` for linked sprites and the `idle-<type>` id
+    /// for dogs).
+    var spriteMessagingStates: [String: SpriteMessagingState] = [:]
+
+    /// FIFO queue of sprite messages awaiting relay connectivity.
+    /// Flushed when the socket reconnects.
+    var queuedSpriteMessages: [QueuedSpriteMessage] = []
+
+    /// Sprite IDs that have an unread `/btw` response and should render the
+    /// green glow on their sprite node. Drained on "Cool Beans" or on open.
+    var unreadResponseSpriteIds: Set<String> = []
+
+    /// Sprite IDs that need a one-shot speech-bubble preview on the next
+    /// scene render (cleared by the view after firing).
+    var pendingBubblePreviews: [String: String] = [:]
+
     // MARK: - Sprite Pool
 
     private static let idlePrefix = "idle-"
@@ -183,6 +202,10 @@ final class OfficeViewModel {
         guard let index = agents.firstIndex(where: { $0.id == id }) else { return }
         guard !isIdleSprite(id) else { return }
 
+        // Scenario #4 — if there's a pending /btw for this agent, mark it
+        // dropped so the user isn't left on "Thinking…" forever.
+        markPendingDropped(for: id)
+
         agents[index].status = .celebrating
         agents[index].currentTask = result
         moodEngine.recordCompletion(id)
@@ -205,6 +228,8 @@ final class OfficeViewModel {
     func handleAgentDismissed(id: String) {
         guard agents.contains(where: { $0.id == id }) else { return }
         guard !isIdleSprite(id) else { return }
+
+        markPendingDropped(for: id)
 
         guard let index = agents.firstIndex(where: { $0.id == id }) else { return }
         agents[index].status = .leaving
@@ -357,6 +382,9 @@ final class OfficeViewModel {
 
         let agentId = agents[index].id
 
+        // Scenario #4 — drop any pending /btw since the subagent is leaving.
+        markPendingDropped(for: agentId)
+
         switch event.reason {
         case "completed":
             agents[index].status = .celebrating
@@ -390,6 +418,176 @@ final class OfficeViewModel {
                 try? await Task.sleep(for: .seconds(1.5))
                 removeAgent(id: agentId)
             }
+        }
+    }
+
+    // MARK: - Sprite Messaging Handlers (Wave 4)
+
+    /// Return the current messaging state for a sprite (`.idle` if none).
+    func messagingState(for spriteId: String) -> SpriteMessagingState {
+        spriteMessagingStates[spriteId] ?? .idle
+    }
+
+    /// Transition a sprite's state.
+    private func setMessagingState(_ state: SpriteMessagingState, for spriteId: String) {
+        if case .idle = state {
+            spriteMessagingStates.removeValue(forKey: spriteId)
+        } else {
+            spriteMessagingStates[spriteId] = state
+        }
+    }
+
+    /// Begin a pending `/btw` for a linked sprite. Caller (RelayService/view) is
+    /// responsible for actually dispatching the WebSocket send when connected.
+    /// Returns the queued message descriptor so the caller can submit it.
+    @discardableResult
+    func beginPendingMessage(
+        spriteId: String,
+        spriteHandle: String,
+        subagentId: String,
+        text: String,
+        isConnected: Bool
+    ) -> QueuedSpriteMessage? {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+        guard case .idle = messagingState(for: spriteId) else { return nil }
+
+        let sid = sessionId ?? ""
+        let messageId = UUID().uuidString
+
+        setMessagingState(.pending(messageId: messageId, question: trimmed), for: spriteId)
+
+        let queued = QueuedSpriteMessage(
+            id: messageId,
+            sessionId: sid,
+            spriteHandle: spriteHandle,
+            subagentId: subagentId,
+            text: trimmed,
+            createdAt: Date()
+        )
+        if !isConnected {
+            queuedSpriteMessages.append(queued)
+            return queued
+        }
+        return queued
+    }
+
+    /// Dog canned-response path — no relay roundtrip. Still transitions
+    /// through pending → ready with a ~200ms delay for consistent UX.
+    func sendDogCannedMessage(spriteId: String, text: String, character: CharacterType) {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+        guard case .idle = messagingState(for: spriteId) else { return }
+
+        let messageId = UUID().uuidString
+        setMessagingState(.pending(messageId: messageId, question: trimmed), for: spriteId)
+
+        Task { @MainActor [weak self] in
+            try? await Task.sleep(for: .milliseconds(200))
+            guard let self else { return }
+            guard case .pending(let pendingId, let pendingQ) = self.messagingState(for: spriteId),
+                  pendingId == messageId else { return }
+            let reply = DogCannedResponses.randomResponse(for: character)
+            self.setMessagingState(
+                .ready(messageId: pendingId, question: pendingQ, response: reply, wasDropped: false),
+                for: spriteId
+            )
+        }
+    }
+
+    /// Route an incoming `sprite.response` to the matching sprite.
+    func handleSpriteResponse(_ event: SpriteResponseEvent) {
+        guard event.status == "delivered" || event.status == "dropped" else {
+            return  // "queued" is informational — no state change
+        }
+
+        // Find sprite by messageId first (most reliable), fall back to subagentId.
+        let spriteId: String? = {
+            if let direct = spriteMessagingStates.first(where: { $0.value.messageId == event.messageId })?.key {
+                return direct
+            }
+            return agents.first(where: { $0.linkedSubagentId == event.subagentId })?.id
+        }()
+
+        guard let spriteId else { return }
+
+        queuedSpriteMessages.removeAll { $0.id == event.messageId }
+
+        let current = messagingState(for: spriteId)
+        guard case .pending(let pendingId, let question) = current,
+              pendingId == event.messageId else {
+            return
+        }
+
+        let responseText: String
+        let wasDropped: Bool
+        switch event.status {
+        case "delivered":
+            responseText = event.text
+            wasDropped = false
+        case "dropped":
+            responseText = "(Agent completed before delivery)"
+            wasDropped = true
+        default:
+            return
+        }
+
+        setMessagingState(
+            .ready(messageId: pendingId, question: question, response: responseText, wasDropped: wasDropped),
+            for: spriteId
+        )
+
+        // If the inspector isn't open on this sprite, flag unread for green
+        // glow + speech bubble preview. The view handles the preview.
+        if selectedAgentId != spriteId {
+            unreadResponseSpriteIds.insert(spriteId)
+            pendingBubblePreviews[spriteId] = responseText
+        }
+    }
+
+    /// "Cool Beans" dismisses the response back to idle.
+    func dismissResponse(for spriteId: String) {
+        setMessagingState(.idle, for: spriteId)
+        unreadResponseSpriteIds.remove(spriteId)
+    }
+
+    /// Inspector opened on this sprite — if there was an unread response,
+    /// clear the green-glow flag so the sprite stops pulsing.
+    func markResponseRead(for spriteId: String) {
+        unreadResponseSpriteIds.remove(spriteId)
+        pendingBubblePreviews.removeValue(forKey: spriteId)
+    }
+
+    /// Called by the view after it has rendered the bubble preview once.
+    func consumeBubblePreview(for spriteId: String) {
+        pendingBubblePreviews.removeValue(forKey: spriteId)
+    }
+
+    /// Pop all queued messages (FIFO). Caller sends them.
+    func drainQueuedSpriteMessages() -> [QueuedSpriteMessage] {
+        let drained = queuedSpriteMessages
+        queuedSpriteMessages.removeAll()
+        return drained
+    }
+
+    /// Mark any pending /btw for `spriteId` as dropped (scenario #4).
+    /// Surfaces the `(Agent completed before delivery)` text + green glow.
+    func markPendingDropped(for spriteId: String) {
+        guard case .pending(let messageId, let question) = messagingState(for: spriteId) else { return }
+
+        queuedSpriteMessages.removeAll { $0.id == messageId }
+        setMessagingState(
+            .ready(
+                messageId: messageId,
+                question: question,
+                response: "(Agent completed before delivery)",
+                wasDropped: true
+            ),
+            for: spriteId
+        )
+        if selectedAgentId != spriteId {
+            unreadResponseSpriteIds.insert(spriteId)
+            pendingBubblePreviews[spriteId] = "(Agent completed before delivery)"
         }
     }
 

--- a/ios/MajorTom/Features/Office/Views/OfficeManagerView.swift
+++ b/ios/MajorTom/Features/Office/Views/OfficeManagerView.swift
@@ -10,6 +10,7 @@ struct OfficeManagerView: View {
     var relay: RelayService
 
     @State private var navigationPath = NavigationPath()
+    @State private var bannerTask: Task<Void, Never>?
 
     var body: some View {
         NavigationStack(path: $navigationPath) {
@@ -25,6 +26,50 @@ struct OfficeManagerView: View {
                     )
                 }
         }
+        .overlay(alignment: .top) {
+            if let banner = sceneManager.pendingCrossSessionBanner {
+                SpriteResponseBanner(
+                    banner: banner,
+                    onTap: { navigateToBannerSession(banner) },
+                    onDismiss: { cancelBannerAutoHide() }
+                )
+                .padding(.horizontal, MajorTomTheme.Spacing.lg)
+                .padding(.top, MajorTomTheme.Spacing.sm)
+                .transition(.move(edge: .top).combined(with: .opacity))
+            }
+        }
+        .animation(.easeInOut(duration: 0.2), value: sceneManager.pendingCrossSessionBanner)
+        .onChange(of: sceneManager.pendingCrossSessionBanner) { _, newBanner in
+            rescheduleBannerAutoHide(for: newBanner)
+        }
+    }
+
+    // MARK: - Banner handling (M2)
+
+    private func navigateToBannerSession(_ banner: OfficeSceneManager.CrossSessionBanner) {
+        cancelBannerAutoHide()
+        if sceneManager.viewModel(for: banner.sessionId) == nil
+            || sceneManager.peekScene(for: banner.sessionId) == nil {
+            sceneManager.createOffice(for: banner.sessionId)
+        }
+        navigationPath = NavigationPath()
+        navigationPath.append(banner.sessionId)
+    }
+
+    private func rescheduleBannerAutoHide(for banner: OfficeSceneManager.CrossSessionBanner?) {
+        bannerTask?.cancel()
+        guard banner != nil else { return }
+        bannerTask = Task { @MainActor in
+            try? await Task.sleep(for: .seconds(3))
+            guard !Task.isCancelled else { return }
+            sceneManager.dismissCrossSessionBanner()
+        }
+    }
+
+    private func cancelBannerAutoHide() {
+        bannerTask?.cancel()
+        bannerTask = nil
+        sceneManager.dismissCrossSessionBanner()
     }
 
     // MARK: - Content

--- a/ios/MajorTom/Features/Office/Views/OfficeView.swift
+++ b/ios/MajorTom/Features/Office/Views/OfficeView.swift
@@ -38,6 +38,12 @@ struct OfficeView: View {
     @State private var previousAgentIds: Set<String> = []
     @State private var previousStatuses: [String: AgentStatus] = [:]
 
+    /// Snapshot of sprite IDs with the green unread-glow attached, for diffing.
+    @State private var previousUnreadIds: Set<String> = []
+
+    /// Snapshot of bubble-preview sprite IDs that have already been rendered.
+    @State private var firedPreviewIds: Set<String> = []
+
     /// Activated scene — populated in onAppear, avoids side effects in body.
     @State private var activatedScene: OfficeScene?
 
@@ -109,6 +115,17 @@ struct OfficeView: View {
                 .ignoresSafeArea(.all, edges: .bottom)
                 .onChange(of: viewModel.agents, initial: true) { _, newAgents in
                     syncScene(with: newAgents, viewModel: viewModel, scene: scene)
+                }
+                .onChange(of: viewModel.unreadResponseSpriteIds, initial: true) { _, ids in
+                    syncUnreadGlows(ids: ids, scene: scene)
+                }
+                .onChange(of: viewModel.pendingBubblePreviews, initial: false) { _, previews in
+                    fireBubblePreviews(previews, viewModel: viewModel, scene: scene)
+                }
+                .onChange(of: relay?.connectionState) { _, newState in
+                    if newState == .connected, let sid = viewModel.sessionId {
+                        relay?.flushQueuedSpriteMessages(for: sid)
+                    }
                 }
 
             // Top overlay: agent count + controls
@@ -208,24 +225,23 @@ struct OfficeView: View {
             switch sheetType {
             case .inspector:
                 if let agent = viewModel.selectedAgent {
-                    AgentInspectorView(
+                    SpriteInspectorView(
                         agent: agent,
+                        viewModel: viewModel,
                         activityDescription: viewModel.activityEngine.activityDescription(for: agent.id),
                         onRename: { newName in
                             viewModel.renameAgent(id: agent.id, newName: newName)
                             scene.updateAgentName(id: agent.id, name: newName)
                         },
-                        onSendMessage: relay != nil ? { message in
-                            let sid = sessionId
-                            guard !sid.isEmpty else { return }
-                            Task {
-                                try? await relay?.sendAgentMessage(
-                                    sessionId: sid,
-                                    agentId: agent.id,
-                                    text: message
-                                )
+                        onSendLinkedMessage: relay.map { relayRef in
+                            { queued in
+                                let connected = relayRef.connectionState == .connected
+                                if connected {
+                                    Task { await relayRef.sendSpriteMessage(queued) }
+                                }
+                                return connected
                             }
-                        } : nil,
+                        },
                         onDismiss: {
                             HapticService.impact(.medium)
                             viewModel.dismissInspector()
@@ -386,6 +402,41 @@ struct OfficeView: View {
             )
         }
         .buttonStyle(.plain)
+    }
+
+    // MARK: - /btw Visuals Sync (Wave 4)
+
+    /// Apply green-glow adds/removes based on viewModel.unreadResponseSpriteIds.
+    private func syncUnreadGlows(ids: Set<String>, scene: OfficeScene) {
+        let additions = ids.subtracting(previousUnreadIds)
+        let removals = previousUnreadIds.subtracting(ids)
+        for id in additions {
+            scene.showUnreadResponseGlow(on: id)
+        }
+        for id in removals {
+            scene.hideUnreadResponseGlow(on: id)
+        }
+        previousUnreadIds = ids
+    }
+
+    /// Fire pending bubble previews once per sprite.
+    private func fireBubblePreviews(_ previews: [String: String], viewModel: OfficeViewModel, scene: OfficeScene) {
+        for (spriteId, text) in previews where !firedPreviewIds.contains(spriteId) {
+            scene.showResponsePreviewBubble(on: spriteId, text: shortPreview(text))
+            firedPreviewIds.insert(spriteId)
+            viewModel.consumeBubblePreview(for: spriteId)
+        }
+        // Clean up fired IDs that no longer have pending previews (e.g. after
+        // Cool Beans dropped state), so next response re-fires.
+        firedPreviewIds = firedPreviewIds.intersection(Set(previews.keys))
+    }
+
+    /// Truncate long responses for the speech-bubble preview.
+    private func shortPreview(_ text: String) -> String {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.count <= 80 { return trimmed }
+        let idx = trimmed.index(trimmed.startIndex, offsetBy: 77)
+        return String(trimmed[..<idx]) + "…"
     }
 
     // MARK: - Scene Sync

--- a/ios/MajorTom/Features/Office/Views/OfficeView.swift
+++ b/ios/MajorTom/Features/Office/Views/OfficeView.swift
@@ -119,8 +119,17 @@ struct OfficeView: View {
                 .onChange(of: viewModel.unreadResponseSpriteIds, initial: true) { _, ids in
                     syncUnreadGlows(ids: ids, scene: scene)
                 }
-                .onChange(of: viewModel.pendingBubblePreviews, initial: false) { _, previews in
+                .onChange(of: viewModel.pendingBubblePreviews, initial: true) { _, previews in
                     fireBubblePreviews(previews, viewModel: viewModel, scene: scene)
+                }
+                .onChange(of: ObjectIdentifier(scene)) { _, _ in
+                    // Scene identity changed (cold rebuild after LRU eviction) —
+                    // reset diffing state so all currently-unread glows/previews
+                    // are re-applied to the fresh scene instead of skipped.
+                    previousUnreadIds = []
+                    firedPreviewIds = []
+                    syncUnreadGlows(ids: viewModel.unreadResponseSpriteIds, scene: scene)
+                    fireBubblePreviews(viewModel.pendingBubblePreviews, viewModel: viewModel, scene: scene)
                 }
                 .onChange(of: relay?.connectionState) { _, newState in
                     if newState == .connected, let sid = viewModel.sessionId {

--- a/ios/MajorTom/Features/Office/Views/SpriteInspectorView.swift
+++ b/ios/MajorTom/Features/Office/Views/SpriteInspectorView.swift
@@ -88,6 +88,15 @@ struct SpriteInspectorView: View {
             // but keep the .ready state so the user can hit Cool Beans.
             viewModel.markResponseRead(for: agent.id)
         }
+        .task {
+            // Build the SpriteKit scene exactly once per inspector
+            // presentation. Doing this inside `body` via an immediately-
+            // invoked closure risks SwiftUI re-rendering and allocating
+            // multiple scenes before the async state update lands.
+            if spriteScene == nil {
+                spriteScene = InspectorSpriteScene(characterType: agent.characterType)
+            }
+        }
         .onChange(of: agent.id) { _, _ in
             // Sprite switched under us (scenario #2) — discard draft.
             draft = ""
@@ -100,12 +109,14 @@ struct SpriteInspectorView: View {
 
     private var spriteHeader: some View {
         HStack(spacing: MajorTomTheme.Spacing.md) {
-            SpriteView(scene: {
-                if let existing = spriteScene { return existing }
-                let scene = InspectorSpriteScene(characterType: agent.characterType)
-                Task { @MainActor in spriteScene = scene }
-                return scene
-            }())
+            Group {
+                if let spriteScene {
+                    SpriteView(scene: spriteScene)
+                } else {
+                    // Placeholder until `.task` builds the scene (one frame at most).
+                    Color.clear
+                }
+            }
             .frame(width: 80, height: 80)
             .clipShape(RoundedRectangle(cornerRadius: MajorTomTheme.Radius.medium))
             .overlay(

--- a/ios/MajorTom/Features/Office/Views/SpriteInspectorView.swift
+++ b/ios/MajorTom/Features/Office/Views/SpriteInspectorView.swift
@@ -53,7 +53,8 @@ struct SpriteInspectorView: View {
     }
 
     private var hasQueuedLocally: Bool {
-        viewModel.queuedSpriteMessages.contains(where: { $0.subagentId == agent.linkedSubagentId })
+        guard let subagentId = agent.linkedSubagentId else { return false }
+        return viewModel.queuedSpriteMessages.contains(where: { $0.subagentId == subagentId })
     }
 
     // MARK: - Body

--- a/ios/MajorTom/Features/Office/Views/SpriteInspectorView.swift
+++ b/ios/MajorTom/Features/Office/Views/SpriteInspectorView.swift
@@ -1,0 +1,561 @@
+import SwiftUI
+import SpriteKit
+
+// MARK: - Sprite Inspector (Wave 4)
+//
+// Three-mode inspector, keyed off the tapped sprite:
+//
+//   linkedSubagentId != nil → `/btw` modal with state machine
+//   isDog                   → local canned-response modal
+//   else                    → info panel only (idle human, Q4 decision D)
+//
+// The caller (OfficeView) passes the agent + a closure that sends a sprite
+// message to the relay. All per-sprite state lives on the OfficeViewModel so
+// the inspector can be opened/closed without losing pending → ready state.
+
+struct SpriteInspectorView: View {
+    let agent: AgentState
+    let viewModel: OfficeViewModel
+    let activityDescription: String?
+    let onRename: (String) -> Void
+    /// Called when the inspector should send a `/btw` to the relay.
+    /// The closure is responsible for dispatching (or queuing) based on
+    /// current relay connectivity. Returns `true` if the socket was
+    /// connected at send time, `false` if the message was queued locally.
+    let onSendLinkedMessage: ((QueuedSpriteMessage) -> Bool)?
+    let onDismiss: () -> Void
+
+    @State private var renameText = ""
+    @State private var isRenaming = false
+    @State private var draft: String = ""
+    @State private var responseExpanded: Bool = false
+    @State private var questionExpanded: Bool = false
+    @State private var spriteScene: InspectorSpriteScene?
+
+    private enum Mode {
+        case linked
+        case dog
+        case idleHuman
+    }
+
+    private var mode: Mode {
+        if agent.linkedSubagentId != nil {
+            return .linked
+        }
+        if agent.characterType.isDog {
+            return .dog
+        }
+        return .idleHuman
+    }
+
+    private var messagingState: SpriteMessagingState {
+        viewModel.messagingState(for: agent.id)
+    }
+
+    private var hasQueuedLocally: Bool {
+        viewModel.queuedSpriteMessages.contains(where: { $0.subagentId == agent.linkedSubagentId })
+    }
+
+    // MARK: - Body
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: MajorTomTheme.Spacing.md) {
+            spriteHeader
+
+            Divider().background(MajorTomTheme.Colors.textTertiary)
+
+            roleAndTask
+
+            if let activityDescription {
+                activitySection(activityDescription)
+            }
+
+            detailRows
+
+            Spacer(minLength: MajorTomTheme.Spacing.sm)
+
+            content
+
+            actions
+        }
+        .padding(MajorTomTheme.Spacing.lg)
+        .background(MajorTomTheme.Colors.surface)
+        .presentationDetents([.medium, .large])
+        .presentationDragIndicator(.visible)
+        .onAppear {
+            // Mark any unread response as read (clears green glow on sprite)
+            // but keep the .ready state so the user can hit Cool Beans.
+            viewModel.markResponseRead(for: agent.id)
+        }
+        .onChange(of: agent.id) { _, _ in
+            // Sprite switched under us (scenario #2) — discard draft.
+            draft = ""
+            responseExpanded = false
+            questionExpanded = false
+        }
+    }
+
+    // MARK: - Header
+
+    private var spriteHeader: some View {
+        HStack(spacing: MajorTomTheme.Spacing.md) {
+            SpriteView(scene: {
+                if let existing = spriteScene { return existing }
+                let scene = InspectorSpriteScene(characterType: agent.characterType)
+                Task { @MainActor in spriteScene = scene }
+                return scene
+            }())
+            .frame(width: 80, height: 80)
+            .clipShape(RoundedRectangle(cornerRadius: MajorTomTheme.Radius.medium))
+            .overlay(
+                RoundedRectangle(cornerRadius: MajorTomTheme.Radius.medium)
+                    .stroke(CharacterCatalog.config(for: agent.characterType).spriteColor.opacity(0.5), lineWidth: 1.5)
+            )
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text(agent.name)
+                    .font(MajorTomTheme.Typography.headline)
+                    .foregroundStyle(MajorTomTheme.Colors.textPrimary)
+
+                Text(CharacterCatalog.config(for: agent.characterType).displayName)
+                    .font(MajorTomTheme.Typography.caption)
+                    .foregroundStyle(MajorTomTheme.Colors.textSecondary)
+
+                statusBadge
+            }
+
+            Spacer()
+        }
+    }
+
+    private var statusBadge: some View {
+        let label: String
+        let color: Color
+        switch mode {
+        case .linked:
+            label = agent.status.rawValue.uppercased()
+            color = statusColor(for: agent.status)
+        case .dog:
+            label = "DOG"
+            color = MajorTomTheme.Colors.accent
+        case .idleHuman:
+            label = "CREW"
+            color = MajorTomTheme.Colors.textSecondary
+        }
+        return Text(label)
+            .font(.system(.caption2, design: .monospaced, weight: .bold))
+            .foregroundStyle(color)
+            .padding(.horizontal, 8)
+            .padding(.vertical, 4)
+            .background(color.opacity(0.15))
+            .clipShape(Capsule())
+    }
+
+    private func statusColor(for status: AgentStatus) -> Color {
+        switch status {
+        case .spawning: return .gray
+        case .walking: return .blue
+        case .working: return MajorTomTheme.Colors.allow
+        case .idle: return MajorTomTheme.Colors.accent
+        case .celebrating: return .yellow
+        case .leaving: return MajorTomTheme.Colors.deny
+        }
+    }
+
+    // MARK: - Role + Task
+
+    private var roleAndTask: some View {
+        VStack(alignment: .leading, spacing: MajorTomTheme.Spacing.sm) {
+            HStack(spacing: MajorTomTheme.Spacing.sm) {
+                Image(systemName: "person.badge.key.fill")
+                    .font(.system(size: 14))
+                    .foregroundStyle(MajorTomTheme.Colors.accent)
+                Text((agent.canonicalRole ?? agent.role).capitalized)
+                    .font(MajorTomTheme.Typography.headline)
+                    .foregroundStyle(MajorTomTheme.Colors.textPrimary)
+            }
+
+            if let task = agent.currentTask {
+                HStack(alignment: .top, spacing: MajorTomTheme.Spacing.sm) {
+                    Image(systemName: "chevron.right.circle.fill")
+                        .font(.system(size: 12))
+                        .foregroundStyle(MajorTomTheme.Colors.allow)
+                    Text(task)
+                        .font(MajorTomTheme.Typography.body)
+                        .foregroundStyle(MajorTomTheme.Colors.textSecondary)
+                        .lineLimit(2)
+                }
+            }
+        }
+        .padding(MajorTomTheme.Spacing.sm)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(MajorTomTheme.Colors.background)
+        .clipShape(RoundedRectangle(cornerRadius: MajorTomTheme.Radius.small))
+    }
+
+    private func activitySection(_ activity: String) -> some View {
+        HStack(spacing: MajorTomTheme.Spacing.sm) {
+            Image(systemName: "figure.walk")
+                .font(.system(size: 12))
+                .foregroundStyle(MajorTomTheme.Colors.accent)
+            Text(activity)
+                .font(MajorTomTheme.Typography.caption)
+                .foregroundStyle(MajorTomTheme.Colors.accent)
+        }
+        .padding(.horizontal, MajorTomTheme.Spacing.sm)
+        .padding(.vertical, MajorTomTheme.Spacing.xs)
+        .background(MajorTomTheme.Colors.accentSubtle)
+        .clipShape(Capsule())
+    }
+
+    private var detailRows: some View {
+        VStack(alignment: .leading, spacing: MajorTomTheme.Spacing.sm) {
+            detailRow(label: "Agent ID", value: String(agent.id.prefix(12)) + "...")
+            detailRow(label: "Desk", value: agent.deskIndex.map { "Desk \($0 + 1)" } ?? "None")
+            detailRow(label: "Uptime", value: agent.uptime)
+        }
+    }
+
+    private func detailRow(label: String, value: String) -> some View {
+        HStack {
+            Text(label)
+                .font(MajorTomTheme.Typography.caption)
+                .foregroundStyle(MajorTomTheme.Colors.textTertiary)
+                .frame(width: 80, alignment: .leading)
+            Text(value)
+                .font(MajorTomTheme.Typography.codeFontSmall)
+                .foregroundStyle(MajorTomTheme.Colors.textSecondary)
+        }
+    }
+
+    // MARK: - Mode content
+
+    @ViewBuilder
+    private var content: some View {
+        switch mode {
+        case .linked:
+            linkedModeContent
+        case .dog:
+            dogModeContent
+        case .idleHuman:
+            idleHumanContent
+        }
+    }
+
+    // MARK: - Linked mode (/btw state machine)
+
+    @ViewBuilder
+    private var linkedModeContent: some View {
+        switch messagingState {
+        case .idle:
+            linkedInput(enabled: true, prompt: "/btw — send an observation...")
+        case .pending(_, let question):
+            pendingQuestionView(question)
+            linkedInput(enabled: false, prompt: "Waiting for response...")
+        case .ready(_, let question, let response, _):
+            pendingQuestionView(question)
+            responseView(response)
+        }
+    }
+
+    @ViewBuilder
+    private func linkedInput(enabled: Bool, prompt: String) -> some View {
+        VStack(alignment: .leading, spacing: MajorTomTheme.Spacing.xs) {
+            HStack(spacing: 6) {
+                Text("/btw")
+                    .font(MajorTomTheme.Typography.codeFontSmall)
+                    .foregroundStyle(MajorTomTheme.Colors.accent)
+                if hasQueuedLocally, enabled {
+                    Text("queued — will send on reconnect")
+                        .font(MajorTomTheme.Typography.caption)
+                        .foregroundStyle(MajorTomTheme.Colors.warning)
+                }
+                Spacer()
+            }
+
+            HStack(spacing: MajorTomTheme.Spacing.sm) {
+                TextField(prompt, text: $draft, axis: .vertical)
+                    .font(MajorTomTheme.Typography.codeFontSmall)
+                    .foregroundStyle(MajorTomTheme.Colors.textPrimary)
+                    .disabled(!enabled)
+                    .padding(MajorTomTheme.Spacing.sm)
+                    .background(MajorTomTheme.Colors.background)
+                    .clipShape(RoundedRectangle(cornerRadius: MajorTomTheme.Radius.small))
+                    .lineLimit(1...4)
+
+                Button(action: sendLinkedDraft) {
+                    Image(systemName: "paperplane.fill")
+                        .font(.system(size: 14))
+                        .foregroundStyle(
+                            sendDisabled
+                            ? MajorTomTheme.Colors.textTertiary
+                            : MajorTomTheme.Colors.accent
+                        )
+                }
+                .disabled(sendDisabled)
+            }
+        }
+    }
+
+    private var sendDisabled: Bool {
+        !messagingState.question.isNilOrEmpty || draft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
+    private func pendingQuestionView(_ question: String) -> some View {
+        VStack(alignment: .leading, spacing: MajorTomTheme.Spacing.xs) {
+            HStack(spacing: 6) {
+                Image(systemName: "quote.opening")
+                    .font(.system(size: 10))
+                    .foregroundStyle(MajorTomTheme.Colors.accent)
+                Text("You asked")
+                    .font(MajorTomTheme.Typography.caption)
+                    .foregroundStyle(MajorTomTheme.Colors.textTertiary)
+                Spacer()
+                if question.count > 140 {
+                    Button(questionExpanded ? "Less" : "More") {
+                        questionExpanded.toggle()
+                    }
+                    .font(MajorTomTheme.Typography.caption)
+                    .foregroundStyle(MajorTomTheme.Colors.accent)
+                }
+            }
+            Text(question)
+                .font(MajorTomTheme.Typography.codeFontSmall)
+                .foregroundStyle(MajorTomTheme.Colors.textSecondary)
+                .lineLimit(questionExpanded ? nil : 3)
+        }
+        .padding(MajorTomTheme.Spacing.sm)
+        .background(MajorTomTheme.Colors.background)
+        .clipShape(RoundedRectangle(cornerRadius: MajorTomTheme.Radius.small))
+    }
+
+    private func responseView(_ response: String) -> some View {
+        VStack(alignment: .leading, spacing: MajorTomTheme.Spacing.xs) {
+            HStack(spacing: 6) {
+                Image(systemName: "bubble.left.fill")
+                    .font(.system(size: 10))
+                    .foregroundStyle(MajorTomTheme.Colors.allow)
+                Text("Response")
+                    .font(MajorTomTheme.Typography.caption)
+                    .foregroundStyle(MajorTomTheme.Colors.textTertiary)
+                Spacer()
+                if response.count > 200 {
+                    Button(responseExpanded ? "Less" : "More") {
+                        responseExpanded.toggle()
+                    }
+                    .font(MajorTomTheme.Typography.caption)
+                    .foregroundStyle(MajorTomTheme.Colors.accent)
+                }
+            }
+            Text(response)
+                .font(MajorTomTheme.Typography.body)
+                .foregroundStyle(MajorTomTheme.Colors.textPrimary)
+                .lineLimit(responseExpanded ? nil : 6)
+        }
+        .padding(MajorTomTheme.Spacing.sm)
+        .background(MajorTomTheme.Colors.allow.opacity(0.08))
+        .overlay(
+            RoundedRectangle(cornerRadius: MajorTomTheme.Radius.small)
+                .stroke(MajorTomTheme.Colors.allow.opacity(0.3), lineWidth: 1)
+        )
+        .clipShape(RoundedRectangle(cornerRadius: MajorTomTheme.Radius.small))
+    }
+
+    // MARK: - Dog mode
+
+    @ViewBuilder
+    private var dogModeContent: some View {
+        switch messagingState {
+        case .idle:
+            dogInput(enabled: true)
+        case .pending(_, let question):
+            pendingQuestionView(question)
+            dogInput(enabled: false)
+        case .ready(_, let question, let response, _):
+            pendingQuestionView(question)
+            responseView(response)
+        }
+    }
+
+    @ViewBuilder
+    private func dogInput(enabled: Bool) -> some View {
+        VStack(alignment: .leading, spacing: MajorTomTheme.Spacing.xs) {
+            HStack(spacing: 6) {
+                Image(systemName: "pawprint.fill")
+                    .font(.system(size: 10))
+                    .foregroundStyle(MajorTomTheme.Colors.accent)
+                Text("Say hi to \(agent.name)")
+                    .font(MajorTomTheme.Typography.caption)
+                    .foregroundStyle(MajorTomTheme.Colors.textTertiary)
+                Spacer()
+            }
+            HStack(spacing: MajorTomTheme.Spacing.sm) {
+                TextField(enabled ? "Pet, praise, or ask a silly question..." : "Thinking...", text: $draft, axis: .vertical)
+                    .font(MajorTomTheme.Typography.codeFontSmall)
+                    .foregroundStyle(MajorTomTheme.Colors.textPrimary)
+                    .disabled(!enabled)
+                    .padding(MajorTomTheme.Spacing.sm)
+                    .background(MajorTomTheme.Colors.background)
+                    .clipShape(RoundedRectangle(cornerRadius: MajorTomTheme.Radius.small))
+                    .lineLimit(1...3)
+
+                Button(action: sendDogDraft) {
+                    Image(systemName: "paperplane.fill")
+                        .font(.system(size: 14))
+                        .foregroundStyle(
+                            sendDisabled
+                            ? MajorTomTheme.Colors.textTertiary
+                            : MajorTomTheme.Colors.accent
+                        )
+                }
+                .disabled(sendDisabled)
+            }
+        }
+    }
+
+    // MARK: - Idle human
+
+    private var idleHumanContent: some View {
+        VStack(alignment: .leading, spacing: MajorTomTheme.Spacing.xs) {
+            HStack(spacing: 6) {
+                Image(systemName: "info.circle.fill")
+                    .font(.system(size: 10))
+                    .foregroundStyle(MajorTomTheme.Colors.textSecondary)
+                Text("Off duty")
+                    .font(MajorTomTheme.Typography.caption)
+                    .foregroundStyle(MajorTomTheme.Colors.textTertiary)
+                Spacer()
+            }
+            Text("This crew member isn't assigned to a subagent right now. They'll wander the station and take breaks.")
+                .font(MajorTomTheme.Typography.caption)
+                .foregroundStyle(MajorTomTheme.Colors.textSecondary)
+                .padding(MajorTomTheme.Spacing.sm)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .background(MajorTomTheme.Colors.background)
+                .clipShape(RoundedRectangle(cornerRadius: MajorTomTheme.Radius.small))
+        }
+    }
+
+    // MARK: - Actions row
+
+    private var actions: some View {
+        HStack(spacing: MajorTomTheme.Spacing.md) {
+            if mode == .linked || mode == .idleHuman {
+                Button {
+                    renameText = agent.name
+                    isRenaming = true
+                } label: {
+                    Label("Rename", systemImage: "pencil")
+                        .font(MajorTomTheme.Typography.caption)
+                }
+                .buttonStyle(.bordered)
+                .tint(MajorTomTheme.Colors.accent)
+                .alert("Rename Crew", isPresented: $isRenaming) {
+                    TextField("Name", text: $renameText)
+                    Button("Cancel", role: .cancel) {}
+                    Button("Rename") {
+                        if !renameText.isEmpty { onRename(renameText) }
+                    }
+                } message: {
+                    Text("Enter a new display name.")
+                }
+            }
+
+            Spacer()
+
+            if case .ready = messagingState {
+                Button {
+                    HapticService.impact(.soft)
+                    viewModel.dismissResponse(for: agent.id)
+                    draft = ""
+                } label: {
+                    Label("Cool Beans", systemImage: "checkmark.circle.fill")
+                        .font(MajorTomTheme.Typography.caption)
+                }
+                .buttonStyle(.borderedProminent)
+                .tint(MajorTomTheme.Colors.allow)
+            } else {
+                Button {
+                    onDismiss()
+                } label: {
+                    Label("Close", systemImage: "xmark.circle")
+                        .font(MajorTomTheme.Typography.caption)
+                }
+                .buttonStyle(.bordered)
+                .tint(MajorTomTheme.Colors.textTertiary)
+            }
+        }
+    }
+
+    // MARK: - Send actions
+
+    private func sendLinkedDraft() {
+        guard let handle = agent.spriteHandle,
+              let subagentId = agent.linkedSubagentId,
+              let send = onSendLinkedMessage,
+              !draft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        else { return }
+
+        let text = draft
+        draft = ""
+        HapticService.impact(.light)
+
+        // Always transition to .pending; the caller decides send vs queue.
+        guard let queued = viewModel.beginPendingMessage(
+            spriteId: agent.id,
+            spriteHandle: handle,
+            subagentId: subagentId,
+            text: text,
+            isConnected: true  // stub — view layer just wants the descriptor
+        ) else { return }
+
+        let wasSent = send(queued)
+        if !wasSent {
+            // Caller signalled offline — persist to queue so reconnect flushes.
+            if !viewModel.queuedSpriteMessages.contains(where: { $0.id == queued.id }) {
+                viewModel.queuedSpriteMessages.append(queued)
+            }
+        }
+    }
+
+    private func sendDogDraft() {
+        guard !draft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
+        let text = draft
+        draft = ""
+        HapticService.impact(.light)
+        viewModel.sendDogCannedMessage(spriteId: agent.id, text: text, character: agent.characterType)
+    }
+}
+
+// MARK: - Optional helpers
+
+private extension Optional where Wrapped == String {
+    var isNilOrEmpty: Bool {
+        switch self {
+        case .none: return true
+        case .some(let s): return s.isEmpty
+        }
+    }
+}
+
+#Preview {
+    SpriteInspectorView(
+        agent: AgentState(
+            id: "preview-1",
+            name: "Alice",
+            role: "frontend",
+            characterType: .frontendDev,
+            status: .working,
+            currentTask: "Building the login page",
+            deskIndex: 0,
+            linkedSubagentId: "sub-1",
+            spriteHandle: "handle-1",
+            canonicalRole: "frontend"
+        ),
+        viewModel: OfficeViewModel(),
+        activityDescription: nil,
+        onRename: { _ in },
+        onSendLinkedMessage: { _ in true },
+        onDismiss: {}
+    )
+}

--- a/ios/MajorTom/Features/Office/Views/SpriteResponseBanner.swift
+++ b/ios/MajorTom/Features/Office/Views/SpriteResponseBanner.swift
@@ -1,0 +1,56 @@
+import SwiftUI
+
+// MARK: - Sprite Response Banner (Wave 4 M2)
+//
+// In-app toast that surfaces a `/btw` response when it arrives for a sprite
+// in a different Office than the one the user is currently viewing. Tapping
+// the banner navigates to the origin session's Office.
+
+struct SpriteResponseBanner: View {
+    let banner: OfficeSceneManager.CrossSessionBanner
+    let onTap: () -> Void
+    let onDismiss: () -> Void
+
+    var body: some View {
+        HStack(alignment: .top, spacing: MajorTomTheme.Spacing.md) {
+            Image(systemName: "bubble.left.and.exclamationmark.bubble.right")
+                .font(.system(size: 16))
+                .foregroundStyle(MajorTomTheme.Colors.allow)
+
+            VStack(alignment: .leading, spacing: MajorTomTheme.Spacing.xs) {
+                Text("[\(banner.sessionName)] \(banner.spriteName)")
+                    .font(.system(.caption, design: .monospaced, weight: .semibold))
+                    .foregroundStyle(MajorTomTheme.Colors.textPrimary)
+                    .lineLimit(1)
+                Text(banner.preview)
+                    .font(.system(.caption, design: .monospaced))
+                    .foregroundStyle(MajorTomTheme.Colors.textSecondary)
+                    .lineLimit(2)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+
+            Button {
+                onDismiss()
+            } label: {
+                Image(systemName: "xmark.circle.fill")
+                    .font(.system(size: 14))
+                    .foregroundStyle(MajorTomTheme.Colors.textTertiary)
+            }
+            .buttonStyle(.plain)
+            .padding(.top, 2)
+        }
+        .padding(MajorTomTheme.Spacing.md)
+        .background(MajorTomTheme.Colors.surfaceElevated)
+        .overlay(
+            RoundedRectangle(cornerRadius: MajorTomTheme.Radius.medium)
+                .stroke(MajorTomTheme.Colors.allow.opacity(0.4), lineWidth: 1)
+        )
+        .clipShape(RoundedRectangle(cornerRadius: MajorTomTheme.Radius.medium))
+        .shadow(color: .black.opacity(0.35), radius: 12, x: 0, y: 6)
+        .contentShape(RoundedRectangle(cornerRadius: MajorTomTheme.Radius.medium))
+        .onTapGesture {
+            HapticService.selection()
+            onTap()
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Wave 4 of the sprite-agent wiring phase — makes the sprite-tap surface real for `/btw` messaging, dog interactions, and idle humans.

### What shipped

- **/btw state machine** — per-sprite `.idle → .pending → .ready` stored in `OfficeViewModel.spriteMessagingStates`. Input locks while pending (read-only display of the question). "Cool Beans" transitions back to idle.
- **SpriteInspectorView** — new three-mode inspector that dispatches on `linkedSubagentId` → /btw; `isDog` → canned; else → idle human info panel.
- **Green glow + speech-bubble preview** — `AgentSprite.showUnreadResponseGlow()` + `showResponsePreviewBubble()` wired via `OfficeView` diffing `viewModel.unreadResponseSpriteIds` and `pendingBubblePreviews`.
- **Cross-session banner (M2)** — `OfficeSceneManager.pendingCrossSessionBanner` surfaced as a SwiftUI overlay on `OfficeManagerView`, auto-dismiss 3s, tap-to-navigate to the origin Office.
- **Local send queue** — `viewModel.queuedSpriteMessages` buffer while offline. `MajorTomApp.onChange(of: relay.connectionState)` calls `flushAllQueuedSpriteMessages()` on reconnect; `OfficeView` also flushes per-session.
- **Dog canned responses** — `DogCannedResponses` with shared + per-character pools, 200ms fake delay through the same `.pending → .ready` machine. No relay roundtrip.
- **Wire types** — `SpriteMessageMessage` (client→relay) and `SpriteResponseEvent` (relay→client, `delivered`/`queued`/`dropped`) added to `Message.swift` + routed through `RelayService`.
- **Scenario #4 safety** — `handleAgentComplete`/`handleAgentDismissed`/`handleSpriteUnlink` all call `markPendingDropped(for:)` so the user never sees permanent "Thinking…".

### Scenarios covered

- `#2` — Switching sprites discards draft (SwiftUI `.onChange(of: agent.id)` clears `@State draft`).
- `#3` — Pending blocks re-send: `TextField.disabled(true)` + `sendDisabled` guard.
- `#4` — Drop surfaced with "(Agent completed before delivery)" + green glow.
- `#5` — Offline queue in `queuedSpriteMessages`, flushed on reconnect.
- `#8` — Empty/whitespace disables the send button.
- `#10` — Long messages get expand/collapse toggles for question & response.
- `M1` — Single-pending gate enforced at state level.
- `M2` — 3s banner + navigation on cross-session response.
- `Q4 idle/dog` — mode dispatch in `SpriteInspectorView`.

### Dependencies on relay PR

Expects relay to emit `sprite.response` with `status: "delivered"` (text = reply) or `status: "dropped"` (text ignored; iOS synthesizes "(Agent completed before delivery)"). `status: "queued"` is accepted as informational (no state change). Parallel relay agent owns this.

### Known limits / manual test checklist

- No simulator automation — `xcodebuild -scheme MajorTom -destination 'platform=iOS Simulator,name=iPhone 17' build` passes cleanly. Manual checks needed:
  - [ ] Tap linked sprite, /btw, wait for response, Cool Beans
  - [ ] Close inspector pre-response, confirm green glow + speech bubble preview
  - [ ] Switch to other Office, confirm cross-session banner + tap-nav
  - [ ] Pull WebSocket (airplane mode), send, restore, confirm auto-flush
  - [ ] Tap each dog, confirm shared + character-specific canned responses
  - [ ] Tap idle human, confirm info-panel only (no input)

🤖 Generated with [Claude Code](https://claude.com/claude-code)