### PR TITLE
feat(ios): Wave 5 visual diff + notifications

### DIFF
--- a/ios/MajorTom.xcodeproj/project.pbxproj
+++ b/ios/MajorTom.xcodeproj/project.pbxproj
@@ -29,6 +29,8 @@
 		2211645B8B3E1BF5093FE2CD /* MoodEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 579C4AF5EF7599467490F248 /* MoodEngine.swift */; };
 		3A1B2C4D5E6F78901234ABCD /* CrewRoster.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B7C8D9E0F1A23456789BCDE /* CrewRoster.swift */; };
 		87DD0EFFCB5F38F604D8E89D /* RoleMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35CE152195BD660297FCDF44 /* RoleMapper.swift */; };
+		F5A7B9C1D3E526A728193B5D /* SpriteAura.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5A7B9C1D3E526A728193B4C /* SpriteAura.swift */; };
+		A2B3C4D5E6F70819304A5B6D /* ToolHumanizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2B3C4D5E6F70819304A5B6C /* ToolHumanizer.swift */; };
 		6FAAD79E27E62840B5B1C665 /* DogCannedResponses.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACBC098BB389E8F292B2EFC7 /* DogCannedResponses.swift */; };
 		E2515F6B841E4F68C14D0419 /* SpriteMessagingState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 433F8F4160504FECAA91BBC2 /* SpriteMessagingState.swift */; };
 		C113A701F7910BAD57011D40 /* SpriteInspectorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B96D3B2D8FF01E0187FC3DD /* SpriteInspectorView.swift */; };
@@ -283,6 +285,8 @@
 		579C4AF5EF7599467490F248 /* MoodEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MoodEngine.swift; sourceTree = "<group>"; };
 		6B7C8D9E0F1A23456789BCDE /* CrewRoster.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CrewRoster.swift; sourceTree = "<group>"; };
 		35CE152195BD660297FCDF44 /* RoleMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoleMapper.swift; sourceTree = "<group>"; };
+		F5A7B9C1D3E526A728193B4C /* SpriteAura.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpriteAura.swift; sourceTree = "<group>"; };
+		A2B3C4D5E6F70819304A5B6C /* ToolHumanizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolHumanizer.swift; sourceTree = "<group>"; };
 		591E0D4455AD31B2BBD8761C /* Session.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Session.swift; sourceTree = "<group>"; };
 		5A61BDDFAF4D3943E1355934 /* ToolActivityRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolActivityRow.swift; sourceTree = "<group>"; };
 		5ACD0D641EBD462C446D4C20 /* CIRunsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CIRunsView.swift; sourceTree = "<group>"; };
@@ -830,6 +834,7 @@
 				ACBC098BB389E8F292B2EFC7 /* DogCannedResponses.swift */,
 				579C4AF5EF7599467490F248 /* MoodEngine.swift */,
 				35CE152195BD660297FCDF44 /* RoleMapper.swift */,
+				A2B3C4D5E6F70819304A5B6C /* ToolHumanizer.swift */,
 				B2A5F6ECD6AEA9681C140DA3 /* OfficeLayout.swift */,
 				BB2C3D4E5F6A7B8C9D0E1F2A /* StationLayout.swift */,
 				433F8F4160504FECAA91BBC2 /* SpriteMessagingState.swift */,
@@ -885,6 +890,7 @@
 			children = (
 				8DD1D371AFD4698EE21925BF /* AgentSprite.swift */,
 				DD8F3697B2C4D5E6F7081902 /* CrewSpriteBuilder.swift */,
+				F5A7B9C1D3E526A728193B4C /* SpriteAura.swift */,
 			);
 			path = Sprites;
 			sourceTree = "<group>";
@@ -1712,6 +1718,8 @@
 				4C3D2E1F0A9B87654321FEDC /* CrewPickerView.swift in Sources */,
 				2211645B8B3E1BF5093FE2CD /* MoodEngine.swift in Sources */,
 				87DD0EFFCB5F38F604D8E89D /* RoleMapper.swift in Sources */,
+				F5A7B9C1D3E526A728193B5D /* SpriteAura.swift in Sources */,
+				A2B3C4D5E6F70819304A5B6D /* ToolHumanizer.swift in Sources */,
 				5AC11640AB3C3745F3F00123 /* NativeKeybar.swift in Sources */,
 				1111499A6385A17E5806AC54 /* NotificationService.swift in Sources */,
 				092B9B0CD510CE78DD29F4E0 /* NotificationSettingsView.swift in Sources */,

--- a/ios/MajorTom/App/MajorTomApp.swift
+++ b/ios/MajorTom/App/MajorTomApp.swift
@@ -184,6 +184,14 @@ struct MajorTomApp: App {
                 }
             }
         }
+
+        // Wave 5 — "Cool Beans" action on /btw response notifications clears
+        // the unread state on the matching sprite (same as in-app Cool Beans).
+        notificationService.onBtwCoolBeansAction = { sessionId, subagentId in
+            let vm = officeSceneManager.ensureViewModel(for: sessionId)
+            // The sprite id equals the subagentId for linked sprites.
+            vm.dismissResponse(for: subagentId)
+        }
     }
 
     private func handleShortcutAction(_ action: ShortcutActionKey.Action) {

--- a/ios/MajorTom/Core/Models/Message.swift
+++ b/ios/MajorTom/Core/Models/Message.swift
@@ -757,6 +757,15 @@ struct ToolStartEvent: Codable {
     let sessionId: String
     let tool: String
     let input: [String: AnyCodableValue]?
+    /// Correlation id for matching `tool.complete` back to this start.
+    /// Wave 5: relay emits this for subagent-attributed tool events.
+    var toolUseId: String?
+    /// Subagent that initiated this tool call (relay Wave 5 field).
+    /// When set, iOS routes the tool bubble to the matching sprite.
+    var subagentId: String?
+    /// Stable sprite handle for the subagent (relay Wave 5 field).
+    /// Mirrors `AgentState.spriteHandle` — provided for redundancy / future use.
+    var spriteHandle: String?
 }
 
 struct ToolCompleteEvent: Codable {
@@ -766,6 +775,11 @@ struct ToolCompleteEvent: Codable {
     var toolUseId: String?
     let output: String
     let success: Bool
+    /// Subagent this complete belongs to (relay Wave 5 field).
+    /// Used to hide the matching tool bubble on the correct sprite.
+    var subagentId: String?
+    /// Stable sprite handle for the subagent (relay Wave 5 field).
+    var spriteHandle: String?
 }
 
 struct AgentSpawnEvent: Codable, Identifiable {
@@ -784,12 +798,20 @@ struct AgentWorkingEvent: Codable {
     let sessionId: String
     let agentId: String
     let task: String
+    /// Number of tool calls the subagent has made so far (relay Wave 5 field).
+    var toolCount: Int?
+    /// Token count consumed by the subagent so far (relay Wave 5 field).
+    var tokenCount: Int?
 }
 
 struct AgentIdleEvent: Codable {
     let type: String
     let sessionId: String
     let agentId: String
+    /// Final tool count at this idle checkpoint (relay Wave 5 field).
+    var toolCount: Int?
+    /// Final token count at this idle checkpoint (relay Wave 5 field).
+    var tokenCount: Int?
 }
 
 struct AgentCompleteEvent: Codable {

--- a/ios/MajorTom/Core/Services/RelayService.swift
+++ b/ios/MajorTom/Core/Services/RelayService.swift
@@ -1,5 +1,6 @@
 import Foundation
 import WidgetKit
+import UIKit
 
 @Observable
 @MainActor
@@ -753,6 +754,16 @@ final class RelayService {
                 if let sid = currentSession?.id {
                     liveActivityManager?.handleToolStart(sessionId: sid, toolName: event.tool)
                 }
+                // Wave 5: route per-sprite tool bubble when relay tags the event.
+                if let subagentId = event.subagentId {
+                    officeSceneManager?.ensureViewModel(for: event.sessionId)
+                        .handleSpriteToolStart(
+                            subagentId: subagentId,
+                            toolUseId: event.toolUseId,
+                            tool: event.tool,
+                            input: event.input
+                        )
+                }
                 updateWidgetData()
             }
 
@@ -779,6 +790,14 @@ final class RelayService {
                 if let sid = currentSession?.id {
                     liveActivityManager?.handleToolComplete(sessionId: sid)
                 }
+                // Wave 5: hide per-sprite tool bubble if relay tagged the event.
+                if let subagentId = event.subagentId {
+                    officeSceneManager?.ensureViewModel(for: event.sessionId)
+                        .handleSpriteToolComplete(
+                            subagentId: subagentId,
+                            toolUseId: event.toolUseId
+                        )
+                }
                 updateWidgetData()
             }
 
@@ -796,12 +815,23 @@ final class RelayService {
 
         case .agentWorking:
             if let event = try? MessageCodec.decode(AgentWorkingEvent.self, from: data) {
-                officeSceneManager?.ensureViewModel(for: event.sessionId).handleAgentWorking(id: event.agentId, task: event.task)
+                officeSceneManager?.ensureViewModel(for: event.sessionId)
+                    .handleAgentWorking(
+                        id: event.agentId,
+                        task: event.task,
+                        toolCount: event.toolCount,
+                        tokenCount: event.tokenCount
+                    )
             }
 
         case .agentIdle:
             if let event = try? MessageCodec.decode(AgentIdleEvent.self, from: data) {
-                officeSceneManager?.ensureViewModel(for: event.sessionId).handleAgentIdle(id: event.agentId)
+                officeSceneManager?.ensureViewModel(for: event.sessionId)
+                    .handleAgentIdle(
+                        id: event.agentId,
+                        toolCount: event.toolCount,
+                        tokenCount: event.tokenCount
+                    )
             }
 
         case .agentComplete:
@@ -1225,6 +1255,11 @@ final class RelayService {
                             preview: bannerPreview(previewSource)
                         )
                     }
+
+                    // Wave 5 — local push when the app isn't in the active
+                    // foreground. Best-effort during iOS backgrounding grace
+                    // window (~10s); relay re-queues beyond that.
+                    postBtwResponseNotificationIfBackgrounded(event: event, vm: vm)
                 }
             }
 
@@ -1246,6 +1281,30 @@ final class RelayService {
             let msg = ChatMessage(role: .assistant, content: event.chunk)
             chatMessages.append(msg)
         }
+    }
+
+    /// Wave 5 — post a local `/btw` response notification if the app is NOT
+    /// in the active foreground state. Delivered responses only (dropped
+    /// responses don't need a push, user will see the green glow on return).
+    private func postBtwResponseNotificationIfBackgrounded(
+        event: SpriteResponseEvent,
+        vm: OfficeViewModel?
+    ) {
+        guard event.status == "delivered" else { return }
+        guard UIApplication.shared.applicationState != .active else { return }
+
+        let agent = vm?.agents.first(where: {
+            $0.linkedSubagentId == event.subagentId || $0.id == event.subagentId
+        })
+        let role = agent?.canonicalRole ?? agent?.role ?? "agent"
+        let spriteName = agent?.name ?? String(event.subagentId.prefix(8))
+        notificationService?.postBtwResponseNotification(
+            sessionId: event.sessionId,
+            subagentId: event.subagentId,
+            role: role,
+            spriteName: spriteName,
+            response: event.text
+        )
     }
 
     private func clearSessionState() {

--- a/ios/MajorTom/Features/Notifications/Services/NotificationService.swift
+++ b/ios/MajorTom/Features/Notifications/Services/NotificationService.swift
@@ -7,11 +7,16 @@ import UIKit
 enum NotificationCategory: String {
     case approvalRequest = "APPROVAL_REQUEST"
     case sessionEvent = "SESSION_EVENT"
+    /// Wave 5 — local push when a `/btw` response arrives while the app is
+    /// backgrounded. Carries a single "Cool Beans" action.
+    case btwResponse = "SPRITE_BTW_RESPONSE"
 }
 
 enum NotificationAction: String {
     case allow = "ALLOW_ACTION"
     case deny = "DENY_ACTION"
+    /// Wave 5 — dismisses the unread `/btw` response for the originating sprite.
+    case coolBeans = "COOL_BEANS"
 }
 
 // MARK: - Notification Service
@@ -25,6 +30,10 @@ final class NotificationService: NSObject {
     /// Callback invoked when user acts on an approval notification.
     /// Parameters: requestId, approved (true = allow, false = deny)
     var onApprovalAction: ((String, Bool) -> Void)?
+
+    /// Wave 5 — invoked when the user taps the "Cool Beans" action on a
+    /// `/btw` response notification. Parameters: sessionId, subagentId.
+    var onBtwCoolBeansAction: ((String, String) -> Void)?
 
     private let center = UNUserNotificationCenter.current()
 
@@ -105,7 +114,20 @@ final class NotificationService: NSObject {
             options: []
         )
 
-        center.setNotificationCategories([approvalCategory, sessionCategory])
+        // Wave 5 — "Cool Beans" action on sprite /btw response notifications.
+        let coolBeansAction = UNNotificationAction(
+            identifier: NotificationAction.coolBeans.rawValue,
+            title: "Cool Beans",
+            options: []
+        )
+        let btwCategory = UNNotificationCategory(
+            identifier: NotificationCategory.btwResponse.rawValue,
+            actions: [coolBeansAction],
+            intentIdentifiers: [],
+            options: [.customDismissAction]
+        )
+
+        center.setNotificationCategories([approvalCategory, sessionCategory, btwCategory])
     }
 
     // MARK: - Local Notification Posting
@@ -178,6 +200,49 @@ final class NotificationService: NSObject {
         )
     }
 
+    /// Post a `/btw` response notification (Wave 5).
+    ///
+    /// Only fires when the app is NOT in the active foreground state. Caller
+    /// is expected to gate on `UIApplication.shared.applicationState != .active`.
+    /// Title: `"[{role}] {spriteName}"`, body: first ~120 chars of the response.
+    /// Carries session/subagent identifiers so the "Cool Beans" action can
+    /// clear the matching unread state.
+    func postBtwResponseNotification(
+        sessionId: String,
+        subagentId: String,
+        role: String,
+        spriteName: String,
+        response: String
+    ) {
+        guard isAuthorized else { return }
+
+        let content = UNMutableNotificationContent()
+        content.title = "[\(role)] \(spriteName)"
+        content.body = Self.truncatedBody(response)
+        content.sound = .default
+        content.categoryIdentifier = NotificationCategory.btwResponse.rawValue
+        content.userInfo = [
+            "sessionId": sessionId,
+            "subagentId": subagentId,
+            "deepLink": "majortom://office"
+        ]
+
+        let request = UNNotificationRequest(
+            identifier: "btw-\(subagentId)-\(UUID().uuidString)",
+            content: content,
+            trigger: nil
+        )
+
+        center.add(request)
+    }
+
+    private static func truncatedBody(_ text: String) -> String {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard trimmed.count > 120 else { return trimmed }
+        let idx = trimmed.index(trimmed.startIndex, offsetBy: 117)
+        return String(trimmed[..<idx]) + "…"
+    }
+
     /// Post a session end notification.
     func postSessionEndNotification(sessionId: String, costUsd: Double) {
         let costString = String(format: "$%.4f", costUsd)
@@ -226,6 +291,13 @@ extension NotificationService: UNUserNotificationCenterDelegate {
             case NotificationAction.deny.rawValue:
                 if let requestId {
                     onApprovalAction?(requestId, false)
+                }
+
+            case NotificationAction.coolBeans.rawValue:
+                // Wave 5 — clear the unread /btw state for the originating sprite.
+                if let sessionId = userInfo["sessionId"] as? String,
+                   let subagentId = userInfo["subagentId"] as? String {
+                    onBtwCoolBeansAction?(sessionId, subagentId)
                 }
 
             case UNNotificationDefaultActionIdentifier:

--- a/ios/MajorTom/Features/Office/Models/RoleMapper.swift
+++ b/ios/MajorTom/Features/Office/Models/RoleMapper.swift
@@ -1,4 +1,5 @@
 import Foundation
+import UIKit
 
 // MARK: - Role Mapper
 
@@ -98,5 +99,45 @@ enum RoleMapper {
 
         updatedBindings[normalizedRole] = picked
         return (picked, updatedBindings)
+    }
+
+    // MARK: - Role Color Palette (Wave 5)
+
+    /// Role-colored aura palette. LOCKED per Wave 5 spec.
+    ///
+    /// Canonical → hex color:
+    ///   researcher (.botanist)         → #4ADE80 (green)
+    ///   architect  (.captain)          → #3B82F6 (blue)
+    ///   qa         (.doctor)           → #EF4444 (red)
+    ///   devops     (.mechanic)         → #F59E0B (orange)
+    ///   frontend   (.frontendDev)      → #EC4899 (magenta)
+    ///   backend    (.backendEngineer)  → #A855F7 (purple)
+    ///   lead       (.pm)               → #EAB308 (yellow)
+    ///   engineer   (.claudimusPrime)   → #06B6D4 (cyan)
+    ///   (fallback)                     → #6B7280 (gray)
+    static func color(forCanonicalRole role: String?) -> UIColor {
+        guard let role = role?.lowercased() else {
+            return UIColor(red: 0x6B / 255.0, green: 0x72 / 255.0, blue: 0x80 / 255.0, alpha: 1)
+        }
+        switch role {
+        case "researcher":
+            return UIColor(red: 0x4A / 255.0, green: 0xDE / 255.0, blue: 0x80 / 255.0, alpha: 1)
+        case "architect":
+            return UIColor(red: 0x3B / 255.0, green: 0x82 / 255.0, blue: 0xF6 / 255.0, alpha: 1)
+        case "qa":
+            return UIColor(red: 0xEF / 255.0, green: 0x44 / 255.0, blue: 0x44 / 255.0, alpha: 1)
+        case "devops":
+            return UIColor(red: 0xF5 / 255.0, green: 0x9E / 255.0, blue: 0x0B / 255.0, alpha: 1)
+        case "frontend":
+            return UIColor(red: 0xEC / 255.0, green: 0x48 / 255.0, blue: 0x99 / 255.0, alpha: 1)
+        case "backend":
+            return UIColor(red: 0xA8 / 255.0, green: 0x55 / 255.0, blue: 0xF7 / 255.0, alpha: 1)
+        case "lead":
+            return UIColor(red: 0xEA / 255.0, green: 0xB3 / 255.0, blue: 0x08 / 255.0, alpha: 1)
+        case "engineer":
+            return UIColor(red: 0x06 / 255.0, green: 0xB6 / 255.0, blue: 0xD4 / 255.0, alpha: 1)
+        default:
+            return UIColor(red: 0x6B / 255.0, green: 0x72 / 255.0, blue: 0x80 / 255.0, alpha: 1)
+        }
     }
 }

--- a/ios/MajorTom/Features/Office/Models/ToolHumanizer.swift
+++ b/ios/MajorTom/Features/Office/Models/ToolHumanizer.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+// MARK: - Tool Humanizer (Wave 5)
+
+/// Maps raw Claude Code tool names to short, humanized labels shown in the
+/// per-sprite tool-event speech bubble.
+///
+/// Input-awareness is kept intentionally minimal — the bubble is a terse status
+/// ("reading files…") not a preview of arguments. If the caller wants to
+/// specialize a label (e.g. show the file name on a Read), they can extend this
+/// enum in the future; for Wave 5 we keep labels fixed per tool.
+enum ToolHumanizer {
+
+    /// Return a short humanized label for a tool call.
+    /// Case-insensitive on the tool name.
+    static func label(for tool: String, input: [String: AnyCodableValue]? = nil) -> String {
+        _ = input  // Reserved for future input-aware labels (file names, commands, etc.)
+        switch tool {
+        case "Read":          return "reading files…"
+        case "Write":         return "writing code…"
+        case "Edit":          return "editing code…"
+        case "Bash":          return "running commands…"
+        case "Grep":          return "searching…"
+        case "Glob":          return "finding files…"
+        case "Task":          return "spawning helper…"
+        case "WebSearch":     return "searching the web…"
+        case "WebFetch":      return "fetching a page…"
+        case "TodoWrite":     return "updating todos…"
+        case "NotebookEdit":  return "editing notebook…"
+        default:              return "working…"
+        }
+    }
+}

--- a/ios/MajorTom/Features/Office/Models/ToolHumanizer.swift
+++ b/ios/MajorTom/Features/Office/Models/ToolHumanizer.swift
@@ -15,18 +15,19 @@ enum ToolHumanizer {
     /// Case-insensitive on the tool name.
     static func label(for tool: String, input: [String: AnyCodableValue]? = nil) -> String {
         _ = input  // Reserved for future input-aware labels (file names, commands, etc.)
-        switch tool {
-        case "Read":          return "reading files…"
-        case "Write":         return "writing code…"
-        case "Edit":          return "editing code…"
-        case "Bash":          return "running commands…"
-        case "Grep":          return "searching…"
-        case "Glob":          return "finding files…"
-        case "Task":          return "spawning helper…"
-        case "WebSearch":     return "searching the web…"
-        case "WebFetch":      return "fetching a page…"
-        case "TodoWrite":     return "updating todos…"
-        case "NotebookEdit":  return "editing notebook…"
+        let normalizedTool = tool.lowercased()
+        switch normalizedTool {
+        case "read":          return "reading files…"
+        case "write":         return "writing code…"
+        case "edit":          return "editing code…"
+        case "bash":          return "running commands…"
+        case "grep":          return "searching…"
+        case "glob":          return "finding files…"
+        case "task":          return "spawning helper…"
+        case "websearch":     return "searching the web…"
+        case "webfetch":      return "fetching a page…"
+        case "todowrite":     return "updating todos…"
+        case "notebookedit":  return "editing notebook…"
         default:              return "working…"
         }
     }

--- a/ios/MajorTom/Features/Office/Scenes/OfficeScene.swift
+++ b/ios/MajorTom/Features/Office/Scenes/OfficeScene.swift
@@ -1786,6 +1786,40 @@ final class OfficeScene: SKScene {
         agentSprites[agentId]?.showResponsePreviewBubble(text)
     }
 
+    // MARK: - Role Aura / Tool Bubble / Progress (Wave 5)
+
+    /// Show the role-colored aura on a sprite (only takes effect if no green
+    /// unread glow is active — AgentSprite coordinates priority internally).
+    func showRoleAura(on agentId: String, canonicalRole: String?) {
+        agentSprites[agentId]?.showRoleAura(canonicalRole: canonicalRole)
+    }
+
+    /// Hide the role aura on a sprite.
+    func hideRoleAura(on agentId: String) {
+        agentSprites[agentId]?.hideRoleAura()
+    }
+
+    /// Show or update the humanized tool-event bubble on a sprite.
+    func showToolBubble(on agentId: String, label: String) {
+        agentSprites[agentId]?.showToolBubble(label: label)
+    }
+
+    /// Hide the tool-event bubble on a sprite.
+    func hideToolBubble(on agentId: String) {
+        agentSprites[agentId]?.hideToolBubble()
+    }
+
+    /// Update the mini progress indicator below a sprite. Pass nil for both
+    /// counts to hide the indicator.
+    func updateProgressIndicator(on agentId: String, toolCount: Int?, tokenCount: Int?) {
+        agentSprites[agentId]?.updateProgressIndicator(toolCount: toolCount, tokenCount: tokenCount)
+    }
+
+    /// Hide the progress indicator on a sprite.
+    func hideProgressIndicator(on agentId: String) {
+        agentSprites[agentId]?.hideProgressIndicator()
+    }
+
     // MARK: - Desk Highlighting
 
     func highlightDesk(_ deskIndex: Int, occupied: Bool) {

--- a/ios/MajorTom/Features/Office/Sprites/AgentSprite.swift
+++ b/ios/MajorTom/Features/Office/Sprites/AgentSprite.swift
@@ -49,6 +49,26 @@ final class AgentSprite: SKSpriteNode {
     /// is waiting. Overrides default working auras.
     private var unreadGlowNode: SKNode?
 
+    /// Role-colored aura shown while the sprite is working (Wave 5).
+    /// Hidden when the green unread glow is active; restored when it clears.
+    private var roleAuraNode: SpriteAura?
+
+    /// Last canonicalRole applied to the role aura — used to decide whether
+    /// to rebuild on role updates.
+    private var currentRoleForAura: String?
+
+    /// Whether a role aura is currently "requested" by the scene — we use
+    /// this to restore the aura when the green unread glow is cleared.
+    private var roleAuraRequested: Bool = false
+
+    /// Humanized tool-event bubble node (Wave 5). Mutable so each tool.start
+    /// can swap the label in-place without re-adding a bubble node.
+    private var toolBubbleBG: SKShapeNode?
+    private var toolBubbleLabel: SKLabelNode?
+
+    /// Mini progress indicator label shown under the sprite while working (Wave 5).
+    private var progressLabel: SKLabelNode?
+
     /// The texture-based crew sprite body node.
     private let bodySprite: SKSpriteNode
 
@@ -654,9 +674,63 @@ final class AgentSprite: SKSpriteNode {
 
     // MARK: - Emote System
 
-    // MARK: - Unread /btw Response Glow (Wave 4)
+    // MARK: - Role Aura (Wave 5)
+
+    /// Show the role-colored aura under the sprite. Hidden while the green
+    /// unread-response glow is active; restored when it clears.
+    ///
+    /// Safe to call repeatedly with the same `canonicalRole` — no-ops when
+    /// the current aura already matches. Role changes rebuild the node.
+    func showRoleAura(canonicalRole: String?) {
+        roleAuraRequested = true
+        currentRoleForAura = canonicalRole
+
+        // Green glow suppresses the role aura entirely.
+        guard unreadGlowNode == nil else {
+            removeRoleAuraNode()
+            return
+        }
+
+        // No-op if the current aura is already for this role.
+        if let existing = roleAuraNode, existing.canonicalRole == canonicalRole {
+            return
+        }
+
+        // Rebuild: remove any existing role aura first.
+        removeRoleAuraNode()
+
+        let spriteSize = CrewSpriteBuilder.size(for: characterType)
+        // ~1.3× sprite bounding radius (spec). Sprite is a square frame.
+        let radius = max(spriteSize.width, spriteSize.height) * 0.5 * 1.3
+
+        let aura = SpriteAura(canonicalRole: canonicalRole, radius: radius)
+        aura.name = "roleAura"
+        // Under the body sprite (zPosition 0) but above the floor (no overlap).
+        aura.zPosition = -1.0
+        addChild(aura)
+        aura.fadeIn()
+        roleAuraNode = aura
+    }
+
+    /// Hide the role aura. Clears both the requested flag and the node so it
+    /// won't re-appear until `showRoleAura` is called again.
+    func hideRoleAura() {
+        roleAuraRequested = false
+        currentRoleForAura = nil
+        removeRoleAuraNode()
+    }
+
+    private func removeRoleAuraNode() {
+        guard let aura = roleAuraNode else { return }
+        aura.fadeOutAndRemove()
+        roleAuraNode = nil
+    }
+
+    // MARK: - Unread /btw Response Glow (Wave 4 + Wave 5 priority)
 
     /// Attach the green "unread /btw response" glow.
+    /// Hides any active role aura — it will be restored by `hideUnreadResponseGlow`
+    /// if the sprite was still requesting one.
     func showUnreadResponseGlow() {
         guard unreadGlowNode == nil else { return }
         let spriteSize = CrewSpriteBuilder.size(for: characterType)
@@ -679,9 +753,13 @@ final class AgentSprite: SKSpriteNode {
 
         addChild(glow)
         unreadGlowNode = glow
+
+        // Green takes priority — suppress the role aura until the glow clears.
+        removeRoleAuraNode()
     }
 
-    /// Remove the unread glow.
+    /// Remove the unread glow. Restores the role aura if one was previously
+    /// requested (i.e. the sprite is still in a working state).
     func hideUnreadResponseGlow() {
         guard let glow = unreadGlowNode else { return }
         glow.removeAllActions()
@@ -690,11 +768,177 @@ final class AgentSprite: SKSpriteNode {
             SKAction.removeFromParent(),
         ]))
         unreadGlowNode = nil
+
+        // Restore the role aura if the scene still wants it shown.
+        if roleAuraRequested {
+            showRoleAura(canonicalRole: currentRoleForAura)
+        }
     }
 
     /// Preview a /btw response as a speech bubble over the sprite.
     func showResponsePreviewBubble(_ text: String, duration: TimeInterval = 5.0) {
         showSpeechBubble(text, duration: duration)
+    }
+
+    // MARK: - Tool Bubble (Wave 5)
+
+    /// Show or update the humanized tool-event bubble above the sprite.
+    /// Auto-hides after `autoHideAfter` seconds as a safety net if the
+    /// matching `tool.complete` never arrives.
+    func showToolBubble(label: String, autoHideAfter: TimeInterval = 30.0) {
+        let spriteSize = CrewSpriteBuilder.size(for: characterType)
+        let textWidth = CGFloat(label.count) * 5.5 + 12
+        let bubbleWidth = max(textWidth, 50)
+        let bubbleY = spriteSize.height / 2 + 36
+
+        if let bg = toolBubbleBG, let lbl = toolBubbleLabel {
+            // Fade-swap the text in place so we don't flash a new node.
+            lbl.run(SKAction.sequence([
+                SKAction.fadeOut(withDuration: 0.1),
+                SKAction.run { lbl.text = label },
+                SKAction.fadeIn(withDuration: 0.15),
+            ]))
+            // Resize background to fit new label.
+            bg.run(SKAction.run { [weak self, weak bg] in
+                guard let bg else { return }
+                let parent = bg.parent
+                bg.removeFromParent()
+                let newBG = SKShapeNode(rectOf: CGSize(width: bubbleWidth, height: 16), cornerRadius: 4)
+                newBG.fillColor = SKColor(white: 0.1, alpha: 0.85)
+                newBG.strokeColor = SKColor(red: 0.35, green: 0.75, blue: 1.0, alpha: 0.5)
+                newBG.lineWidth = 0.5
+                newBG.position = CGPoint(x: 0, y: bubbleY)
+                newBG.zPosition = 18
+                parent?.addChild(newBG)
+                self?.toolBubbleBG = newBG
+            })
+        } else {
+            // Build fresh
+            let bg = SKShapeNode(rectOf: CGSize(width: bubbleWidth, height: 16), cornerRadius: 4)
+            bg.fillColor = SKColor(white: 0.1, alpha: 0.85)
+            bg.strokeColor = SKColor(red: 0.35, green: 0.75, blue: 1.0, alpha: 0.5)
+            bg.lineWidth = 0.5
+            bg.position = CGPoint(x: 0, y: bubbleY)
+            bg.zPosition = 18
+            bg.alpha = 0
+            addChild(bg)
+
+            let lbl = SKLabelNode(fontNamed: "Menlo")
+            lbl.fontSize = 8
+            lbl.fontColor = SKColor(red: 0.85, green: 0.95, blue: 1.0, alpha: 1)
+            lbl.horizontalAlignmentMode = .center
+            lbl.verticalAlignmentMode = .center
+            lbl.text = label
+            lbl.position = CGPoint(x: 0, y: bubbleY)
+            lbl.zPosition = 19
+            lbl.alpha = 0
+            addChild(lbl)
+
+            let fadeIn = SKAction.fadeAlpha(to: 1.0, duration: 0.2)
+            bg.run(fadeIn)
+            lbl.run(fadeIn)
+
+            toolBubbleBG = bg
+            toolBubbleLabel = lbl
+        }
+
+        // (Re)schedule the safety auto-hide.
+        removeAction(forKey: "toolBubbleSafety")
+        let safety = SKAction.sequence([
+            SKAction.wait(forDuration: autoHideAfter),
+            SKAction.run { [weak self] in self?.hideToolBubble() },
+        ])
+        run(safety, withKey: "toolBubbleSafety")
+    }
+
+    /// Hide the tool-event bubble (fades out and removes).
+    func hideToolBubble() {
+        removeAction(forKey: "toolBubbleSafety")
+        let fade = SKAction.sequence([
+            SKAction.fadeOut(withDuration: 0.2),
+            SKAction.removeFromParent(),
+        ])
+        toolBubbleBG?.run(fade)
+        toolBubbleLabel?.run(fade)
+        toolBubbleBG = nil
+        toolBubbleLabel = nil
+    }
+
+    // MARK: - Progress Indicator (Wave 5)
+
+    /// Update the mini progress indicator shown below the sprite.
+    /// Passing `nil` for both params hides the indicator.
+    func updateProgressIndicator(toolCount: Int?, tokenCount: Int?) {
+        let formatted = Self.formatProgressText(toolCount: toolCount, tokenCount: tokenCount)
+        guard let text = formatted else {
+            hideProgressIndicator()
+            return
+        }
+
+        let spriteSize = CrewSpriteBuilder.size(for: characterType)
+        // Above the status dot (which is at -(height/2 + 6)), but below the
+        // sprite body. Use -height/2 - 18 for clear separation from the dot.
+        let yPos = -(spriteSize.height / 2 + 18)
+
+        if let lbl = progressLabel {
+            lbl.text = text
+            lbl.position = CGPoint(x: 0, y: yPos)
+            return
+        }
+
+        let lbl = SKLabelNode(fontNamed: "Menlo")
+        lbl.fontSize = 7
+        lbl.fontColor = SKColor(red: 0.75, green: 0.85, blue: 1.0, alpha: 0.95)
+        lbl.horizontalAlignmentMode = .center
+        lbl.verticalAlignmentMode = .top
+        lbl.text = text
+        lbl.position = CGPoint(x: 0, y: yPos)
+        lbl.zPosition = 8
+        lbl.alpha = 0
+        addChild(lbl)
+        progressLabel = lbl
+        lbl.run(SKAction.fadeAlpha(to: 1.0, duration: 0.2))
+    }
+
+    /// Hide the progress indicator (fades out and removes).
+    func hideProgressIndicator() {
+        guard let lbl = progressLabel else { return }
+        lbl.run(SKAction.sequence([
+            SKAction.fadeOut(withDuration: 0.2),
+            SKAction.removeFromParent(),
+        ]))
+        progressLabel = nil
+    }
+
+    /// Format `{toolCount} tools · {tokenCount}k tokens` with k/M suffix
+    /// on the token count (one decimal). Returns nil when neither is present.
+    static func formatProgressText(toolCount: Int?, tokenCount: Int?) -> String? {
+        let toolPart: String? = toolCount.map { count in
+            let label = count == 1 ? "tool" : "tools"
+            return "\(count) \(label)"
+        }
+        let tokenPart: String? = tokenCount.map(formatTokenCount)
+
+        switch (toolPart, tokenPart) {
+        case let (tools?, tokens?): return "\(tools) · \(tokens)"
+        case let (tools?, nil):     return tools
+        case let (nil, tokens?):    return tokens
+        default:                    return nil
+        }
+    }
+
+    /// Format a raw token count as `"1.2k tokens"` / `"3.4M tokens"` / `"812 tokens"`.
+    static func formatTokenCount(_ count: Int) -> String {
+        let absCount = abs(count)
+        if absCount >= 1_000_000 {
+            let millions = Double(count) / 1_000_000.0
+            return String(format: "%.1fM tokens", millions)
+        } else if absCount >= 1_000 {
+            let thousands = Double(count) / 1_000.0
+            return String(format: "%.1fk tokens", thousands)
+        } else {
+            return "\(count) tokens"
+        }
     }
 
     /// Show an animated emote above the sprite.

--- a/ios/MajorTom/Features/Office/Sprites/AgentSprite.swift
+++ b/ios/MajorTom/Features/Office/Sprites/AgentSprite.swift
@@ -798,20 +798,22 @@ final class AgentSprite: SKSpriteNode {
                 SKAction.run { lbl.text = label },
                 SKAction.fadeIn(withDuration: 0.15),
             ]))
-            // Resize background to fit new label.
-            bg.run(SKAction.run { [weak self, weak bg] in
-                guard let bg else { return }
-                let parent = bg.parent
-                bg.removeFromParent()
-                let newBG = SKShapeNode(rectOf: CGSize(width: bubbleWidth, height: 16), cornerRadius: 4)
-                newBG.fillColor = SKColor(white: 0.1, alpha: 0.85)
-                newBG.strokeColor = SKColor(red: 0.35, green: 0.75, blue: 1.0, alpha: 0.5)
-                newBG.lineWidth = 0.5
-                newBG.position = CGPoint(x: 0, y: bubbleY)
-                newBG.zPosition = 18
-                parent?.addChild(newBG)
-                self?.toolBubbleBG = newBG
-            })
+            // Resize background in-place by updating its path. Avoids the
+            // previous queued-SKAction race where hideToolBubble() could run
+            // before the resize action fired, leaving an orphaned background.
+            let bubbleHeight: CGFloat = 16
+            let rect = CGRect(
+                x: -bubbleWidth / 2,
+                y: -bubbleHeight / 2,
+                width: bubbleWidth,
+                height: bubbleHeight
+            )
+            bg.path = CGPath(
+                roundedRect: rect,
+                cornerWidth: 4,
+                cornerHeight: 4,
+                transform: nil
+            )
         } else {
             // Build fresh
             let bg = SKShapeNode(rectOf: CGSize(width: bubbleWidth, height: 16), cornerRadius: 4)

--- a/ios/MajorTom/Features/Office/Sprites/SpriteAura.swift
+++ b/ios/MajorTom/Features/Office/Sprites/SpriteAura.swift
@@ -1,0 +1,79 @@
+import SpriteKit
+
+// MARK: - Sprite Aura (Wave 5)
+
+/// A soft-glow ring that sits UNDER an agent sprite, colored per canonical role.
+///
+/// Layering priority (AgentSprite coordinates):
+///   1. Green "unread /btw response" glow (highest — added on top of role aura)
+///   2. Role aura (shown while the sprite is `.working` and no unread response)
+///   3. Nothing (default idle / celebrating / leaving states)
+///
+/// The aura renders as three concentric `SKShapeNode` circles with decreasing
+/// alpha to fake a gaussian-style glow without the runtime cost of a CIFilter
+/// effect node. Multi-layer alpha stacking is cheap on modern iPhones and
+/// survives `scene.isPaused` just fine.
+final class SpriteAura: SKNode {
+
+    /// The canonical role this aura is colored for (tracked so callers can
+    /// decide whether to rebuild on role updates).
+    private(set) var canonicalRole: String?
+
+    init(canonicalRole: String?, radius: CGFloat) {
+        self.canonicalRole = canonicalRole
+        super.init()
+        build(radius: radius, color: RoleMapper.color(forCanonicalRole: canonicalRole))
+    }
+
+    @available(*, unavailable)
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - Build
+
+    private func build(radius: CGFloat, color: UIColor) {
+        // Outer — largest, softest
+        let outer = SKShapeNode(circleOfRadius: radius)
+        outer.fillColor = color
+        outer.strokeColor = .clear
+        outer.alpha = 0.15
+        outer.zPosition = 0
+        addChild(outer)
+
+        // Mid — medium size, medium alpha
+        let mid = SKShapeNode(circleOfRadius: radius * 0.75)
+        mid.fillColor = color
+        mid.strokeColor = .clear
+        mid.alpha = 0.25
+        mid.zPosition = 1
+        addChild(mid)
+
+        // Inner — tight, most saturated
+        let inner = SKShapeNode(circleOfRadius: radius * 0.5)
+        inner.fillColor = color
+        inner.strokeColor = color.withAlphaComponent(0.4)
+        inner.lineWidth = 1
+        inner.alpha = 0.4
+        inner.zPosition = 2
+        addChild(inner)
+
+        // Start invisible so callers can fade in
+        self.alpha = 0
+    }
+
+    // MARK: - Animations
+
+    /// Fade the aura in (call after adding to parent).
+    func fadeIn(duration: TimeInterval = 0.25) {
+        removeAction(forKey: "auraFade")
+        run(SKAction.fadeAlpha(to: 1.0, duration: duration), withKey: "auraFade")
+    }
+
+    /// Fade out and remove from parent when complete.
+    func fadeOutAndRemove(duration: TimeInterval = 0.25) {
+        removeAction(forKey: "auraFade")
+        let fade = SKAction.fadeOut(withDuration: duration)
+        run(SKAction.sequence([fade, SKAction.removeFromParent()]), withKey: "auraFade")
+    }
+}

--- a/ios/MajorTom/Features/Office/ViewModels/OfficeViewModel.swift
+++ b/ios/MajorTom/Features/Office/ViewModels/OfficeViewModel.swift
@@ -71,6 +71,28 @@ final class OfficeViewModel {
     /// scene render (cleared by the view after firing).
     var pendingBubblePreviews: [String: String] = [:]
 
+    // MARK: - Visual Differentiation (Wave 5)
+
+    /// Active tool-event labels by sprite id. Set on `tool.start`, cleared on
+    /// `tool.complete` (matched by `toolUseId`) or on sprite despawn.
+    var spriteToolLabels: [String: String] = [:]
+
+    /// Open `toolUseId`s per sprite — lets `tool.complete` clear the exact
+    /// bubble that `tool.start` raised, even when multiple tools interleave.
+    var spriteOpenToolUseIds: [String: Set<String>] = [:]
+
+    /// Per-sprite progress metrics (toolCount, tokenCount) from
+    /// `agent.working`/`agent.idle`. Missing entry == hide indicator.
+    struct ProgressMetrics: Equatable {
+        var toolCount: Int?
+        var tokenCount: Int?
+    }
+    var spriteProgressMetrics: [String: ProgressMetrics] = [:]
+
+    /// Sprite ids currently "requesting" the role aura. The view diff-renders
+    /// this set against the scene. Managed by working/idle/dismiss handlers.
+    var spriteAuraActive: Set<String> = []
+
     // MARK: - Sprite Pool
 
     private static let idlePrefix = "idle-"
@@ -171,14 +193,29 @@ final class OfficeViewModel {
 
     /// Called when the relay broadcasts `agent.working`.
     /// Agent sits at their desk and starts working.
-    func handleAgentWorking(id: String, task: String) {
+    ///
+    /// Wave 5: optional `toolCount` / `tokenCount` drive the mini progress
+    /// indicator below the sprite. Missing values leave prior metrics intact.
+    func handleAgentWorking(id: String, task: String, toolCount: Int? = nil, tokenCount: Int? = nil) {
         guard let index = agents.firstIndex(where: { $0.id == id }) else { return }
+        guard !isIdleSprite(id) else { return }
         agents[index].status = .working
         agents[index].currentTask = task
 
         // Release any activity station
         activityEngine.releaseActivity(for: id)
         moodEngine.recordActivity(id)
+
+        // Wave 5: role aura is active while working.
+        spriteAuraActive.insert(id)
+
+        // Wave 5: update progress metrics (preserve existing when a field is nil).
+        var metrics = spriteProgressMetrics[id] ?? ProgressMetrics()
+        if let toolCount { metrics.toolCount = toolCount }
+        if let tokenCount { metrics.tokenCount = tokenCount }
+        if metrics.toolCount != nil || metrics.tokenCount != nil {
+            spriteProgressMetrics[id] = metrics
+        }
     }
 
     /// Called when a tool error or permission denial occurs for an agent.
@@ -188,11 +225,31 @@ final class OfficeViewModel {
 
     /// Called when the relay broadcasts `agent.idle`.
     /// Agent gets up and wanders to a break area.
-    func handleAgentIdle(id: String) {
+    ///
+    /// Wave 5: stop the role aura and clear the progress indicator unless an
+    /// unread `/btw` response is still pending (in which case the sprite keeps
+    /// the green glow until the user hits Cool Beans).
+    func handleAgentIdle(id: String, toolCount: Int? = nil, tokenCount: Int? = nil) {
         guard let index = agents.firstIndex(where: { $0.id == id }) else { return }
+        guard !isIdleSprite(id) else { return }
         agents[index].status = .idle
         agents[index].currentTask = nil
         moodEngine.recordIdle(id)
+
+        // Wave 5: role aura is not shown in idle state.
+        spriteAuraActive.remove(id)
+
+        // Wave 5: hide progress indicator unless there's an unread /btw
+        // response — in which case we still want to keep the indicator clean
+        // (green glow is the primary attention cue).
+        if unreadResponseSpriteIds.contains(id) {
+            // Keep any last-reported metrics visible until the user Cool Beans.
+            // Just don't overwrite with the final counts.
+            _ = toolCount
+            _ = tokenCount
+        } else {
+            spriteProgressMetrics.removeValue(forKey: id)
+        }
     }
 
     /// Called when the relay broadcasts `agent.complete`.
@@ -307,6 +364,11 @@ final class OfficeViewModel {
         activityEngine.releaseActivity(for: id)
         moodEngine.removeAgent(id)
         agents.removeAll { $0.id == id }
+        // Wave 5 cleanup — stop any bubbles/indicators pointing at this sprite.
+        spriteAuraActive.remove(id)
+        spriteToolLabels.removeValue(forKey: id)
+        spriteOpenToolUseIds.removeValue(forKey: id)
+        spriteProgressMetrics.removeValue(forKey: id)
         if selectedAgentId == id {
             selectedAgentId = nil
         }
@@ -418,6 +480,49 @@ final class OfficeViewModel {
                 try? await Task.sleep(for: .seconds(1.5))
                 removeAgent(id: agentId)
             }
+        }
+    }
+
+    // MARK: - Tool Bubble Handlers (Wave 5)
+
+    /// Handle a `tool.start` event routed to a specific subagent's sprite.
+    /// Call only when `subagentId` resolves to a known agent. The humanized
+    /// label is shown above the sprite until `tool.complete` for the same
+    /// `toolUseId` arrives (or 30s safety-net expires on the sprite itself).
+    func handleSpriteToolStart(subagentId: String, toolUseId: String?, tool: String, input: [String: AnyCodableValue]?) {
+        // Resolve by subagentId — agent.spawn/sprite.link uses subagentId as the primary key.
+        guard agents.contains(where: { $0.id == subagentId }) else { return }
+        guard !isIdleSprite(subagentId) else { return }
+
+        let label = ToolHumanizer.label(for: tool, input: input)
+        spriteToolLabels[subagentId] = label
+
+        if let id = toolUseId {
+            var open = spriteOpenToolUseIds[subagentId] ?? Set<String>()
+            open.insert(id)
+            spriteOpenToolUseIds[subagentId] = open
+        }
+    }
+
+    /// Handle a `tool.complete` event for a specific subagent's sprite.
+    /// Removes the matching open `toolUseId`. If no other tools are still
+    /// pending, the tool bubble is cleared.
+    func handleSpriteToolComplete(subagentId: String, toolUseId: String?) {
+        guard agents.contains(where: { $0.id == subagentId }) else { return }
+
+        if let id = toolUseId, var open = spriteOpenToolUseIds[subagentId] {
+            open.remove(id)
+            if open.isEmpty {
+                spriteOpenToolUseIds.removeValue(forKey: subagentId)
+                spriteToolLabels.removeValue(forKey: subagentId)
+            } else {
+                spriteOpenToolUseIds[subagentId] = open
+            }
+        } else {
+            // No toolUseId to match — best-effort clear all open ids so the
+            // bubble doesn't stick around forever on pre-Wave-5 relay frames.
+            spriteOpenToolUseIds.removeValue(forKey: subagentId)
+            spriteToolLabels.removeValue(forKey: subagentId)
         }
     }
 

--- a/ios/MajorTom/Features/Office/Views/OfficeView.swift
+++ b/ios/MajorTom/Features/Office/Views/OfficeView.swift
@@ -54,6 +54,12 @@ struct OfficeView: View {
     /// is holding the slot for 5s). Used to restore when the hold expires.
     @State private var toolBubbleHolds: Set<String> = []
 
+    /// Per-sprite restore tasks for the 5s tool-bubble hold. Tracked so a new
+    /// preview arriving within an existing 5s window cancels the previous
+    /// restore Task — otherwise two overlapping timers would clear the hold
+    /// early.
+    @State private var toolBubbleHoldTasks: [String: Task<Void, Never>] = [:]
+
     /// Snapshot of sprite progress metrics for diffing.
     @State private var previousProgressMetrics: [String: OfficeViewModel.ProgressMetrics] = [:]
 
@@ -154,6 +160,8 @@ struct OfficeView: View {
                     previousToolLabels = [:]
                     previousProgressMetrics = [:]
                     toolBubbleHolds = []
+                    for (_, task) in toolBubbleHoldTasks { task.cancel() }
+                    toolBubbleHoldTasks = [:]
                     syncUnreadGlows(ids: viewModel.unreadResponseSpriteIds, scene: scene)
                     fireBubblePreviews(viewModel.pendingBubblePreviews, viewModel: viewModel, scene: scene)
                     syncRoleAuras(ids: viewModel.spriteAuraActive, viewModel: viewModel, scene: scene)
@@ -468,14 +476,21 @@ struct OfficeView: View {
             if viewModel.spriteToolLabels[spriteId] != nil {
                 scene.hideToolBubble(on: spriteId)
                 toolBubbleHolds.insert(spriteId)
+                // Cancel any existing restore task for this sprite so a second
+                // preview inside the 5s window doesn't let a stale timer clear
+                // the hold early.
+                toolBubbleHoldTasks[spriteId]?.cancel()
                 // After 5s, if the tool is still active, re-show it.
-                Task { @MainActor in
+                let task = Task { @MainActor in
                     try? await Task.sleep(for: .seconds(5))
+                    guard !Task.isCancelled else { return }
                     if let label = viewModel.spriteToolLabels[spriteId] {
                         scene.showToolBubble(on: spriteId, label: label)
                     }
                     toolBubbleHolds.remove(spriteId)
+                    toolBubbleHoldTasks[spriteId] = nil
                 }
+                toolBubbleHoldTasks[spriteId] = task
             }
             scene.showResponsePreviewBubble(on: spriteId, text: shortPreview(text))
             firedPreviewIds.insert(spriteId)

--- a/ios/MajorTom/Features/Office/Views/OfficeView.swift
+++ b/ios/MajorTom/Features/Office/Views/OfficeView.swift
@@ -44,6 +44,19 @@ struct OfficeView: View {
     /// Snapshot of bubble-preview sprite IDs that have already been rendered.
     @State private var firedPreviewIds: Set<String> = []
 
+    /// Snapshot of sprite IDs with role aura active, for diffing.
+    @State private var previousAuraIds: Set<String> = []
+
+    /// Snapshot of sprite IDs with an active tool bubble, for diffing.
+    @State private var previousToolLabels: [String: String] = [:]
+
+    /// Sprite IDs whose tool bubble is currently suppressed (response bubble
+    /// is holding the slot for 5s). Used to restore when the hold expires.
+    @State private var toolBubbleHolds: Set<String> = []
+
+    /// Snapshot of sprite progress metrics for diffing.
+    @State private var previousProgressMetrics: [String: OfficeViewModel.ProgressMetrics] = [:]
+
     /// Activated scene — populated in onAppear, avoids side effects in body.
     @State private var activatedScene: OfficeScene?
 
@@ -122,14 +135,30 @@ struct OfficeView: View {
                 .onChange(of: viewModel.pendingBubblePreviews, initial: true) { _, previews in
                     fireBubblePreviews(previews, viewModel: viewModel, scene: scene)
                 }
+                .onChange(of: viewModel.spriteAuraActive, initial: true) { _, ids in
+                    syncRoleAuras(ids: ids, viewModel: viewModel, scene: scene)
+                }
+                .onChange(of: viewModel.spriteToolLabels, initial: true) { _, labels in
+                    syncToolBubbles(labels: labels, scene: scene)
+                }
+                .onChange(of: viewModel.spriteProgressMetrics, initial: true) { _, metrics in
+                    syncProgressMetrics(metrics: metrics, scene: scene)
+                }
                 .onChange(of: ObjectIdentifier(scene)) { _, _ in
                     // Scene identity changed (cold rebuild after LRU eviction) —
                     // reset diffing state so all currently-unread glows/previews
                     // are re-applied to the fresh scene instead of skipped.
                     previousUnreadIds = []
                     firedPreviewIds = []
+                    previousAuraIds = []
+                    previousToolLabels = [:]
+                    previousProgressMetrics = [:]
+                    toolBubbleHolds = []
                     syncUnreadGlows(ids: viewModel.unreadResponseSpriteIds, scene: scene)
                     fireBubblePreviews(viewModel.pendingBubblePreviews, viewModel: viewModel, scene: scene)
+                    syncRoleAuras(ids: viewModel.spriteAuraActive, viewModel: viewModel, scene: scene)
+                    syncToolBubbles(labels: viewModel.spriteToolLabels, scene: scene)
+                    syncProgressMetrics(metrics: viewModel.spriteProgressMetrics, scene: scene)
                 }
                 .onChange(of: relay?.connectionState) { _, newState in
                     if newState == .connected, let sid = viewModel.sessionId {
@@ -429,8 +458,25 @@ struct OfficeView: View {
     }
 
     /// Fire pending bubble previews once per sprite.
+    ///
+    /// M3 priority: if a tool bubble is currently showing on this sprite, yield
+    /// to the response bubble for 5 seconds, then restore the tool bubble if
+    /// it's still active. The green glow persists independently on the sprite.
     private func fireBubblePreviews(_ previews: [String: String], viewModel: OfficeViewModel, scene: OfficeScene) {
         for (spriteId, text) in previews where !firedPreviewIds.contains(spriteId) {
+            // M3: hide active tool bubble for the 5s response window.
+            if viewModel.spriteToolLabels[spriteId] != nil {
+                scene.hideToolBubble(on: spriteId)
+                toolBubbleHolds.insert(spriteId)
+                // After 5s, if the tool is still active, re-show it.
+                Task { @MainActor in
+                    try? await Task.sleep(for: .seconds(5))
+                    if let label = viewModel.spriteToolLabels[spriteId] {
+                        scene.showToolBubble(on: spriteId, label: label)
+                    }
+                    toolBubbleHolds.remove(spriteId)
+                }
+            }
             scene.showResponsePreviewBubble(on: spriteId, text: shortPreview(text))
             firedPreviewIds.insert(spriteId)
             viewModel.consumeBubblePreview(for: spriteId)
@@ -446,6 +492,65 @@ struct OfficeView: View {
         if trimmed.count <= 80 { return trimmed }
         let idx = trimmed.index(trimmed.startIndex, offsetBy: 77)
         return String(trimmed[..<idx]) + "…"
+    }
+
+    // MARK: - Wave 5 Sync Helpers
+
+    /// Apply role-aura adds/removes to the scene based on `spriteAuraActive`.
+    /// The canonical role comes from the matching AgentState.
+    private func syncRoleAuras(ids: Set<String>, viewModel: OfficeViewModel, scene: OfficeScene) {
+        let additions = ids.subtracting(previousAuraIds)
+        let removals = previousAuraIds.subtracting(ids)
+        for id in additions {
+            let role = viewModel.agents.first(where: { $0.id == id })?.canonicalRole
+            scene.showRoleAura(on: id, canonicalRole: role)
+        }
+        for id in removals {
+            scene.hideRoleAura(on: id)
+        }
+        previousAuraIds = ids
+    }
+
+    /// Apply tool-bubble updates: show new bubbles, swap labels when changed,
+    /// hide when removed. Respects the M3 hold set (response bubble is
+    /// holding the slot for 5 seconds).
+    private func syncToolBubbles(labels: [String: String], scene: OfficeScene) {
+        let currentIds = Set(labels.keys)
+        let previousIds = Set(previousToolLabels.keys)
+
+        // Additions + label changes
+        for (id, label) in labels {
+            let prev = previousToolLabels[id]
+            if prev != label && !toolBubbleHolds.contains(id) {
+                scene.showToolBubble(on: id, label: label)
+            }
+        }
+
+        // Removals
+        for id in previousIds.subtracting(currentIds) {
+            scene.hideToolBubble(on: id)
+        }
+
+        previousToolLabels = labels
+    }
+
+    /// Apply progress indicator updates: update text when changed, hide when removed.
+    private func syncProgressMetrics(metrics: [String: OfficeViewModel.ProgressMetrics], scene: OfficeScene) {
+        let currentIds = Set(metrics.keys)
+        let previousIds = Set(previousProgressMetrics.keys)
+
+        for (id, m) in metrics {
+            let prev = previousProgressMetrics[id]
+            if prev != m {
+                scene.updateProgressIndicator(on: id, toolCount: m.toolCount, tokenCount: m.tokenCount)
+            }
+        }
+
+        for id in previousIds.subtracting(currentIds) {
+            scene.hideProgressIndicator(on: id)
+        }
+
+        previousProgressMetrics = metrics
     }
 
     // MARK: - Scene Sync


### PR DESCRIPTION
## Summary

Wave 5 of the Sprite / Agent Wiring phase — visual differentiation + local push notifications for the iOS client.

- **Role-colored aura** under working sprites via new `SpriteAura` node. Color palette locked per spec (researcher->green, architect->blue, qa->red, devops->orange, frontend->magenta, backend->purple, lead->yellow, engineer->cyan, fallback->gray).
- **Green glow priority** — when a sprite has an unread `/btw` response, the green glow replaces the role aura. On Cool Beans / read, the role aura restores itself if the sprite is still working.
- **Tool-event speech bubbles** — humanized labels (`reading files...`, `writing code...`, etc) above sprites driven by `tool.start` / `tool.complete` when relay tags those events with `subagentId`. 30s safety-net auto-hide if complete never arrives.
- **M3 collision priority** — when both a response preview and a tool bubble would show, the response bubble takes the slot for 5 seconds, then the tool bubble resumes if still active. Green glow persists independently of bubble state.
- **Mini progress indicator** under working sprites — `"{toolCount} tools - {tokenCount}k tokens"` with k/M suffix formatting, updated from `agent.working` / `agent.idle` events. Hidden on idle unless an unread `/btw` keeps the sprite flagged.
- **Local push notifications** — new `SPRITE_BTW_RESPONSE` category with single **Cool Beans** action. Fires only when the app is NOT in the active foreground state (best-effort during the iOS ~10s suspension grace window per research doc). Tapping Cool Beans in the notification calls the same `dismissResponse` flow as in-app Cool Beans.

## Dependencies on relay PR (wire field names)

New optional Wave 5 fields the relay side is expected to emit:

- `ToolStartEvent`: `subagentId: string?`, `spriteHandle: string?`, `toolUseId: string?`
- `ToolCompleteEvent`: `subagentId: string?`, `spriteHandle: string?` (already had `toolUseId`)
- `AgentWorkingEvent`: `toolCount: number?`, `tokenCount: number?`
- `AgentIdleEvent`: `toolCount: number?`, `tokenCount: number?`

All fields are optional — iOS gracefully degrades when relay does not emit them yet (no sprite tool bubble, no progress indicator).

## Scenarios covered

- **Q5**: role aura + desk + tool bubble + progress indicator — all four tier-1 visuals shipped.
- **M3**: bubble collision priority — response bubble holds slot 5s, tool bubble resumes, green glow independent.
- **Local push**: `/btw` response notification when app backgrounded, Cool Beans action clears unread state on the matching sprite.

## Files changed

- `ios/MajorTom/Features/Office/Models/RoleMapper.swift` — `color(forCanonicalRole:)` palette
- `ios/MajorTom/Features/Office/Models/ToolHumanizer.swift` *(new)* — tool to humanized label mapping
- `ios/MajorTom/Features/Office/Sprites/SpriteAura.swift` *(new)* — soft-glow ring node
- `ios/MajorTom/Features/Office/Sprites/AgentSprite.swift` — role aura + tool bubble + progress APIs, updated unread-glow priority
- `ios/MajorTom/Features/Office/Scenes/OfficeScene.swift` — scene helpers forwarding to sprites
- `ios/MajorTom/Features/Office/ViewModels/OfficeViewModel.swift` — wave 5 state (aura set, tool labels, open toolUseIds, progress metrics), tool start/complete handlers, updated working/idle signatures
- `ios/MajorTom/Features/Office/Views/OfficeView.swift` — onChange sync for aura/tool/progress, M3 5-second hold on tool bubble
- `ios/MajorTom/Core/Models/Message.swift` — optional fields on `ToolStartEvent` / `ToolCompleteEvent` / `AgentWorkingEvent` / `AgentIdleEvent`
- `ios/MajorTom/Core/Services/RelayService.swift` — route tool.* per-sprite, pass counts through to viewmodel, gate background push
- `ios/MajorTom/Features/Notifications/Services/NotificationService.swift` — `SPRITE_BTW_RESPONSE` category + `postBtwResponseNotification` + `onBtwCoolBeansAction` callback
- `ios/MajorTom/App/MajorTomApp.swift` — wire `onBtwCoolBeansAction` to dismissResponse

## Test plan

- [x] iPhone 17 simulator: `xcodebuild -scheme MajorTom -destination 'platform=iOS Simulator,name=iPhone 17' build` — BUILD SUCCEEDED
- [ ] Manual: spawn a subagent, observe role-colored aura matching the locked palette
- [ ] Manual: send `/btw`, close inspector, verify 5s preview bubble appears then collapses to green glow
- [ ] Manual: send `/btw` while a tool bubble is active, verify 5s response hold then tool resumes
- [ ] Manual: relay emits `tool.start` with `subagentId`, verify humanized bubble ("reading files...") appears on the correct sprite
- [ ] Manual: relay emits `agent.working` with counts, verify `"{N} tools - {k}k tokens"` label below sprite
- [ ] Manual: background app, trigger `/btw` response, verify notification appears with "Cool Beans" action
- [ ] Manual: tap Cool Beans in notification, verify green glow clears on next app open

Generated with [Claude Code](https://claude.com/claude-code)
