### PR TITLE
feat(relay): sprite /btw queue + turn-boundary injection (Wave 4)

### DIFF
--- a/relay/src/adapters/claude-cli.adapter.ts
+++ b/relay/src/adapters/claude-cli.adapter.ts
@@ -23,6 +23,7 @@ import type {
 } from './adapter.interface.js';
 import { agentTracker } from '../events/agent-tracker.js';
 import { logger } from '../utils/logger.js';
+import { BtwQueue, type BtwQueueEventMap } from '../sprites/btw-queue.js';
 
 // ── Claude Code SDK Adapter ─────────────────────────────────
 // Uses the official Agent SDK's v2 session API.
@@ -130,6 +131,20 @@ export interface AutoAllowEvent {
   toolUseId: string;
 }
 
+/**
+ * Sprite-response event type exposed by ClaudeCliAdapter. Keeps ws.ts
+ * decoupled from the internal BtwQueue event shape.
+ */
+export interface SpriteResponseEvent {
+  sessionId: string;
+  spriteHandle: string;
+  subagentId: string;
+  messageId: string;
+  text: string;
+  status: 'delivered' | 'dropped';
+  dropReason?: string;
+}
+
 export class ClaudeCliAdapter implements IAdapter {
   readonly type = 'cli' as const;
   private emitter = new EventEmitter();
@@ -137,11 +152,37 @@ export class ClaudeCliAdapter implements IAdapter {
   private sessionManager: SessionManager;
   private approvalQueue: ApprovalQueue;
   readonly permissionFilter: PermissionFilter;
+  /** Wave 4 — /btw queue. See `relay/src/sprites/btw-queue.ts`. */
+  readonly btwQueue = new BtwQueue();
 
   constructor(sessionManager: SessionManager, approvalQueue: ApprovalQueue) {
     this.sessionManager = sessionManager;
     this.approvalQueue = approvalQueue;
     this.permissionFilter = new PermissionFilter();
+
+    // Fan queue terminal events out through the adapter's main emitter so
+    // ws.ts can subscribe with a single `on('sprite-response', ...)`.
+    this.btwQueue.on('responded', (ev: BtwQueueEventMap['responded']) => {
+      this.emitter.emit('sprite-response', {
+        sessionId: ev.sessionId,
+        spriteHandle: ev.spriteHandle,
+        subagentId: ev.subagentId,
+        messageId: ev.messageId,
+        text: ev.text,
+        status: 'delivered',
+      } satisfies SpriteResponseEvent);
+    });
+    this.btwQueue.on('dropped', (ev: BtwQueueEventMap['dropped']) => {
+      this.emitter.emit('sprite-response', {
+        sessionId: ev.sessionId,
+        spriteHandle: ev.spriteHandle,
+        subagentId: ev.subagentId,
+        messageId: ev.messageId,
+        text: '',
+        status: 'dropped',
+        dropReason: ev.reason,
+      } satisfies SpriteResponseEvent);
+    });
   }
 
   async start(workingDir: string): Promise<Session> {
@@ -263,6 +304,14 @@ export class ClaudeCliAdapter implements IAdapter {
                 const stopInput = input as SubagentStopHookInput;
                 const { agent_id: agentId } = stopInput;
 
+                // Wave 4 — drop any /btw messages queued for this subagent.
+                // Scenario #4: agent finished before we could deliver. Emits
+                // 'dropped' which the adapter forwards as sprite-response.
+                this.btwQueue.dropForSubagent(
+                  agentId,
+                  'Subagent completed before delivery',
+                );
+
                 // `last_assistant_message` is available on stopInput
                 // but ws.ts's `dismissed` handler (see routes/ws.ts
                 // agent-lifecycle switch) ignores `event.result` —
@@ -348,9 +397,43 @@ export class ClaudeCliAdapter implements IAdapter {
     logger.info({ sessionId, agentId, textLength: text.length }, 'Agent message sent via SDK');
   }
 
+  /**
+   * Wave 4 — enqueue a /btw sprite message for turn-boundary injection.
+   * Used by ws.ts when a client sends `sprite.message`. The queue emits
+   * 'responded' or 'dropped' which fans out as `sprite-response` events
+   * to ws.ts.
+   */
+  enqueueSpriteMessage(input: {
+    sessionId: string;
+    subagentId: string;
+    spriteHandle: string;
+    messageId: string;
+    userText: string;
+    role: string;
+    task: string;
+  }): void {
+    if (!this.sessions.has(input.sessionId)) {
+      // Session not alive here — this is the single-worker path and the
+      // session didn't exist. Emit dropped so caller sees a terminal state.
+      this.btwQueue.enqueue(input);
+      this.btwQueue.dropForSubagent(input.subagentId, 'Session not alive');
+      return;
+    }
+    this.btwQueue.enqueue(input);
+  }
+
+  /** Wave 4 — drop /btw entries for a subagent that's been unlinked. */
+  dropSpriteForSubagent(subagentId: string, reason: string): void {
+    this.btwQueue.dropForSubagent(subagentId, reason);
+  }
+
   async cancelOperation(sessionId: string): Promise<void> {
     const entry = this.sessions.get(sessionId);
     if (!entry) return;
+
+    // Wave 4 — drop pending /btw entries. They can't be delivered once the
+    // SDK session closes.
+    this.btwQueue.dropForSession(sessionId, 'Session cancelled');
 
     // Close the SDK session (kills the underlying Claude process) and
     // abort the stream consumption loop so we stop processing events.
@@ -461,6 +544,12 @@ export class ClaudeCliAdapter implements IAdapter {
         // Turn complete (stream yielded `result` and returned).
         // Loop back to call stream() again for the next turn.
         logger.debug({ sessionId, messagesInTurn }, 'Turn stream ended, waiting for next turn');
+
+        // Wave 4 — drain one queued /btw at the turn boundary. See the
+        // identical path in fleet/worker.ts for the design rationale.
+        if (!signal.aborted) {
+          await this.drainOneBtw(sessionId, sdkSession);
+        }
       }
     } catch (err) {
       if (!signal.aborted) {
@@ -470,6 +559,41 @@ export class ClaudeCliAdapter implements IAdapter {
     } finally {
       if (entry) entry.streamAlive = false;
       logger.info({ sessionId }, 'Stream consumer exited');
+    }
+  }
+
+  /**
+   * Drain one queued /btw for this session at a turn boundary. One per
+   * boundary so the next assistant message can be correlated unambiguously.
+   */
+  private async drainOneBtw(sessionId: string, sdkSession: SDKSession): Promise<void> {
+    const queued = this.btwQueue.peekQueuedForSession(sessionId);
+    if (queued.length === 0) return;
+    const oldest = queued[0];
+    if (!oldest) return;
+    const entry = this.btwQueue.takeNextForSubagent(oldest.subagentId);
+    if (!entry) return;
+    try {
+      await sdkSession.send(entry.constrainedText);
+      this.btwQueue.markAwaitingResponse(entry.messageId);
+      logger.info(
+        {
+          sessionId,
+          subagentId: entry.subagentId,
+          messageId: entry.messageId,
+          queuedForMs: Date.now() - entry.queuedAt,
+        },
+        'Injected /btw at turn boundary, awaiting response',
+      );
+    } catch (err) {
+      logger.error(
+        { sessionId, subagentId: entry.subagentId, messageId: entry.messageId, err },
+        'Failed to inject /btw — dropping',
+      );
+      this.btwQueue.dropForSubagent(
+        entry.subagentId,
+        `Injection failed: ${err instanceof Error ? err.message : 'unknown'}`,
+      );
     }
   }
 
@@ -549,6 +673,12 @@ export class ClaudeCliAdapter implements IAdapter {
 
     const entry = this.sessions.get(sessionId);
 
+    // Wave 4 — if a /btw is awaiting a response, capture the full text of
+    // this assistant message as the response. Emits 'responded' which this
+    // adapter forwards as `sprite-response { status: 'delivered' }`.
+    const awaiting = this.btwQueue.findAwaitingForSession(sessionId);
+    let collectedText = '';
+
     for (const block of content) {
       if (block['type'] === 'text') {
         // Only emit full text if we didn't already stream it via deltas
@@ -557,6 +687,10 @@ export class ClaudeCliAdapter implements IAdapter {
           if (text) {
             this.emitter.emit('output', sessionId, text);
           }
+        }
+        if (awaiting) {
+          const t = block['text'];
+          if (typeof t === 'string') collectedText += t;
         }
       }
 
@@ -567,6 +701,10 @@ export class ClaudeCliAdapter implements IAdapter {
           sessionId,
         } satisfies ToolInfo);
       }
+    }
+
+    if (awaiting && collectedText.trim().length > 0) {
+      this.btwQueue.markResponded(awaiting.messageId, collectedText);
     }
   }
 
@@ -673,6 +811,8 @@ export class ClaudeCliAdapter implements IAdapter {
   destroySession(sessionId: string): void {
     const entry = this.sessions.get(sessionId);
     if (!entry) return;
+    // Wave 4 — drop any /btw entries for the session being destroyed.
+    this.btwQueue.dropForSession(sessionId, 'Session destroyed');
     entry.streamAbort.abort();
     entry.sdkSession.close();
     entry.session.close();
@@ -689,6 +829,7 @@ export class ClaudeCliAdapter implements IAdapter {
   on(event: 'tool-complete', handler: (result: ToolResult) => void): void;
   on(event: 'agent-lifecycle', handler: (event: AgentEvent) => void): void;
   on(event: 'session-result', handler: (result: SessionResult) => void): void;
+  on(event: 'sprite-response', handler: (ev: SpriteResponseEvent) => void): void;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   on(event: string, handler: (...args: any[]) => void): void {
     this.emitter.on(event, handler);

--- a/relay/src/adapters/claude-cli.adapter.ts
+++ b/relay/src/adapters/claude-cli.adapter.ts
@@ -567,6 +567,22 @@ export class ClaudeCliAdapter implements IAdapter {
    * boundary so the next assistant message can be correlated unambiguously.
    */
   private async drainOneBtw(sessionId: string, sdkSession: SDKSession): Promise<void> {
+    // Single-in-flight guard: if a previous /btw for this session is still
+    // awaiting a response, do NOT inject another one or response
+    // correlation breaks. The next turn boundary (after the response lands
+    // or the entry is dropped) will resume draining.
+    const inFlight = this.btwQueue.findAwaitingForSession(sessionId);
+    if (inFlight) {
+      logger.debug(
+        {
+          sessionId,
+          awaitingMessageId: inFlight.messageId,
+        },
+        'Skipping /btw drain — another /btw still awaiting response for this session',
+      );
+      return;
+    }
+
     const queued = this.btwQueue.peekQueuedForSession(sessionId);
     if (queued.length === 0) return;
     const oldest = queued[0];
@@ -590,8 +606,10 @@ export class ClaudeCliAdapter implements IAdapter {
         { sessionId, subagentId: entry.subagentId, messageId: entry.messageId, err },
         'Failed to inject /btw — dropping',
       );
-      this.btwQueue.dropForSubagent(
-        entry.subagentId,
+      // Drop ONLY this entry so unrelated queued messages for the same
+      // subagent survive to try again on the next turn boundary.
+      this.btwQueue.dropByMessageId(
+        entry.messageId,
         `Injection failed: ${err instanceof Error ? err.message : 'unknown'}`,
       );
     }

--- a/relay/src/fleet/fleet-manager.ts
+++ b/relay/src/fleet/fleet-manager.ts
@@ -35,7 +35,7 @@ import type {
   AgentEvent,
   SessionResult,
 } from '../adapters/adapter.interface.js';
-import type { AutoAllowEvent } from '../adapters/claude-cli.adapter.js';
+import type { AutoAllowEvent, SpriteResponseEvent } from '../adapters/claude-cli.adapter.js';
 import type { ApprovalDecision } from '../hooks/approval-queue.js';
 import {
   isChildToParentMessage,
@@ -461,6 +461,21 @@ export class FleetManager {
       case 'ipc:worker.error':
         logger.error({ workerId: msg.workerId, error: msg.error }, 'Worker-level error');
         break;
+
+      case 'ipc:sprite.response':
+        // Wave 4 — worker's BtwQueue hit a terminal state for a /btw.
+        // Re-emit as an adapter-shaped event so ws.ts can forward it
+        // to iOS/PWA clients uniformly with the single-worker path.
+        this.emitter.emit('sprite-response', {
+          sessionId: msg.sessionId,
+          spriteHandle: msg.spriteHandle,
+          subagentId: msg.subagentId,
+          messageId: msg.messageId,
+          text: msg.text,
+          status: msg.status,
+          dropReason: msg.dropReason,
+        } satisfies SpriteResponseEvent);
+        break;
     }
   }
 
@@ -541,6 +556,53 @@ export class FleetManager {
       sessionId,
       agentId,
       text,
+    });
+  }
+
+  /**
+   * Wave 4 — enqueue a /btw sprite message. The worker owning `sessionId`
+   * receives it via IPC and injects at the next turn boundary.
+   * Returns true if routed, false if no worker was found (caller should
+   * emit a `dropped` sprite.response directly).
+   */
+  enqueueSpriteMessage(input: {
+    sessionId: string;
+    subagentId: string;
+    spriteHandle: string;
+    messageId: string;
+    userText: string;
+    role: string;
+    task: string;
+  }): boolean {
+    const entry = this.getWorkerForSession(input.sessionId);
+    if (!entry) return false;
+    this.sendToWorker(entry, {
+      type: 'ipc:sprite.enqueue',
+      sessionId: input.sessionId,
+      subagentId: input.subagentId,
+      spriteHandle: input.spriteHandle,
+      messageId: input.messageId,
+      userText: input.userText,
+      role: input.role,
+      task: input.task,
+    });
+    return true;
+  }
+
+  /**
+   * Wave 4 — tell the worker to drop any /btw entries queued for a
+   * subagent. Called when the sprite layer detects an unlink from a
+   * non-SubagentStop path (the SubagentStop hook inside the worker
+   * already handles that case locally).
+   */
+  dropSpriteForSubagent(sessionId: string, subagentId: string, reason: string): void {
+    const entry = this.getWorkerForSession(sessionId);
+    if (!entry) return;
+    this.sendToWorker(entry, {
+      type: 'ipc:sprite.drop',
+      sessionId,
+      subagentId,
+      reason,
     });
   }
 
@@ -770,6 +832,7 @@ export class FleetManager {
   on(event: 'tool-complete', handler: (result: ToolResult) => void): void;
   on(event: 'agent-lifecycle', handler: (event: AgentEvent) => void): void;
   on(event: 'session-result', handler: (result: SessionResult) => void): void;
+  on(event: 'sprite-response', handler: (ev: SpriteResponseEvent) => void): void;
   on(event: 'worker-spawned', handler: (info: { workerId: string; workingDir: string; dirName: string }) => void): void;
   on(event: 'worker-crashed', handler: (info: { workerId: string; workingDir: string; dirName: string; restartCount: number }) => void): void;
   on(event: 'worker-restarted', handler: (info: { workerId: string; workingDir: string; dirName: string; restartCount: number }) => void): void;

--- a/relay/src/fleet/ipc-messages.ts
+++ b/relay/src/fleet/ipc-messages.ts
@@ -77,6 +77,34 @@ export interface IpcSpriteMessage {
   messageId: string;
 }
 
+/**
+ * Parent → Child: enqueue a /btw message for turn-boundary injection.
+ * Worker owns the queue; parent routes here after looking up the session's
+ * worker. The `role` + `task` come from the sprite mapping so the worker
+ * can build the constraint framing without loading mapping state itself.
+ */
+export interface IpcSpriteEnqueue {
+  type: 'ipc:sprite.enqueue';
+  sessionId: string;
+  subagentId: string;
+  spriteHandle: string;
+  messageId: string;
+  userText: string;
+  role: string;
+  task: string;
+}
+
+/**
+ * Parent → Child: drop queued /btw entries for a subagent (fires when the
+ * sprite layer unlinks before delivery — scenario #4).
+ */
+export interface IpcSpriteDrop {
+  type: 'ipc:sprite.drop';
+  sessionId: string;
+  subagentId: string;
+  reason: string;
+}
+
 export type ParentToChildMessage =
   | IpcSessionStart
   | IpcSessionDestroy
@@ -87,7 +115,9 @@ export type ParentToChildMessage =
   | IpcContextAdd
   | IpcContextRemove
   | IpcPermissionMode
-  | IpcSpriteMessage;
+  | IpcSpriteMessage
+  | IpcSpriteEnqueue
+  | IpcSpriteDrop;
 
 // ── Child → Parent Messages ────────────────────────────────
 
@@ -174,6 +204,22 @@ export interface IpcWorkerError {
   error: string;
 }
 
+/**
+ * Child → Parent: a /btw message reached terminal state (delivered to
+ * the client or dropped because the subagent went away first). The parent
+ * fans this out to iOS/PWA clients as `sprite.response`.
+ */
+export interface IpcSpriteResponse {
+  type: 'ipc:sprite.response';
+  sessionId: string;
+  spriteHandle: string;
+  subagentId: string;
+  messageId: string;
+  text: string;
+  status: 'delivered' | 'dropped';
+  dropReason?: string;
+}
+
 export type ChildToParentMessage =
   | IpcSessionStarted
   | IpcSessionError
@@ -185,7 +231,8 @@ export type ChildToParentMessage =
   | IpcAgentLifecycle
   | IpcSessionResult
   | IpcWorkerReady
-  | IpcWorkerError;
+  | IpcWorkerError
+  | IpcSpriteResponse;
 
 // ── Union of all IPC messages ──────────────────────────────
 
@@ -209,6 +256,7 @@ export function isChildToParentMessage(msg: unknown): msg is ChildToParentMessag
     'ipc:session.result',
     'ipc:worker.ready',
     'ipc:worker.error',
+    'ipc:sprite.response',
   ].includes(typed.type);
 }
 
@@ -227,5 +275,7 @@ export function isParentToChildMessage(msg: unknown): msg is ParentToChildMessag
     'ipc:context.remove',
     'ipc:permission.mode',
     'ipc:sprite.message',
+    'ipc:sprite.enqueue',
+    'ipc:sprite.drop',
   ].includes(typed.type);
 }

--- a/relay/src/fleet/worker.ts
+++ b/relay/src/fleet/worker.ts
@@ -608,6 +608,23 @@ async function drainOneBtwForSession(
   sessionId: string,
   sdkSession: SDKSession,
 ): Promise<void> {
+  // Single-in-flight guard: if a previous /btw for this session is still
+  // awaiting a response (e.g. injection yielded tool-calls before any
+  // assistant text), do NOT inject another one or response correlation
+  // breaks. The next turn boundary (after the response lands or the
+  // entry is dropped) will resume draining.
+  const inFlight = btwQueue.findAwaitingForSession(sessionId);
+  if (inFlight) {
+    workerLog.debug(
+      {
+        sessionId,
+        awaitingMessageId: inFlight.messageId,
+      },
+      'Skipping /btw drain — another /btw still awaiting response for this session',
+    );
+    return;
+  }
+
   const queued = btwQueue.peekQueuedForSession(sessionId);
   if (queued.length === 0) return;
 
@@ -634,9 +651,11 @@ async function drainOneBtwForSession(
       { sessionId, subagentId: entry.subagentId, messageId: entry.messageId, err },
       'Failed to inject /btw — dropping',
     );
-    // Drop this entry so client sees a final answer rather than hanging.
-    btwQueue.dropForSubagent(
-      entry.subagentId,
+    // Drop ONLY this entry so the client sees a final answer rather
+    // than hanging, while unrelated queued messages for the same
+    // subagent survive to try again on the next turn boundary.
+    btwQueue.dropByMessageId(
+      entry.messageId,
       `Injection failed: ${err instanceof Error ? err.message : 'unknown'}`,
     );
   }

--- a/relay/src/fleet/worker.ts
+++ b/relay/src/fleet/worker.ts
@@ -25,6 +25,7 @@ import {
   type ParentToChildMessage,
   type ChildToParentMessage,
 } from './ipc-messages.js';
+import { BtwQueue } from '../sprites/btw-queue.js';
 import pino from 'pino';
 
 // ── Worker-local logger ─────────────────────────────────────
@@ -95,6 +96,38 @@ interface WorkerSession {
 const sessions = new Map<string, WorkerSession>();
 const approvalQueue = new ApprovalQueue();
 const permissionFilter = new PermissionFilter();
+
+// ── Sprite /btw queue (Wave 4) ─────────────────────────────
+// Per-worker BtwQueue. Wires terminal events ('responded', 'dropped') back
+// to the parent relay process via IPC; the parent fans out `sprite.response`
+// to iOS/PWA clients. 'injected' is internal — we only need to tell clients
+// when a message actually landed or went away.
+const btwQueue = new BtwQueue();
+
+btwQueue.on('responded', (ev) => {
+  sendToParent({
+    type: 'ipc:sprite.response',
+    sessionId: ev.sessionId,
+    spriteHandle: ev.spriteHandle,
+    subagentId: ev.subagentId,
+    messageId: ev.messageId,
+    text: ev.text,
+    status: 'delivered',
+  });
+});
+
+btwQueue.on('dropped', (ev) => {
+  sendToParent({
+    type: 'ipc:sprite.response',
+    sessionId: ev.sessionId,
+    spriteHandle: ev.spriteHandle,
+    subagentId: ev.subagentId,
+    messageId: ev.messageId,
+    text: '',
+    status: 'dropped',
+    dropReason: ev.reason,
+  });
+});
 
 /**
  * Drain expired entries from a pending-task map. Called on every
@@ -256,6 +289,22 @@ async function startSession(sessionId: string, _workingDir: string): Promise<voi
                 const stopInput = input as SubagentStopHookInput;
                 const { agent_id: agentId } = stopInput;
 
+                // Wave 4 — drop any /btw messages queued for this
+                // subagent before we notify the parent. Scenario #4:
+                // the agent completed before we could deliver. The
+                // queue emits 'dropped' which sendToParent forwards
+                // as `sprite.response { status: 'dropped' }`.
+                const dropped = btwQueue.dropForSubagent(
+                  agentId,
+                  'Subagent completed before delivery',
+                );
+                if (dropped > 0) {
+                  workerLog.info(
+                    { sessionId, agentId, dropped },
+                    'Dropped /btw messages due to SubagentStop',
+                  );
+                }
+
                 // `last_assistant_message` is available on stopInput
                 // but ws.ts's `dismissed` handler (see routes/ws.ts
                 // agent-lifecycle switch) ignores `event.result` —
@@ -315,6 +364,14 @@ function destroySession(sessionId: string): void {
   const entry = sessions.get(sessionId);
   if (!entry) return;
 
+  // Wave 4 — drop any /btw messages queued for this session. These
+  // entries can't be injected anymore; emit 'dropped' so the client
+  // knows. Scenario: session.end while messages are pending.
+  const droppedCount = btwQueue.dropForSession(sessionId, 'Session ended');
+  if (droppedCount > 0) {
+    workerLog.info({ sessionId, droppedCount }, 'Dropped /btw messages on session destroy');
+  }
+
   entry.streamAbort.abort();
   entry.sdkSession.close();
   sessions.delete(sessionId);
@@ -365,6 +422,10 @@ async function sendAgentMessage(sessionId: string, agentId: string, text: string
 async function cancelSession(sessionId: string): Promise<void> {
   const entry = sessions.get(sessionId);
   if (!entry) return;
+
+  // Wave 4 — drop any /btw messages queued for this session (same rationale
+  // as destroySession).
+  btwQueue.dropForSession(sessionId, 'Session cancelled');
 
   entry.streamAbort.abort();
   entry.sdkSession.close();
@@ -507,6 +568,21 @@ async function consumeStream(
       }
 
       workerLog.debug({ sessionId, messagesInTurn }, 'Turn stream ended, waiting for next turn');
+
+      // Wave 4 — drain any /btw messages queued for this session at the
+      // turn boundary. `stream()` just returned; before looping back to
+      // `stream()` again we can synchronously call `sdkSession.send()`
+      // with the constraint-framed user turn. The NEXT iteration's
+      // assistant text will be captured as the /btw response by
+      // `handleAssistantMessage` / `handleStreamEvent`.
+      //
+      // Spec M1 says a single /btw at a time per sprite, but multiple
+      // sprites in the same session can each have one queued. We inject
+      // only ONE per turn boundary to keep response correlation clean
+      // — the next turn boundary will drain the next one.
+      if (!signal.aborted) {
+        await drainOneBtwForSession(sessionId, sdkSession);
+      }
     }
   } catch (err) {
     if (!signal.aborted) {
@@ -520,6 +596,49 @@ async function consumeStream(
   } finally {
     if (entry) entry.streamAlive = false;
     workerLog.info({ sessionId }, 'Stream consumer exited');
+  }
+}
+
+/**
+ * Drain one queued /btw from the session's queue and send it to the SDK
+ * as a new user turn. Called at turn boundaries in `consumeStream`. Only
+ * one per boundary so response correlation is unambiguous.
+ */
+async function drainOneBtwForSession(
+  sessionId: string,
+  sdkSession: SDKSession,
+): Promise<void> {
+  const queued = btwQueue.peekQueuedForSession(sessionId);
+  if (queued.length === 0) return;
+
+  // Oldest entry first; one subagent at a time.
+  const oldest = queued[0];
+  if (!oldest) return;
+  const entry = btwQueue.takeNextForSubagent(oldest.subagentId);
+  if (!entry) return;
+
+  try {
+    await sdkSession.send(entry.constrainedText);
+    btwQueue.markAwaitingResponse(entry.messageId);
+    workerLog.info(
+      {
+        sessionId,
+        subagentId: entry.subagentId,
+        messageId: entry.messageId,
+        queuedForMs: Date.now() - entry.queuedAt,
+      },
+      'Injected /btw at turn boundary, awaiting response',
+    );
+  } catch (err) {
+    workerLog.error(
+      { sessionId, subagentId: entry.subagentId, messageId: entry.messageId, err },
+      'Failed to inject /btw — dropping',
+    );
+    // Drop this entry so client sees a final answer rather than hanging.
+    btwQueue.dropForSubagent(
+      entry.subagentId,
+      `Injection failed: ${err instanceof Error ? err.message : 'unknown'}`,
+    );
   }
 }
 
@@ -599,6 +718,16 @@ function handleAssistantMessage(sessionId: string, message: SDKMessage): void {
 
   const entry = sessions.get(sessionId);
 
+  // Wave 4 — if a /btw is awaiting a response for this session, capture
+  // the full text content of this assistant message as the response.
+  // This runs alongside the normal output-emission path (we still stream
+  // to the client so the operator can also see it) — the /btw response is
+  // a COPY, not a replacement. Response correlation is imprecise per the
+  // research doc; the constraint framing should keep this to the 1-2
+  // sentences we asked for.
+  const awaiting = btwQueue.findAwaitingForSession(sessionId);
+  let collectedText = '';
+
   for (const block of content) {
     if (block['type'] === 'text') {
       // Only emit full text if we didn't already stream it via deltas
@@ -607,6 +736,10 @@ function handleAssistantMessage(sessionId: string, message: SDKMessage): void {
         if (text) {
           sendToParent({ type: 'ipc:output', sessionId, chunk: text });
         }
+      }
+      if (awaiting) {
+        const t = block['text'];
+        if (typeof t === 'string') collectedText += t;
       }
     }
 
@@ -618,6 +751,11 @@ function handleAssistantMessage(sessionId: string, message: SDKMessage): void {
         input: block['input'] as Record<string, unknown>,
       });
     }
+  }
+
+  // Resolve the awaiting /btw if we captured text.
+  if (awaiting && collectedText.trim().length > 0) {
+    btwQueue.markResponded(awaiting.messageId, collectedText);
   }
 }
 
@@ -759,6 +897,28 @@ function handleParentMessage(msg: ParentToChildMessage): void {
         const queueMode = msg.mode === 'delay' ? 'delay' as const : 'manual' as const;
         approvalQueue.setMode(queueMode, msg.delaySeconds);
       }
+      break;
+
+    case 'ipc:sprite.enqueue':
+      // Wave 4 — parent routed a /btw for one of our sessions. Enqueue it;
+      // the consumeStream turn-boundary drain will pick it up next tick.
+      btwQueue.enqueue({
+        sessionId: msg.sessionId,
+        subagentId: msg.subagentId,
+        spriteHandle: msg.spriteHandle,
+        messageId: msg.messageId,
+        userText: msg.userText,
+        role: msg.role,
+        task: msg.task,
+      });
+      break;
+
+    case 'ipc:sprite.drop':
+      // Wave 4 — parent signalled a sprite unlink (SubagentStop-based drops
+      // happen locally; this is for fan-out from the parent when the sprite
+      // mapping layer decides a mapping is gone, e.g. from agent-lifecycle
+      // paths that bypass SubagentStop).
+      btwQueue.dropForSubagent(msg.subagentId, msg.reason);
       break;
   }
 }

--- a/relay/src/routes/ws.ts
+++ b/relay/src/routes/ws.ts
@@ -911,7 +911,7 @@ export function createWsRoute(deps: WsDeps): FastifyPluginAsync {
         break;
       }
 
-      // ── Sprite messaging (Wave 4 will implement actual queue/injection) ──
+      // ── Sprite messaging (Wave 4 — real queue + turn-boundary injection) ──
       case 'sprite.message': {
         // Validate the sprite mapping exists for this agent
         const spriteState = spriteMappings.get(message.sessionId);
@@ -932,8 +932,39 @@ export function createWsRoute(deps: WsDeps): FastifyPluginAsync {
           });
           break;
         }
-        // Wave 2 acknowledge: confirm receipt. Wave 4 will implement
-        // turn-boundary queueing and actual injection.
+
+        // Route the /btw to the worker owning this session. Worker's
+        // BtwQueue injects at the next turn boundary and emits a
+        // terminal `ipc:sprite.response` back to the parent → re-fanned
+        // out via the `sprite-response` listener below.
+        const routed = fleetManager.enqueueSpriteMessage({
+          sessionId: message.sessionId,
+          subagentId: message.subagentId,
+          spriteHandle: message.spriteHandle,
+          messageId: message.messageId,
+          userText: message.text,
+          role: mapping.canonicalRole,
+          task: mapping.task,
+        });
+        if (!routed) {
+          // No worker for the session — treat as dropped. This is the
+          // session-ended race: mapping existed in memory but the SDK
+          // session went away between mapping-check and enqueue.
+          sendToClient(ws, {
+            type: 'sprite.response',
+            sessionId: message.sessionId,
+            spriteHandle: message.spriteHandle,
+            subagentId: message.subagentId,
+            messageId: message.messageId,
+            text: '',
+            status: 'dropped',
+            dropReason: 'No active session — /btw cannot be delivered',
+          });
+          break;
+        }
+        // Immediate `queued` ack so clients know the relay accepted the
+        // message. The terminal `delivered` / `dropped` response follows
+        // when the turn boundary drains the queue.
         sendToClient(ws, {
           type: 'sprite.response',
           sessionId: message.sessionId,
@@ -944,8 +975,14 @@ export function createWsRoute(deps: WsDeps): FastifyPluginAsync {
           status: 'queued',
         });
         logger.info(
-          { sessionId: message.sessionId, subagentId: message.subagentId, spriteHandle: message.spriteHandle },
-          'Sprite message received — queued for Wave 4 delivery',
+          {
+            sessionId: message.sessionId,
+            subagentId: message.subagentId,
+            spriteHandle: message.spriteHandle,
+            messageId: message.messageId,
+            textLength: message.text.length,
+          },
+          'Sprite /btw routed to worker queue',
         );
         break;
       }
@@ -1855,6 +1892,33 @@ export function createWsRoute(deps: WsDeps): FastifyPluginAsync {
       });
     });
 
+    // ── Sprite /btw responses (Wave 4) ──────────────────────
+    // Worker's BtwQueue hit a terminal state (delivered or dropped) —
+    // forward to the session's clients as `sprite.response`.
+    fleetManager.on('sprite-response', (ev) => {
+      broadcastToSession(ev.sessionId, {
+        type: 'sprite.response',
+        sessionId: ev.sessionId,
+        spriteHandle: ev.spriteHandle,
+        subagentId: ev.subagentId,
+        messageId: ev.messageId,
+        text: ev.text,
+        status: ev.status,
+        dropReason: ev.dropReason,
+      });
+      logger.info(
+        {
+          sessionId: ev.sessionId,
+          subagentId: ev.subagentId,
+          messageId: ev.messageId,
+          status: ev.status,
+          dropReason: ev.dropReason,
+          textLength: ev.text.length,
+        },
+        'Sprite /btw terminal state forwarded to clients',
+      );
+    });
+
     fleetManager.on('agent-lifecycle', (event) => {
       const sid = event.sessionId;
       switch (event.event) {
@@ -1929,6 +1993,11 @@ export function createWsRoute(deps: WsDeps): FastifyPluginAsync {
                 subagentId: event.agentId,
                 reason: 'completed',
               });
+              // Wave 4 — tell worker to drop any queued /btw for this
+              // subagent. Scenario #4. The SubagentStop hook inside the
+              // worker usually fires first and handles this locally, but
+              // some lifecycle paths skip SubagentStop — be idempotent.
+              fleetManager.dropSpriteForSubagent(sid, event.agentId, 'Subagent completed');
             }
           }
           break;
@@ -1953,6 +2022,8 @@ export function createWsRoute(deps: WsDeps): FastifyPluginAsync {
                 subagentId: event.agentId,
                 reason: 'dismissed',
               });
+              // Wave 4 — same as 'complete' above, drop any queued /btw.
+              fleetManager.dropSpriteForSubagent(sid, event.agentId, 'Subagent dismissed');
             }
           }
           break;

--- a/relay/src/sprites/__tests__/btw-queue.test.ts
+++ b/relay/src/sprites/__tests__/btw-queue.test.ts
@@ -1,0 +1,217 @@
+import { describe, it, expect, vi } from 'vitest';
+import { BtwQueue, buildConstrainedText } from '../btw-queue.js';
+
+describe('buildConstrainedText', () => {
+  it('wraps user text in the locked constraint framing', () => {
+    const out = buildConstrainedText({
+      role: 'frontend',
+      task: 'build a form',
+      userText: 'any progress on that form?',
+    });
+    expect(out).toContain('non-blocking observation');
+    expect(out).toContain('subagent "frontend"');
+    expect(out).toContain('task: "build a form"');
+    expect(out).toContain("'any progress on that form?'");
+    expect(out).toContain('1-2 sentences');
+    expect(out).toContain('Do NOT change the subagent');
+  });
+
+  it('escapes quotes in user text, role, and task', () => {
+    const out = buildConstrainedText({
+      role: "it's fine",
+      task: "don't worry",
+      userText: "don't panic",
+    });
+    // Single quotes are escaped so the outer framing stays parseable.
+    expect(out).toContain("\\'");
+  });
+});
+
+describe('BtwQueue', () => {
+  const baseInput = () => ({
+    sessionId: 'sess-1',
+    subagentId: 'agent-1',
+    spriteHandle: 'sprite-abc',
+    messageId: 'msg-1',
+    userText: 'hi there',
+    role: 'backend',
+    task: 'wire the queue',
+  });
+
+  it('enqueues a message and marks it queued', () => {
+    const q = new BtwQueue();
+    const entry = q.enqueue(baseInput());
+    expect(entry.status).toBe('queued');
+    expect(entry.constrainedText).toContain('non-blocking observation');
+    expect(q.size).toBe(1);
+    expect(q.sizeFor('agent-1')).toBe(1);
+  });
+
+  it('emits "injected" when takeNextForSubagent is called', () => {
+    const q = new BtwQueue();
+    q.enqueue(baseInput());
+    const injected = vi.fn();
+    q.on('injected', injected);
+    const taken = q.takeNextForSubagent('agent-1');
+    expect(taken?.status).toBe('injected');
+    expect(injected).toHaveBeenCalledWith({
+      sessionId: 'sess-1',
+      subagentId: 'agent-1',
+      spriteHandle: 'sprite-abc',
+      messageId: 'msg-1',
+    });
+  });
+
+  it('FIFO per subagent (M1 — multiple queued)', () => {
+    const q = new BtwQueue();
+    q.enqueue({ ...baseInput(), messageId: 'msg-1' });
+    q.enqueue({ ...baseInput(), messageId: 'msg-2' });
+    q.enqueue({ ...baseInput(), messageId: 'msg-3' });
+    expect(q.sizeFor('agent-1')).toBe(3);
+    const first = q.takeNextForSubagent('agent-1');
+    expect(first?.messageId).toBe('msg-1');
+    const second = q.takeNextForSubagent('agent-1');
+    expect(second?.messageId).toBe('msg-2');
+    const third = q.takeNextForSubagent('agent-1');
+    expect(third?.messageId).toBe('msg-3');
+  });
+
+  it('peekQueuedForSession returns only queued entries for that session', () => {
+    const q = new BtwQueue();
+    q.enqueue({ ...baseInput(), messageId: 'msg-1', subagentId: 'a1' });
+    q.enqueue({ ...baseInput(), messageId: 'msg-2', subagentId: 'a2' });
+    q.enqueue({ ...baseInput(), messageId: 'msg-3', sessionId: 'sess-other' });
+
+    const forSess1 = q.peekQueuedForSession('sess-1');
+    expect(forSess1).toHaveLength(2);
+    expect(forSess1.map(e => e.messageId)).toEqual(['msg-1', 'msg-2']);
+  });
+
+  it('peekQueuedForSession ignores already-injected entries', () => {
+    const q = new BtwQueue();
+    q.enqueue({ ...baseInput(), messageId: 'msg-1' });
+    q.enqueue({ ...baseInput(), messageId: 'msg-2' });
+    q.takeNextForSubagent('agent-1'); // injects msg-1
+    const forSess1 = q.peekQueuedForSession('sess-1');
+    expect(forSess1).toHaveLength(1);
+    expect(forSess1[0]!.messageId).toBe('msg-2');
+  });
+
+  it('markAwaitingResponse transitions injected entries correctly', () => {
+    const q = new BtwQueue();
+    q.enqueue(baseInput());
+    q.takeNextForSubagent('agent-1');
+    const marked = q.markAwaitingResponse('msg-1');
+    expect(marked?.status).toBe('awaiting_response');
+  });
+
+  it('findAwaitingForSession returns the in-flight entry', () => {
+    const q = new BtwQueue();
+    q.enqueue(baseInput());
+    q.takeNextForSubagent('agent-1');
+    q.markAwaitingResponse('msg-1');
+    const found = q.findAwaitingForSession('sess-1');
+    expect(found?.messageId).toBe('msg-1');
+    expect(found?.status).toBe('awaiting_response');
+  });
+
+  it('markResponded removes entry and emits "responded"', () => {
+    const q = new BtwQueue();
+    q.enqueue(baseInput());
+    q.takeNextForSubagent('agent-1');
+    q.markAwaitingResponse('msg-1');
+    const responded = vi.fn();
+    q.on('responded', responded);
+    const removed = q.markResponded('msg-1', 'Making good progress on the wiring!');
+    expect(removed?.messageId).toBe('msg-1');
+    expect(q.size).toBe(0);
+    expect(responded).toHaveBeenCalledWith({
+      sessionId: 'sess-1',
+      subagentId: 'agent-1',
+      spriteHandle: 'sprite-abc',
+      messageId: 'msg-1',
+      text: 'Making good progress on the wiring!',
+    });
+  });
+
+  it('dropForSubagent fires "dropped" for each entry (scenario #4)', () => {
+    const q = new BtwQueue();
+    q.enqueue({ ...baseInput(), messageId: 'msg-1' });
+    q.enqueue({ ...baseInput(), messageId: 'msg-2' });
+    const dropped = vi.fn();
+    q.on('dropped', dropped);
+    const count = q.dropForSubagent('agent-1', 'Subagent completed before delivery');
+    expect(count).toBe(2);
+    expect(dropped).toHaveBeenCalledTimes(2);
+    expect(dropped).toHaveBeenNthCalledWith(1, expect.objectContaining({
+      messageId: 'msg-1',
+      reason: 'Subagent completed before delivery',
+    }));
+    expect(dropped).toHaveBeenNthCalledWith(2, expect.objectContaining({
+      messageId: 'msg-2',
+      reason: 'Subagent completed before delivery',
+    }));
+    expect(q.size).toBe(0);
+  });
+
+  it('dropForSubagent drops both queued AND injected/awaiting entries', () => {
+    const q = new BtwQueue();
+    q.enqueue({ ...baseInput(), messageId: 'msg-1' });
+    q.enqueue({ ...baseInput(), messageId: 'msg-2' });
+    q.takeNextForSubagent('agent-1'); // msg-1 → injected
+    q.markAwaitingResponse('msg-1');  // msg-1 → awaiting_response
+    const dropped = vi.fn();
+    q.on('dropped', dropped);
+    const count = q.dropForSubagent('agent-1', 'Session ended');
+    expect(count).toBe(2);
+    expect(dropped).toHaveBeenCalledTimes(2);
+  });
+
+  it('dropForSession drops entries across multiple subagents', () => {
+    const q = new BtwQueue();
+    q.enqueue({ ...baseInput(), subagentId: 'a1', messageId: 'msg-1' });
+    q.enqueue({ ...baseInput(), subagentId: 'a2', messageId: 'msg-2' });
+    q.enqueue({ ...baseInput(), subagentId: 'a3', messageId: 'msg-3', sessionId: 'sess-2' });
+    const dropped = vi.fn();
+    q.on('dropped', dropped);
+    const count = q.dropForSession('sess-1', 'Session ended');
+    expect(count).toBe(2);
+    expect(dropped).toHaveBeenCalledTimes(2);
+    expect(q.sizeFor('a3')).toBe(1); // different session, not dropped
+  });
+
+  it('dropForSubagent on empty queue returns 0, emits nothing', () => {
+    const q = new BtwQueue();
+    const dropped = vi.fn();
+    q.on('dropped', dropped);
+    const count = q.dropForSubagent('ghost-agent', 'Nonexistent');
+    expect(count).toBe(0);
+    expect(dropped).not.toHaveBeenCalled();
+  });
+
+  it('takeNextForSubagent on empty queue returns undefined', () => {
+    const q = new BtwQueue();
+    expect(q.takeNextForSubagent('nobody')).toBeUndefined();
+  });
+
+  it('markResponded for unknown messageId returns undefined', () => {
+    const q = new BtwQueue();
+    expect(q.markResponded('ghost-msg', 'irrelevant')).toBeUndefined();
+  });
+
+  it('multiple subagents, independent queues', () => {
+    const q = new BtwQueue();
+    q.enqueue({ ...baseInput(), subagentId: 'a1', messageId: 'msg-a1-1' });
+    q.enqueue({ ...baseInput(), subagentId: 'a1', messageId: 'msg-a1-2' });
+    q.enqueue({ ...baseInput(), subagentId: 'a2', messageId: 'msg-a2-1' });
+
+    expect(q.sizeFor('a1')).toBe(2);
+    expect(q.sizeFor('a2')).toBe(1);
+    expect(q.size).toBe(3);
+
+    // Dropping a1 doesn't touch a2
+    q.dropForSubagent('a1', 'gone');
+    expect(q.sizeFor('a1')).toBe(0);
+    expect(q.sizeFor('a2')).toBe(1);
+  });
+});

--- a/relay/src/sprites/__tests__/btw-queue.test.ts
+++ b/relay/src/sprites/__tests__/btw-queue.test.ts
@@ -9,24 +9,72 @@ describe('buildConstrainedText', () => {
       userText: 'any progress on that form?',
     });
     expect(out).toContain('non-blocking observation');
+    // role, task, and userText are JSON.stringify'd → plain values come
+    // out wrapped in double quotes.
     expect(out).toContain('subagent "frontend"');
     expect(out).toContain('task: "build a form"');
-    expect(out).toContain("'any progress on that form?'");
+    expect(out).toContain('"any progress on that form?"');
     expect(out).toContain('1-2 sentences');
     expect(out).toContain('Do NOT change the subagent');
   });
 
-  it('escapes single quotes in user text, role, and task', () => {
+  it('encodes user text, role, and task with JSON-safe escaping', () => {
+    // Single quotes are a no-op for JSON.stringify — no backslash escape
+    // happens because they are not JSON metacharacters inside a double-
+    // quoted string.
     const out = buildConstrainedText({
       role: "it's fine",
       task: "don't worry",
       userText: "don't panic",
     });
-    // Only single quotes are escaped (double quotes are not — the
-    // surrounding framing uses double quotes around role/task but single
-    // quotes around the user text, so only single quotes need escaping
-    // to keep the structure parseable).
-    expect(out).toContain("\\'");
+    expect(out).toContain(`"it's fine"`);
+    expect(out).toContain(`"don't worry"`);
+    expect(out).toContain(`"don't panic"`);
+  });
+
+  it('escapes embedded double quotes via JSON.stringify', () => {
+    const out = buildConstrainedText({
+      role: 'say "hi"',
+      task: 'finish the "form"',
+      userText: 'he said "hello"',
+    });
+    // JSON-encoded embedded double quotes → \" inside the wrapping quotes.
+    expect(out).toContain('"say \\"hi\\""');
+    expect(out).toContain('"finish the \\"form\\""');
+    expect(out).toContain('"he said \\"hello\\""');
+    // Framing integrity: the full output is still a well-formed sentence
+    // with the expected framing tokens.
+    expect(out).toContain('non-blocking observation');
+    expect(out).toContain('Do NOT change the subagent');
+  });
+
+  it('escapes embedded backslashes via JSON.stringify', () => {
+    const out = buildConstrainedText({
+      role: 'path\\writer',
+      task: 'handle C:\\temp',
+      userText: 'one\\two\\three',
+    });
+    // JSON-encoded backslashes → each raw \ doubles to \\ inside quotes.
+    expect(out).toContain('"path\\\\writer"');
+    expect(out).toContain('"handle C:\\\\temp"');
+    expect(out).toContain('"one\\\\two\\\\three"');
+  });
+
+  it('escapes embedded newlines and tabs via JSON.stringify', () => {
+    const out = buildConstrainedText({
+      role: 'line1\nline2',
+      task: 'col1\tcol2',
+      userText: 'hello\nworld\twith\ttabs',
+    });
+    // JSON encodes literal newlines as the two-char sequence \n, and
+    // literal tabs as \t — so the produced framing never contains a raw
+    // control character and stays on one line.
+    expect(out).toContain('"line1\\nline2"');
+    expect(out).toContain('"col1\\tcol2"');
+    expect(out).toContain('"hello\\nworld\\twith\\ttabs"');
+    // No raw newlines / tabs leaked through.
+    expect(out).not.toMatch(/\n/);
+    expect(out).not.toMatch(/\t/);
   });
 });
 

--- a/relay/src/sprites/__tests__/btw-queue.test.ts
+++ b/relay/src/sprites/__tests__/btw-queue.test.ts
@@ -16,13 +16,16 @@ describe('buildConstrainedText', () => {
     expect(out).toContain('Do NOT change the subagent');
   });
 
-  it('escapes quotes in user text, role, and task', () => {
+  it('escapes single quotes in user text, role, and task', () => {
     const out = buildConstrainedText({
       role: "it's fine",
       task: "don't worry",
       userText: "don't panic",
     });
-    // Single quotes are escaped so the outer framing stays parseable.
+    // Only single quotes are escaped (double quotes are not — the
+    // surrounding framing uses double quotes around role/task but single
+    // quotes around the user text, so only single quotes need escaping
+    // to keep the structure parseable).
     expect(out).toContain("\\'");
   });
 });
@@ -197,6 +200,64 @@ describe('BtwQueue', () => {
   it('markResponded for unknown messageId returns undefined', () => {
     const q = new BtwQueue();
     expect(q.markResponded('ghost-msg', 'irrelevant')).toBeUndefined();
+  });
+
+  it('dropByMessageId removes only the targeted entry and emits "dropped"', () => {
+    const q = new BtwQueue();
+    q.enqueue({ ...baseInput(), messageId: 'msg-1' });
+    q.enqueue({ ...baseInput(), messageId: 'msg-2' });
+    q.enqueue({ ...baseInput(), messageId: 'msg-3' });
+    const dropped = vi.fn();
+    q.on('dropped', dropped);
+    const removed = q.dropByMessageId('msg-2', 'Injection failed: boom');
+    expect(removed?.messageId).toBe('msg-2');
+    expect(q.sizeFor('agent-1')).toBe(2);
+    expect(dropped).toHaveBeenCalledTimes(1);
+    expect(dropped).toHaveBeenCalledWith(expect.objectContaining({
+      sessionId: 'sess-1',
+      subagentId: 'agent-1',
+      messageId: 'msg-2',
+      reason: 'Injection failed: boom',
+    }));
+    // Remaining entries (msg-1, msg-3) survive.
+    const survivors = q.peekQueuedForSession('sess-1').map(e => e.messageId);
+    expect(survivors).toEqual(['msg-1', 'msg-3']);
+  });
+
+  it('dropByMessageId works on injected and awaiting_response entries', () => {
+    const q = new BtwQueue();
+    q.enqueue({ ...baseInput(), messageId: 'msg-1' });
+    q.enqueue({ ...baseInput(), messageId: 'msg-2' });
+    q.takeNextForSubagent('agent-1'); // msg-1 → injected
+    q.markAwaitingResponse('msg-1');  // msg-1 → awaiting_response
+    const dropped = vi.fn();
+    q.on('dropped', dropped);
+    const removed = q.dropByMessageId('msg-1', 'timed out');
+    expect(removed?.status).toBe('awaiting_response');
+    expect(dropped).toHaveBeenCalledTimes(1);
+    // msg-2 (still queued) is untouched.
+    expect(q.sizeFor('agent-1')).toBe(1);
+    expect(q.peekQueuedForSession('sess-1')[0]?.messageId).toBe('msg-2');
+  });
+
+  it('dropByMessageId returns undefined and emits nothing for unknown id', () => {
+    const q = new BtwQueue();
+    q.enqueue(baseInput());
+    const dropped = vi.fn();
+    q.on('dropped', dropped);
+    const removed = q.dropByMessageId('ghost-msg', 'irrelevant');
+    expect(removed).toBeUndefined();
+    expect(dropped).not.toHaveBeenCalled();
+    expect(q.size).toBe(1);
+  });
+
+  it('dropByMessageId cleans up an empty subagent list', () => {
+    const q = new BtwQueue();
+    q.enqueue({ ...baseInput(), subagentId: 'a1', messageId: 'msg-1' });
+    q.enqueue({ ...baseInput(), subagentId: 'a2', messageId: 'msg-2' });
+    q.dropByMessageId('msg-1', 'gone');
+    expect(q.sizeFor('a1')).toBe(0);
+    expect(q.sizeFor('a2')).toBe(1);
   });
 
   it('multiple subagents, independent queues', () => {

--- a/relay/src/sprites/btw-queue.ts
+++ b/relay/src/sprites/btw-queue.ts
@@ -68,14 +68,18 @@ export function buildConstrainedText(opts: {
   userText: string;
 }): string {
   const { role, task, userText } = opts;
-  // Escape single quotes to keep the framing parseable to Claude without
-  // breaking the surrounding structure.
-  const safeRole = role.replace(/'/g, "\\'");
-  const safeTask = task.replace(/'/g, "\\'");
-  const safeUser = userText.replace(/'/g, "\\'");
+  // Use JSON.stringify to produce properly-escaped, double-quoted strings.
+  // This handles embedded double quotes, backslashes, newlines, tabs, and
+  // any other control characters correctly — the framing stays well-formed
+  // regardless of what text the user or agent sends. JSON.stringify already
+  // includes the surrounding quotes, so the template literal does not add
+  // its own.
+  const safeRole = JSON.stringify(role);
+  const safeTask = JSON.stringify(task);
+  const safeUser = JSON.stringify(userText);
   return (
     `The user sent a non-blocking observation via sprite tap to subagent ` +
-    `"${safeRole}" (task: "${safeTask}"): '${safeUser}'. ` +
+    `${safeRole} (task: ${safeTask}): ${safeUser}. ` +
     `Respond in 1-2 sentences about the subagent's current progress. ` +
     `Do NOT change the subagent's task, plan, or approach. ` +
     `Continue exactly as planned.`

--- a/relay/src/sprites/btw-queue.ts
+++ b/relay/src/sprites/btw-queue.ts
@@ -273,9 +273,51 @@ export class BtwQueue extends EventEmitter {
   }
 
   /**
-   * Drop all queued+injected entries for a subagent (e.g. subagent
-   * completed before delivery). Emits 'dropped' for each with the same
-   * reason. Returns the count dropped.
+   * Drop a single entry by its messageId, regardless of which subagent
+   * owns it or what status it is in (queued / injected / awaiting_response).
+   *
+   * Used when a specific /btw entry must be abandoned (e.g. `sdkSession.send`
+   * throws on injection) without collaterally dropping unrelated queued
+   * messages for the same subagent. Emits 'dropped' for the entry that was
+   * removed. Returns the removed entry, or undefined if no match was found.
+   */
+  dropByMessageId(messageId: string, reason: string): BtwQueueEntry | undefined {
+    for (const [subagentId, list] of this.bySubagent) {
+      const idx = list.findIndex(e => e.messageId === messageId);
+      if (idx >= 0) {
+        const entry = list[idx]!;
+        list.splice(idx, 1);
+        if (list.length === 0) this.bySubagent.delete(subagentId);
+        logger.info(
+          {
+            sessionId: entry.sessionId,
+            subagentId,
+            messageId,
+            status: entry.status,
+            reason,
+          },
+          'BtwQueue: dropped (single messageId)',
+        );
+        this.emit('dropped', {
+          sessionId: entry.sessionId,
+          subagentId,
+          spriteHandle: entry.spriteHandle,
+          messageId: entry.messageId,
+          reason,
+        } satisfies BtwQueueEventMap['dropped']);
+        return entry;
+      }
+    }
+    return undefined;
+  }
+
+  /**
+   * Drop ALL entries for a subagent, regardless of status (queued /
+   * injected / awaiting_response). Used when the subagent is unlinked
+   * (complete / failed / dismissed) and nothing more can be delivered —
+   * callers rely on this being a clean teardown of the subagent's queue.
+   * Emits 'dropped' for each entry with the given reason. Returns the
+   * count dropped.
    */
   dropForSubagent(subagentId: string, reason: string): number {
     const list = this.bySubagent.get(subagentId);
@@ -303,8 +345,10 @@ export class BtwQueue extends EventEmitter {
   }
 
   /**
-   * Drop all queued+injected entries for a session (e.g. session.end).
-   * Used by the ws.ts session cleanup path to shed state.
+   * Drop ALL entries for a session, regardless of status (queued /
+   * injected / awaiting_response). Used by the ws.ts session cleanup
+   * path (e.g. session.end) to shed all sprite-message state tied to
+   * the session before it disappears.
    */
   dropForSession(sessionId: string, reason: string): number {
     let total = 0;

--- a/relay/src/sprites/btw-queue.ts
+++ b/relay/src/sprites/btw-queue.ts
@@ -1,0 +1,372 @@
+/**
+ * BtwQueue — Per-subagent FIFO queue for "/btw" sprite messages.
+ *
+ * Design (see docs/SPRITE-WIRING-RESEARCH-RELAY.md Gate 3):
+ *   The SDK exposes no direct handle to a subagent's conversation, so /btw
+ *   messages are injected as a new user turn on the orchestrator session at
+ *   the next turn boundary (between stream() returning and the next send()).
+ *   The message text is wrapped with constraint framing that tells Claude
+ *   to give a short status response without changing its task.
+ *
+ *   Multiple /btw messages to the same subagent queue FIFO (spec M1). When
+ *   the subagent's sprite is unlinked (complete/failed/dismissed) before
+ *   delivery, all queued entries for that subagent drop with a "completed
+ *   before delivery" reason (spec scenario #4).
+ *
+ *   Response correlation is imprecise per research: after injection we mark
+ *   the entry `injected` and the worker's stream loop captures the next
+ *   assistant text output as the response. Good enough given the constraint
+ *   framing asks for an immediate 1-2 sentence answer.
+ *
+ * Events emitted:
+ *   - 'injected'  → { sessionId, subagentId, messageId }          — sent to SDK
+ *   - 'responded' → { sessionId, subagentId, messageId, text }     — response captured
+ *   - 'dropped'   → { sessionId, subagentId, messageId, reason }  — dropped before delivery
+ *
+ * Ownership:
+ *   One BtwQueue per process hosting SDK sessions (single-worker adapter
+ *   or each fleet worker). The ws.ts layer routes `sprite.message` to the
+ *   owning worker via IPC (fleet) or directly (single-worker).
+ */
+
+import { EventEmitter } from 'node:events';
+import { logger } from '../utils/logger.js';
+
+export type BtwEntryStatus = 'queued' | 'injected' | 'awaiting_response';
+
+export interface BtwQueueEntry {
+  sessionId: string;
+  subagentId: string;
+  spriteHandle: string;
+  messageId: string;
+  /** Raw user text as received from the client */
+  userText: string;
+  /** Pre-built constraint-framed text actually sent to the SDK */
+  constrainedText: string;
+  queuedAt: number;
+  status: BtwEntryStatus;
+  injectedAt?: number;
+}
+
+export interface BtwEnqueueInput {
+  sessionId: string;
+  subagentId: string;
+  spriteHandle: string;
+  messageId: string;
+  userText: string;
+  role: string;
+  task: string;
+}
+
+/**
+ * Build the constraint-framed user turn that gets injected into the
+ * orchestrator's session. Wording is locked per Phase spec Q3.
+ */
+export function buildConstrainedText(opts: {
+  role: string;
+  task: string;
+  userText: string;
+}): string {
+  const { role, task, userText } = opts;
+  // Escape single quotes to keep the framing parseable to Claude without
+  // breaking the surrounding structure.
+  const safeRole = role.replace(/'/g, "\\'");
+  const safeTask = task.replace(/'/g, "\\'");
+  const safeUser = userText.replace(/'/g, "\\'");
+  return (
+    `The user sent a non-blocking observation via sprite tap to subagent ` +
+    `"${safeRole}" (task: "${safeTask}"): '${safeUser}'. ` +
+    `Respond in 1-2 sentences about the subagent's current progress. ` +
+    `Do NOT change the subagent's task, plan, or approach. ` +
+    `Continue exactly as planned.`
+  );
+}
+
+export interface BtwQueueEventMap {
+  injected: {
+    sessionId: string;
+    subagentId: string;
+    spriteHandle: string;
+    messageId: string;
+  };
+  responded: {
+    sessionId: string;
+    subagentId: string;
+    spriteHandle: string;
+    messageId: string;
+    text: string;
+  };
+  dropped: {
+    sessionId: string;
+    subagentId: string;
+    spriteHandle: string;
+    messageId: string;
+    reason: string;
+  };
+}
+
+type Listener<T> = (payload: T) => void;
+
+export class BtwQueue extends EventEmitter {
+  /** subagentId → FIFO queue of pending entries */
+  private bySubagent = new Map<string, BtwQueueEntry[]>();
+
+  constructor() {
+    super();
+    this.setMaxListeners(50);
+  }
+
+  /**
+   * Enqueue a /btw message for later injection at the next turn boundary.
+   * Returns the queued entry. Does NOT emit — injection is what fires
+   * `injected`.
+   */
+  enqueue(input: BtwEnqueueInput): BtwQueueEntry {
+    const entry: BtwQueueEntry = {
+      sessionId: input.sessionId,
+      subagentId: input.subagentId,
+      spriteHandle: input.spriteHandle,
+      messageId: input.messageId,
+      userText: input.userText,
+      constrainedText: buildConstrainedText({
+        role: input.role,
+        task: input.task,
+        userText: input.userText,
+      }),
+      queuedAt: Date.now(),
+      status: 'queued',
+    };
+    const list = this.bySubagent.get(input.subagentId) ?? [];
+    list.push(entry);
+    this.bySubagent.set(input.subagentId, list);
+    logger.info(
+      {
+        sessionId: entry.sessionId,
+        subagentId: entry.subagentId,
+        spriteHandle: entry.spriteHandle,
+        messageId: entry.messageId,
+        queueDepth: list.length,
+      },
+      'BtwQueue: enqueued /btw message',
+    );
+    return entry;
+  }
+
+  /**
+   * Return queued entries owned by `sessionId` (across all subagents) that
+   * haven't been injected yet. Caller (the consumeStream loop at turn
+   * boundary) iterates and calls `markInjected` as it sends each.
+   */
+  peekQueuedForSession(sessionId: string): BtwQueueEntry[] {
+    const out: BtwQueueEntry[] = [];
+    for (const list of this.bySubagent.values()) {
+      for (const entry of list) {
+        if (entry.status === 'queued' && entry.sessionId === sessionId) {
+          out.push(entry);
+        }
+      }
+    }
+    // FIFO across all subagents in this session
+    out.sort((a, b) => a.queuedAt - b.queuedAt);
+    return out;
+  }
+
+  /**
+   * Take the oldest queued entry for a specific subagent. Marks it
+   * `injected`, emits 'injected'. The consumeStream loop uses this to
+   * drain messages one at a time at the turn boundary.
+   */
+  takeNextForSubagent(subagentId: string): BtwQueueEntry | undefined {
+    const list = this.bySubagent.get(subagentId);
+    if (!list || list.length === 0) return undefined;
+    const entry = list.find(e => e.status === 'queued');
+    if (!entry) return undefined;
+    entry.status = 'injected';
+    entry.injectedAt = Date.now();
+    logger.info(
+      {
+        sessionId: entry.sessionId,
+        subagentId: entry.subagentId,
+        messageId: entry.messageId,
+      },
+      'BtwQueue: marked injected',
+    );
+    this.emit('injected', {
+      sessionId: entry.sessionId,
+      subagentId: entry.subagentId,
+      spriteHandle: entry.spriteHandle,
+      messageId: entry.messageId,
+    } satisfies BtwQueueEventMap['injected']);
+    return entry;
+  }
+
+  /**
+   * Transition an injected entry to `awaiting_response`. Called by the
+   * adapter right after `sdkSession.send()` resolves so the stream loop
+   * starts looking for the reply text.
+   */
+  markAwaitingResponse(messageId: string): BtwQueueEntry | undefined {
+    for (const list of this.bySubagent.values()) {
+      for (const entry of list) {
+        if (entry.messageId === messageId) {
+          entry.status = 'awaiting_response';
+          return entry;
+        }
+      }
+    }
+    return undefined;
+  }
+
+  /**
+   * Find the earliest entry that's currently awaiting a response for
+   * the given session. Used by the adapter's stream handler to correlate
+   * the next assistant text with the injected /btw.
+   */
+  findAwaitingForSession(sessionId: string): BtwQueueEntry | undefined {
+    let candidate: BtwQueueEntry | undefined;
+    for (const list of this.bySubagent.values()) {
+      for (const entry of list) {
+        if (
+          entry.status === 'awaiting_response' &&
+          entry.sessionId === sessionId
+        ) {
+          if (!candidate || entry.injectedAt! < candidate.injectedAt!) {
+            candidate = entry;
+          }
+        }
+      }
+    }
+    return candidate;
+  }
+
+  /**
+   * Mark a message as responded. Removes it from the queue and emits
+   * 'responded' so the ws layer can fan out `sprite.response` to clients.
+   */
+  markResponded(messageId: string, text: string): BtwQueueEntry | undefined {
+    for (const [subagentId, list] of this.bySubagent) {
+      const idx = list.findIndex(e => e.messageId === messageId);
+      if (idx >= 0) {
+        const entry = list[idx]!;
+        list.splice(idx, 1);
+        if (list.length === 0) this.bySubagent.delete(subagentId);
+        logger.info(
+          {
+            sessionId: entry.sessionId,
+            subagentId: entry.subagentId,
+            messageId,
+            textLength: text.length,
+          },
+          'BtwQueue: marked responded',
+        );
+        this.emit('responded', {
+          sessionId: entry.sessionId,
+          subagentId: entry.subagentId,
+          spriteHandle: entry.spriteHandle,
+          messageId: entry.messageId,
+          text,
+        } satisfies BtwQueueEventMap['responded']);
+        return entry;
+      }
+    }
+    return undefined;
+  }
+
+  /**
+   * Drop all queued+injected entries for a subagent (e.g. subagent
+   * completed before delivery). Emits 'dropped' for each with the same
+   * reason. Returns the count dropped.
+   */
+  dropForSubagent(subagentId: string, reason: string): number {
+    const list = this.bySubagent.get(subagentId);
+    if (!list || list.length === 0) return 0;
+    this.bySubagent.delete(subagentId);
+    for (const entry of list) {
+      logger.info(
+        {
+          sessionId: entry.sessionId,
+          subagentId,
+          messageId: entry.messageId,
+          reason,
+        },
+        'BtwQueue: dropped (subagent-level)',
+      );
+      this.emit('dropped', {
+        sessionId: entry.sessionId,
+        subagentId,
+        spriteHandle: entry.spriteHandle,
+        messageId: entry.messageId,
+        reason,
+      } satisfies BtwQueueEventMap['dropped']);
+    }
+    return list.length;
+  }
+
+  /**
+   * Drop all queued+injected entries for a session (e.g. session.end).
+   * Used by the ws.ts session cleanup path to shed state.
+   */
+  dropForSession(sessionId: string, reason: string): number {
+    let total = 0;
+    for (const [subagentId, list] of [...this.bySubagent]) {
+      const remain: BtwQueueEntry[] = [];
+      for (const entry of list) {
+        if (entry.sessionId === sessionId) {
+          total++;
+          logger.info(
+            {
+              sessionId,
+              subagentId,
+              messageId: entry.messageId,
+              reason,
+            },
+            'BtwQueue: dropped (session-level)',
+          );
+          this.emit('dropped', {
+            sessionId: entry.sessionId,
+            subagentId,
+            spriteHandle: entry.spriteHandle,
+            messageId: entry.messageId,
+            reason,
+          } satisfies BtwQueueEventMap['dropped']);
+        } else {
+          remain.push(entry);
+        }
+      }
+      if (remain.length === 0) this.bySubagent.delete(subagentId);
+      else this.bySubagent.set(subagentId, remain);
+    }
+    return total;
+  }
+
+  /** Queue depth for a specific subagent (0 if unknown). */
+  sizeFor(subagentId: string): number {
+    return this.bySubagent.get(subagentId)?.length ?? 0;
+  }
+
+  /** Total queue depth across all subagents. */
+  get size(): number {
+    let n = 0;
+    for (const list of this.bySubagent.values()) n += list.length;
+    return n;
+  }
+
+  /** Typed event overloads for better DX at callsites. */
+  override on<K extends keyof BtwQueueEventMap>(
+    event: K,
+    listener: Listener<BtwQueueEventMap[K]>,
+  ): this;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  override on(event: string, listener: (...args: any[]) => void): this {
+    return super.on(event, listener);
+  }
+
+  override emit<K extends keyof BtwQueueEventMap>(
+    event: K,
+    payload: BtwQueueEventMap[K],
+  ): boolean;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  override emit(event: string, ...args: any[]): boolean {
+    return super.emit(event, ...args);
+  }
+}


### PR DESCRIPTION
## What shipped

- **`BtwQueue`** class (`relay/src/sprites/btw-queue.ts`) — per-subagent FIFO with `enqueue` / `takeNextForSubagent` / `markAwaitingResponse` / `findAwaitingForSession` / `markResponded` / `dropForSubagent` / `dropForSession`. Emits `injected` / `responded` / `dropped` events. Constraint framing pre-built on enqueue per spec Q3.
- **Turn-boundary injection** — both `fleet/worker.ts` and `adapters/claude-cli.adapter.ts` now call `drainOneBtw*` after each `stream()` returns, before looping back. One message per turn boundary so response correlation stays unambiguous.
- **Response correlation** — `handleAssistantMessage` in both worker + adapter checks `findAwaitingForSession`; first non-empty assistant text after injection is captured as the response via `markResponded`. Matches the research doc's "first text after injection" approach.
- **`ws.ts` `sprite.message` handler** — replaced the stub with real routing:
  - Missing mapping → immediate `status: 'dropped'` (scenario #4 race, existing behavior preserved)
  - Valid mapping + no worker → immediate `status: 'dropped'` (session-ended race)
  - Valid mapping + worker → enqueue via `fleetManager.enqueueSpriteMessage`, send `status: 'queued'` ack, terminal `delivered` / `dropped` follows when the queue resolves
- **Fleet IPC** — `IpcSpriteEnqueue` + `IpcSpriteDrop` (parent→worker), `IpcSpriteResponse` (worker→parent). Type guards updated.
- **Lifecycle cleanup**:
  - `SubagentStop` hook in worker + adapter drops queued entries for that subagent (scenario #4 local path)
  - `agent.complete` / `agent.dismissed` lifecycle in ws.ts forwards `ipc:sprite.drop` to the worker (paths that bypass SubagentStop)
  - Session `cancel` / `destroy` drops all entries for that session

## Scenarios covered (relay-side)

- **#4** — subagent completed before delivery → `sprite.response { status: 'dropped', dropReason: 'Subagent completed before delivery' }`
- **#6** — subagent mid-tool-call → queue persists, delivered at next turn boundary
- **M1** — multiple /btw for the same subagent → FIFO; spec says UI only allows one at a time, but queue handles multiple cleanly if they arrive

## Scenarios iOS handles (not relay's concern)

- **#5** disconnected → iOS local pending queue. Relay just queues normally when the message eventually arrives.
- **M2** cross-session banner → iOS watches `sprite.response` globally
- **M3** bubble priority → iOS rendering decision

## Open questions / known limits

- **Response correlation imprecision** (per research doc Gate 3): if the orchestrator produces multiple assistant messages between injection and the desired /btw response, we capture the first one. Constraint framing ("Respond in 1-2 sentences") should make this reliable in practice, but watch the logs on first live test.
- **PostToolUse `additionalContext`** marked YELLOW in research, deferred to Wave 5+. Current path uses queued `send()` at orchestrator turn boundary (Option A).
- **Dog canned responses** — iOS client-side per spec Q4, not implemented here.
- **Log lines** include `sessionId`, `subagentId`, `messageId`, `textLength` for post-hoc debugging.

## Test coverage

New: `relay/src/sprites/__tests__/btw-queue.test.ts` — 17 tests covering:
- Constraint framing text + quote escaping
- Enqueue / FIFO per subagent
- `injected` / `responded` / `dropped` event emission
- `peekQueuedForSession` honours status + session filters
- `dropForSubagent` hits both queued and awaiting_response entries
- `dropForSession` spans multiple subagents, leaves other sessions alone
- Multi-subagent independence

Existing tests: all 60 still pass. Build + typecheck clean.

## Test plan

- [ ] Live test: send /btw to a working subagent, verify `sprite.response { status: 'delivered' }` arrives with sensible text
- [ ] Live test: send /btw, dismiss the subagent before response, verify `dropped`
- [ ] Live test: spam 3 /btw messages to same subagent, verify all delivered FIFO
- [ ] Live test: session.end while /btw pending, verify `dropped` with reason "Session ended"

Generated with Claude Code
