### PR TITLE
feat(ios): Wave 6 edge cases + battle test

### DIFF
--- a/ios/MajorTom/Features/Office/Models/AgentState.swift
+++ b/ios/MajorTom/Features/Office/Models/AgentState.swift
@@ -82,6 +82,13 @@ struct AgentState: Identifiable {
     /// Needed for future multi-session routing (Wave 3).
     var parentId: String?
 
+    // MARK: - Overflow Placement (Wave 6 — S5)
+
+    /// Pre-claimed overflow position when all 8 desks are occupied.
+    /// Set when the agent spawns into an empty-desk situation; the scene
+    /// walks the sprite to this point instead of a desk seat.
+    var overflowPosition: CGPoint?
+
     init(
         id: String,
         name: String,
@@ -94,7 +101,8 @@ struct AgentState: Identifiable {
         linkedSubagentId: String? = nil,
         spriteHandle: String? = nil,
         canonicalRole: String? = nil,
-        parentId: String? = nil
+        parentId: String? = nil,
+        overflowPosition: CGPoint? = nil
     ) {
         self.id = id
         self.name = name
@@ -108,6 +116,7 @@ struct AgentState: Identifiable {
         self.spriteHandle = spriteHandle
         self.canonicalRole = canonicalRole
         self.parentId = parentId
+        self.overflowPosition = overflowPosition
     }
 
     /// Time since the agent was spawned, formatted for display.
@@ -135,6 +144,7 @@ extension AgentState: Equatable {
         lhs.spriteHandle == rhs.spriteHandle &&
         lhs.canonicalRole == rhs.canonicalRole &&
         lhs.parentId == rhs.parentId &&
-        lhs.characterType == rhs.characterType
+        lhs.characterType == rhs.characterType &&
+        lhs.overflowPosition == rhs.overflowPosition
     }
 }

--- a/ios/MajorTom/Features/Office/Models/OfficeLayout.swift
+++ b/ios/MajorTom/Features/Office/Models/OfficeLayout.swift
@@ -92,6 +92,32 @@ struct OfficeLayout {
         Desk(id: 7, position: CGPoint(x: 500, y: 2250)),
     ]
 
+    // MARK: - Overflow Positions (S5)
+
+    /// Overflow standing positions for agent sprites when all desks are taken.
+    /// Placed in the empty Command Bridge floor space below the lower desk row
+    /// (y=2250). These are programmatic "huddle spots" — sprites stand there
+    /// instead of sitting at a desk.
+    ///
+    /// Command Bridge bounds: x=0–600, y=1980–2620. Desks at y=2250 and y=2450.
+    /// Free span below desks: y=1990–2200 (~210pt tall). Furniture (captain's
+    /// chair, tactical display, status screens) all sit at the TOP of the
+    /// module, so the lower band is clear.
+    ///
+    /// Grid: 6 columns × 3 rows = 18 slots. Sprite width is ~32pt, so 80pt
+    /// column spacing + 70pt row spacing keeps overflow sprites from overlapping.
+    static let overflowPositions: [CGPoint] = {
+        var points: [CGPoint] = []
+        let xs: [CGFloat] = [80, 160, 240, 320, 400, 480, 560]
+        let ys: [CGFloat] = [2030, 2100, 2170]
+        for y in ys {
+            for x in xs {
+                points.append(CGPoint(x: x, y: y))
+            }
+        }
+        return points
+    }()
+
     // MARK: - Helpers
 
     /// Get a random position within an area for idle/break movement.

--- a/ios/MajorTom/Features/Office/Models/OfficeLayout.swift
+++ b/ios/MajorTom/Features/Office/Models/OfficeLayout.swift
@@ -104,7 +104,7 @@ struct OfficeLayout {
     /// chair, tactical display, status screens) all sit at the TOP of the
     /// module, so the lower band is clear.
     ///
-    /// Grid: 6 columns × 3 rows = 18 slots. Sprite width is ~32pt, so 80pt
+    /// Grid: 7 columns × 3 rows = 21 slots. Sprite width is ~32pt, so 80pt
     /// column spacing + 70pt row spacing keeps overflow sprites from overlapping.
     static let overflowPositions: [CGPoint] = {
         var points: [CGPoint] = []

--- a/ios/MajorTom/Features/Office/Scenes/OfficeScene.swift
+++ b/ios/MajorTom/Features/Office/Scenes/OfficeScene.swift
@@ -1820,6 +1820,41 @@ final class OfficeScene: SKScene {
         agentSprites[agentId]?.hideProgressIndicator()
     }
 
+    // MARK: - Disconnected State (Wave 6 — S4)
+
+    /// Apply the gray-out/reconnecting treatment to a specific sprite.
+    func showDisconnectedState(on agentId: String) {
+        agentSprites[agentId]?.showDisconnectedState()
+    }
+
+    /// Clear the disconnected treatment on a specific sprite.
+    func hideDisconnectedState(on agentId: String) {
+        agentSprites[agentId]?.hideDisconnectedState()
+    }
+
+    /// True if the named sprite is currently in the disconnected visual state.
+    /// Used by OfficeView to gate inspector messaging.
+    func isSpriteDisconnected(_ agentId: String) -> Bool {
+        agentSprites[agentId]?.isDisconnected ?? false
+    }
+
+    // MARK: - Overflow Placement (Wave 6 — S5)
+
+    /// Walk the agent to a programmatic overflow position in the work room
+    /// (Command Bridge floor). Used when all 8 desks are occupied.
+    func moveAgentToOverflow(id: String, position: CGPoint) {
+        guard let sprite = agentSprites[id] else { return }
+        sprite.stopAnimations()
+        sprite.updateStatus(.walking)
+        gridEngine.releaseAllReservations(for: id)
+        let waypoints = gridEngine.findFullPath(from: sprite.position, to: position, agentId: id)
+        sprite.moveAlongPath(waypoints) {
+            sprite.updateStatus(.working)
+            sprite.updateModule(.commandBridge)
+            sprite.startWorkAnimation()
+        }
+    }
+
     // MARK: - Desk Highlighting
 
     func highlightDesk(_ deskIndex: Int, occupied: Bool) {

--- a/ios/MajorTom/Features/Office/Scenes/OfficeScene.swift
+++ b/ios/MajorTom/Features/Office/Scenes/OfficeScene.swift
@@ -1832,12 +1832,6 @@ final class OfficeScene: SKScene {
         agentSprites[agentId]?.hideDisconnectedState()
     }
 
-    /// True if the named sprite is currently in the disconnected visual state.
-    /// Used by OfficeView to gate inspector messaging.
-    func isSpriteDisconnected(_ agentId: String) -> Bool {
-        agentSprites[agentId]?.isDisconnected ?? false
-    }
-
     // MARK: - Overflow Placement (Wave 6 — S5)
 
     /// Walk the agent to a programmatic overflow position in the work room

--- a/ios/MajorTom/Features/Office/Sprites/AgentSprite.swift
+++ b/ios/MajorTom/Features/Office/Sprites/AgentSprite.swift
@@ -912,6 +912,69 @@ final class AgentSprite: SKSpriteNode {
         progressLabel = nil
     }
 
+    // MARK: - Disconnected State (Wave 6 — S4)
+
+    /// Whether the sprite is currently displayed in the disconnected visual
+    /// treatment. Read by OfficeView / inspector to swap messaging paths for
+    /// a "relay offline" message.
+    private(set) var isDisconnected: Bool = false
+
+    /// Small "~" indicator hovering above the name label while disconnected.
+    private var disconnectIndicator: SKLabelNode?
+
+    /// Apply the "disconnected from relay" visual treatment: desaturate the
+    /// body, dim the whole sprite slightly, and hover a pulsing "~" indicator
+    /// above the name label.
+    ///
+    /// Uses `colorBlendFactor` + `color` on the body sprite for a cheap
+    /// desaturation — no SKEffectNode pipeline required.
+    func showDisconnectedState() {
+        guard !isDisconnected else { return }
+        isDisconnected = true
+
+        bodySprite.color = SKColor(white: 0.4, alpha: 1)
+        bodySprite.colorBlendFactor = 0.65
+
+        run(SKAction.fadeAlpha(to: 0.7, duration: 0.2), withKey: "disconnectFade")
+
+        if disconnectIndicator == nil {
+            let indicator = SKLabelNode(fontNamed: "Menlo-Bold")
+            indicator.text = "~"
+            indicator.fontSize = 10
+            indicator.fontColor = SKColor(red: 0.85, green: 0.75, blue: 0.35, alpha: 0.9)
+            indicator.horizontalAlignmentMode = .center
+            indicator.verticalAlignmentMode = .bottom
+            let spriteSize = CrewSpriteBuilder.size(for: characterType)
+            indicator.position = CGPoint(x: 0, y: spriteSize.height / 2 + 14)
+            indicator.zPosition = 22
+            indicator.alpha = 0
+            addChild(indicator)
+
+            let pulse = SKAction.repeatForever(SKAction.sequence([
+                SKAction.fadeAlpha(to: 0.4, duration: 0.6),
+                SKAction.fadeAlpha(to: 0.95, duration: 0.6),
+            ]))
+            indicator.run(pulse)
+            disconnectIndicator = indicator
+        }
+    }
+
+    /// Restore normal sprite coloring after reconnect.
+    func hideDisconnectedState() {
+        guard isDisconnected else { return }
+        isDisconnected = false
+
+        bodySprite.colorBlendFactor = 0
+        run(SKAction.fadeAlpha(to: 1.0, duration: 0.2), withKey: "disconnectFade")
+
+        disconnectIndicator?.removeAllActions()
+        disconnectIndicator?.run(SKAction.sequence([
+            SKAction.fadeOut(withDuration: 0.2),
+            SKAction.removeFromParent(),
+        ]))
+        disconnectIndicator = nil
+    }
+
     /// Format `{toolCount} tools · {tokenCount}k tokens` with k/M suffix
     /// on the token count (one decimal). Returns nil when neither is present.
     static func formatProgressText(toolCount: Int?, tokenCount: Int?) -> String? {

--- a/ios/MajorTom/Features/Office/Sprites/AgentSprite.swift
+++ b/ios/MajorTom/Features/Office/Sprites/AgentSprite.swift
@@ -914,9 +914,14 @@ final class AgentSprite: SKSpriteNode {
 
     // MARK: - Disconnected State (Wave 6 — S4)
 
-    /// Whether the sprite is currently displayed in the disconnected visual
-    /// treatment. Read by OfficeView / inspector to swap messaging paths for
-    /// a "relay offline" message.
+    /// Internal visual-treatment flag for this sprite's "disconnected from
+    /// relay" styling. OfficeView drives show/hide by diffing
+    /// `OfficeViewModel.disconnectedSpriteIds` and calling
+    /// `showDisconnectedState()` / `hideDisconnectedState()` on the scene;
+    /// this flag is the idempotency guard that prevents those methods from
+    /// re-applying (or re-clearing) the same visual state. It is NOT the
+    /// source of truth consumed by OfficeView or SpriteInspectorView — those
+    /// read `viewModel.disconnectedSpriteIds` directly.
     private(set) var isDisconnected: Bool = false
 
     /// Small "~" indicator hovering above the name label while disconnected.

--- a/ios/MajorTom/Features/Office/ViewModels/OfficeSceneManager.swift
+++ b/ios/MajorTom/Features/Office/ViewModels/OfficeSceneManager.swift
@@ -177,6 +177,9 @@ final class OfficeSceneManager {
             if let deskIndex = agent.deskIndex {
                 scene.highlightDesk(deskIndex, occupied: true)
                 scene.moveAgentToDesk(id: agent.id, deskIndex: deskIndex)
+            } else if let overflowPosition = agent.overflowPosition {
+                // Wave 6 — S5 overflow placement after cold rebuild.
+                scene.moveAgentToOverflow(id: agent.id, position: overflowPosition)
             }
             switch agent.status {
             case .working:

--- a/ios/MajorTom/Features/Office/ViewModels/OfficeViewModel.swift
+++ b/ios/MajorTom/Features/Office/ViewModels/OfficeViewModel.swift
@@ -115,7 +115,7 @@ final class OfficeViewModel {
 
     /// Overflow positions currently claimed by agent sprites, keyed by agent id.
     /// When an agent despawns, its position is released for the next spawn.
-    var claimedOverflowPositions: [String: CGPoint] = [:]
+    private var claimedOverflowPositions: [String: CGPoint] = [:]
 
     // MARK: - Spawn Timing (Wave 6 — S6)
 

--- a/ios/MajorTom/Features/Office/ViewModels/OfficeViewModel.swift
+++ b/ios/MajorTom/Features/Office/ViewModels/OfficeViewModel.swift
@@ -93,6 +93,31 @@ final class OfficeViewModel {
     /// this set against the scene. Managed by working/idle/dismiss handlers.
     var spriteAuraActive: Set<String> = []
 
+    // MARK: - Disconnected State (Wave 6 — S4)
+
+    /// Sprite ids currently displayed with the "disconnected" gray-out treatment.
+    /// The view diff-renders this set against the scene. Separate from the
+    /// relay's connectionState so we can debounce brief drops (<1s) and keep
+    /// the idle sprite pool unaffected.
+    var disconnectedSpriteIds: Set<String> = []
+
+    // MARK: - Overflow Placement (Wave 6 — S5)
+
+    /// Overflow positions currently claimed by agent sprites, keyed by agent id.
+    /// When an agent despawns, its position is released for the next spawn.
+    var claimedOverflowPositions: [String: CGPoint] = [:]
+
+    // MARK: - Spawn Timing (Wave 6 — S6)
+
+    /// Per-agent spawn timestamps, used to guarantee a minimum on-screen
+    /// duration before complete/dismissed despawn animations start. Prevents
+    /// the "flash-appear-flash-gone" UX when a subagent finishes in <1s.
+    private var spawnTimestamps: [String: Date] = [:]
+
+    /// Minimum total display time for a newly spawned sprite (spawn + work +
+    /// celebration + poof). Anything faster gets padded out with a Task.sleep.
+    private static let minDisplayDurationSeconds: TimeInterval = 1.5
+
     // MARK: - Sprite Pool
 
     private static let idlePrefix = "idle-"
@@ -173,7 +198,8 @@ final class OfficeViewModel {
         )
         sessionRoleBindings = updatedBindings
 
-        let deskIndex = assignNextAvailableDesk(to: id)
+        // S5 — placement cascade: desk first, then overflow.
+        let placement = assignPlacement(to: id)
 
         let agent = AgentState(
             id: id,
@@ -182,13 +208,15 @@ final class OfficeViewModel {
             characterType: characterType,
             status: .spawning,
             currentTask: task,
-            deskIndex: deskIndex,
+            deskIndex: placement.deskIndex,
             linkedSubagentId: id,
             canonicalRole: role,
-            parentId: parentId
+            parentId: parentId,
+            overflowPosition: placement.overflowPosition
         )
         agents.append(agent)
         moodEngine.addAgent(id)
+        spawnTimestamps[id] = Date()
     }
 
     /// Called when the relay broadcasts `agent.working`.
@@ -255,23 +283,34 @@ final class OfficeViewModel {
     /// Called when the relay broadcasts `agent.complete`.
     /// Clone-not-consume: agent sprite celebrates then despawns entirely.
     /// Idle sprites are unaffected — no return-to-pool needed.
+    ///
+    /// S6 (Wave 6): if the agent spawned <1.5s ago, hold the sprite in
+    /// `.spawning`/`.working` first so the user gets to see the spawn+work
+    /// chain before the celebration and poof-despawn.
     func handleAgentComplete(id: String, result: String) {
-        guard let index = agents.firstIndex(where: { $0.id == id }) else { return }
+        guard agents.firstIndex(where: { $0.id == id }) != nil else { return }
         guard !isIdleSprite(id) else { return }
 
         // Scenario #4 — if there's a pending /btw for this agent, mark it
         // dropped so the user isn't left on "Thinking…" forever.
         markPendingDropped(for: id)
 
-        agents[index].status = .celebrating
-        agents[index].currentTask = result
         moodEngine.recordCompletion(id)
+        let warmup = fastCompleteDelay(for: id)
 
-        // After a brief celebration, transition to leaving, then despawn
+        // After a brief celebration, transition to leaving, then despawn.
+        // Warmup guarantees spawn+work animations run for at least 1.5s.
         Task { @MainActor in
+            if warmup > 0 {
+                try? await Task.sleep(for: .seconds(warmup))
+            }
+            guard let idx1 = agents.firstIndex(where: { $0.id == id }) else { return }
+            agents[idx1].status = .celebrating
+            agents[idx1].currentTask = result
+
             try? await Task.sleep(for: .seconds(2))
-            if let idx = agents.firstIndex(where: { $0.id == id }) {
-                agents[idx].status = .leaving
+            if let idx2 = agents.firstIndex(where: { $0.id == id }) {
+                agents[idx2].status = .leaving
             }
             try? await Task.sleep(for: .seconds(1.5))
             removeAgent(id: id)
@@ -282,19 +321,27 @@ final class OfficeViewModel {
 
     /// Called when the relay broadcasts `agent.dismissed`.
     /// Clone-not-consume: agent sprite leaves then despawns entirely.
+    ///
+    /// S6 (Wave 6): same fast-complete guard as handleAgentComplete — the
+    /// spawn animation always gets a chance to run.
     func handleAgentDismissed(id: String) {
         guard agents.contains(where: { $0.id == id }) else { return }
         guard !isIdleSprite(id) else { return }
 
         markPendingDropped(for: id)
 
-        guard let index = agents.firstIndex(where: { $0.id == id }) else { return }
-        agents[index].status = .leaving
-        agents[index].currentTask = nil
+        let warmup = fastCompleteDelay(for: id)
 
         // Agent sprite despawns after walking out.
         // Clone-not-consume: idle sprites were never consumed, so no return-to-pool.
         Task { @MainActor in
+            if warmup > 0 {
+                try? await Task.sleep(for: .seconds(warmup))
+            }
+            guard let idx = agents.firstIndex(where: { $0.id == id }) else { return }
+            agents[idx].status = .leaving
+            agents[idx].currentTask = nil
+
             try? await Task.sleep(for: .seconds(1.5))
             removeAgent(id: id)
         }
@@ -351,6 +398,39 @@ final class OfficeViewModel {
         return deskIndex
     }
 
+    /// Claim the first free overflow slot for an agent.
+    /// Returns nil if every overflow point is already occupied (shouldn't
+    /// happen in practice — overflow pool is 18, way beyond reasonable
+    /// concurrent-subagent count).
+    private func claimOverflowPosition(for agentId: String) -> CGPoint? {
+        let taken = Set(claimedOverflowPositions.values.map { point in
+            // Round to nearest integer to form a stable dictionary key.
+            CGPoint(x: point.x.rounded(), y: point.y.rounded())
+        })
+        for candidate in OfficeLayout.overflowPositions {
+            let rounded = CGPoint(x: candidate.x.rounded(), y: candidate.y.rounded())
+            if !taken.contains(rounded) {
+                claimedOverflowPositions[agentId] = candidate
+                return candidate
+            }
+        }
+        return nil
+    }
+
+    /// Release an overflow position when an agent leaves.
+    private func releaseOverflow(for agentId: String) {
+        claimedOverflowPositions.removeValue(forKey: agentId)
+    }
+
+    /// Build a placement (desk-first, overflow-fallback) for a spawning agent.
+    /// Returns (deskIndex, overflowPosition) where exactly one is non-nil.
+    private func assignPlacement(to agentId: String) -> (deskIndex: Int?, overflowPosition: CGPoint?) {
+        if let deskIndex = assignNextAvailableDesk(to: agentId) {
+            return (deskIndex, nil)
+        }
+        return (nil, claimOverflowPosition(for: agentId))
+    }
+
     /// Release a desk when an agent leaves.
     private func releaseDesk(for agentId: String) {
         if let deskIndex = desks.firstIndex(where: { $0.occupantId == agentId }) {
@@ -361,6 +441,7 @@ final class OfficeViewModel {
     /// Remove an agent entirely (after they've left the office).
     private func removeAgent(id: String) {
         releaseDesk(for: id)
+        releaseOverflow(for: id)
         activityEngine.releaseActivity(for: id)
         moodEngine.removeAgent(id)
         agents.removeAll { $0.id == id }
@@ -369,9 +450,37 @@ final class OfficeViewModel {
         spriteToolLabels.removeValue(forKey: id)
         spriteOpenToolUseIds.removeValue(forKey: id)
         spriteProgressMetrics.removeValue(forKey: id)
+        // Wave 6 cleanup
+        disconnectedSpriteIds.remove(id)
+        spawnTimestamps.removeValue(forKey: id)
         if selectedAgentId == id {
             selectedAgentId = nil
         }
+    }
+
+    /// Return additional delay (seconds) needed before starting a despawn
+    /// animation so the spawn+work+celebration chain always shows for at least
+    /// `minDisplayDurationSeconds`. Returns 0 when the agent has been around
+    /// long enough or was restored from relay state (no spawn timestamp).
+    private func fastCompleteDelay(for agentId: String) -> TimeInterval {
+        guard let spawnedAt = spawnTimestamps[agentId] else { return 0 }
+        let age = Date().timeIntervalSince(spawnedAt)
+        let remaining = Self.minDisplayDurationSeconds - age
+        return max(0, remaining)
+    }
+
+    // MARK: - Disconnect / Reconnect (Wave 6 — S4)
+
+    /// Mark every non-idle agent sprite as "disconnected from relay". Idle
+    /// sprites keep their colors — they aren't driven by the WebSocket.
+    func markAllAgentsDisconnected() {
+        let nonIdle = agents.filter { !isIdleSprite($0.id) }.map(\.id)
+        disconnectedSpriteIds = Set(nonIdle)
+    }
+
+    /// Clear the disconnected flag on all sprites (reconcile handled elsewhere).
+    func clearDisconnectedState() {
+        disconnectedSpriteIds.removeAll()
     }
 
     // MARK: - Sprite Protocol Handlers (Wave 2)
@@ -414,7 +523,8 @@ final class OfficeViewModel {
         sessionRoleBindings = updatedBindings
 
         // Use subagentId as primary ID so agent.* lifecycle handlers find this agent
-        let deskIndex = assignNextAvailableDesk(to: event.subagentId)
+        // S5 — placement cascade: desk first, then overflow.
+        let placement = assignPlacement(to: event.subagentId)
 
         let agent = AgentState(
             id: event.subagentId,
@@ -423,18 +533,24 @@ final class OfficeViewModel {
             characterType: characterType,
             status: .spawning,
             currentTask: event.task,
-            deskIndex: deskIndex,
+            deskIndex: placement.deskIndex,
             linkedSubagentId: event.subagentId,
             spriteHandle: event.spriteHandle,
             canonicalRole: event.canonicalRole,
-            parentId: event.parentId
+            parentId: event.parentId,
+            overflowPosition: placement.overflowPosition
         )
         agents.append(agent)
         moodEngine.addAgent(event.subagentId)
+        spawnTimestamps[event.subagentId] = Date()
     }
 
     /// Handle `sprite.unlink` — despawn the linked sprite.
     /// Looks up by subagentId first (primary key), falls back to spriteHandle metadata.
+    ///
+    /// S6 (Wave 6): same fast-complete guard — wait out the minimum display
+    /// duration before the despawn animation starts so spawn+work gets a
+    /// chance to render.
     func handleSpriteUnlink(_ event: SpriteUnlinkEvent) {
         guard let index = agents.firstIndex(where: {
             $0.id == event.subagentId || $0.spriteHandle == event.spriteHandle
@@ -447,36 +563,52 @@ final class OfficeViewModel {
         // Scenario #4 — drop any pending /btw since the subagent is leaving.
         markPendingDropped(for: agentId)
 
+        let warmup = fastCompleteDelay(for: agentId)
+
         switch event.reason {
         case "completed":
-            agents[index].status = .celebrating
-            agents[index].currentTask = event.result
             moodEngine.recordCompletion(agentId)
 
             Task { @MainActor in
+                if warmup > 0 {
+                    try? await Task.sleep(for: .seconds(warmup))
+                }
+                guard let idx1 = agents.firstIndex(where: { $0.id == agentId }) else { return }
+                agents[idx1].status = .celebrating
+                agents[idx1].currentTask = event.result
+
                 try? await Task.sleep(for: .seconds(2))
-                if let idx = agents.firstIndex(where: { $0.id == agentId }) {
-                    agents[idx].status = .leaving
+                if let idx2 = agents.firstIndex(where: { $0.id == agentId }) {
+                    agents[idx2].status = .leaving
                 }
                 try? await Task.sleep(for: .seconds(1.5))
                 removeAgent(id: agentId)
             }
 
         case "failed":
-            agents[index].status = .leaving
-            agents[index].currentTask = event.result ?? "Error"
             moodEngine.recordError(agentId)
 
             Task { @MainActor in
+                if warmup > 0 {
+                    try? await Task.sleep(for: .seconds(warmup))
+                }
+                guard let idx = agents.firstIndex(where: { $0.id == agentId }) else { return }
+                agents[idx].status = .leaving
+                agents[idx].currentTask = event.result ?? "Error"
+
                 try? await Task.sleep(for: .seconds(1.5))
                 removeAgent(id: agentId)
             }
 
         default:  // "dismissed" or unknown
-            agents[index].status = .leaving
-            agents[index].currentTask = nil
-
             Task { @MainActor in
+                if warmup > 0 {
+                    try? await Task.sleep(for: .seconds(warmup))
+                }
+                guard let idx = agents.firstIndex(where: { $0.id == agentId }) else { return }
+                agents[idx].status = .leaving
+                agents[idx].currentTask = nil
+
                 try? await Task.sleep(for: .seconds(1.5))
                 removeAgent(id: agentId)
             }
@@ -730,7 +862,8 @@ final class OfficeViewModel {
             default: status = .working
             }
 
-            let deskIndex = assignNextAvailableDesk(to: mapping.subagentId)
+            // S5 — placement cascade: desk first, then overflow.
+            let placement = assignPlacement(to: mapping.subagentId)
 
             let agent = AgentState(
                 id: mapping.subagentId,
@@ -739,14 +872,17 @@ final class OfficeViewModel {
                 characterType: characterType,
                 status: status,
                 currentTask: mapping.task,
-                deskIndex: deskIndex,
+                deskIndex: placement.deskIndex,
                 linkedSubagentId: mapping.subagentId,
                 spriteHandle: mapping.spriteHandle,
                 canonicalRole: mapping.canonicalRole,
-                parentId: mapping.parentId
+                parentId: mapping.parentId,
+                overflowPosition: placement.overflowPosition
             )
             agents.append(agent)
             moodEngine.addAgent(mapping.subagentId)
+            // Reconnect/rebuild: assume these have been around a while — no
+            // need to debounce their celebration. Leave spawnTimestamps clear.
         }
     }
 }

--- a/ios/MajorTom/Features/Office/ViewModels/OfficeViewModel.swift
+++ b/ios/MajorTom/Features/Office/ViewModels/OfficeViewModel.swift
@@ -101,6 +101,16 @@ final class OfficeViewModel {
     /// the idle sprite pool unaffected.
     var disconnectedSpriteIds: Set<String> = []
 
+    /// Pending debounce Task that applies the disconnect gray-out after the
+    /// 1s debounce window. Owned by the view model so it survives view
+    /// appear/disappear cycles — a drop that starts while the Office is
+    /// visible still resolves correctly if the user backgrounds the view.
+    private var disconnectDebounceTask: Task<Void, Never>?
+
+    /// Debounce window before a disconnect paints sprites gray. Short enough
+    /// to surface long drops, long enough to swallow WebSocket blips.
+    private static let disconnectDebounceSeconds: TimeInterval = 1
+
     // MARK: - Overflow Placement (Wave 6 — S5)
 
     /// Overflow positions currently claimed by agent sprites, keyed by agent id.
@@ -400,7 +410,7 @@ final class OfficeViewModel {
 
     /// Claim the first free overflow slot for an agent.
     /// Returns nil if every overflow point is already occupied (shouldn't
-    /// happen in practice — overflow pool is 18, way beyond reasonable
+    /// happen in practice — overflow pool is 21 (7×3), way beyond reasonable
     /// concurrent-subagent count).
     private func claimOverflowPosition(for agentId: String) -> CGPoint? {
         let taken = Set(claimedOverflowPositions.values.map { point in
@@ -481,6 +491,29 @@ final class OfficeViewModel {
     /// Clear the disconnected flag on all sprites (reconcile handled elsewhere).
     func clearDisconnectedState() {
         disconnectedSpriteIds.removeAll()
+    }
+
+    /// Relay dropped or is reconnecting. Schedules the gray-out after the
+    /// debounce window; a quick reconnect cancels it before anything paints.
+    ///
+    /// Lives on the ViewModel (not the view) so the Task survives view
+    /// disappearance — otherwise the sprites would remain stuck in whatever
+    /// state the last render left them in if the user navigated away mid-drop.
+    func beginDisconnectDebounce() {
+        disconnectDebounceTask?.cancel()
+        disconnectDebounceTask = Task { @MainActor [weak self] in
+            try? await Task.sleep(for: .seconds(Self.disconnectDebounceSeconds))
+            guard let self, !Task.isCancelled else { return }
+            self.markAllAgentsDisconnected()
+            self.disconnectDebounceTask = nil
+        }
+    }
+
+    /// Relay reconnected. Cancel any pending debounce and clear gray-out.
+    func resolveReconnect() {
+        disconnectDebounceTask?.cancel()
+        disconnectDebounceTask = nil
+        clearDisconnectedState()
     }
 
     // MARK: - Sprite Protocol Handlers (Wave 2)

--- a/ios/MajorTom/Features/Office/Views/OfficeView.swift
+++ b/ios/MajorTom/Features/Office/Views/OfficeView.swift
@@ -66,10 +66,6 @@ struct OfficeView: View {
     /// Snapshot of sprite IDs currently grayed out as disconnected, for diffing.
     @State private var previousDisconnectedIds: Set<String> = []
 
-    /// Pending Task that applies the disconnect gray-out after the 1s debounce.
-    /// Held so a quick reconnect can cancel it without flashing gray sprites.
-    @State private var disconnectDebounceTask: Task<Void, Never>?
-
     /// Activated scene — populated in onAppear, avoids side effects in body.
     @State private var activatedScene: OfficeScene?
 
@@ -595,31 +591,24 @@ struct OfficeView: View {
         previousDisconnectedIds = ids
     }
 
-    /// Debounced disconnect/reconnect handler (S4).
+    /// Debounced disconnect/reconnect handler (S4). The debounce itself lives
+    /// on `OfficeViewModel` so the pending Task survives view appear/disappear
+    /// cycles — this function only dispatches connection-state transitions to
+    /// the view model and triggers relay-side side effects on reconnect.
     ///
-    /// - On `.disconnected` or `.reconnecting`: schedule a 1-second Task that
-    ///   gray-outs all non-idle sprites. A quick reconnect inside the window
-    ///   cancels the Task so nothing flashes.
-    /// - On `.connected`: cancel any pending gray-out, clear any existing
-    ///   gray-out, flush queued sprite messages, and re-request sprite state
-    ///   from the relay so the scene reconciles any subagents that
-    ///   completed/spawned during the drop.
+    /// - On `.disconnected` or `.reconnecting`: ask the view model to start
+    ///   the 1-second debounce. A quick reconnect cancels it before any
+    ///   gray-out is applied.
+    /// - On `.connected`: ask the view model to resolve, then flush queued
+    ///   sprite messages and re-request sprite state from the relay so the
+    ///   scene reconciles any subagents that completed/spawned during the drop.
     private func handleConnectionStateChange(_ newState: ConnectionState?, viewModel: OfficeViewModel) {
         switch newState {
         case .disconnected, .reconnecting:
-            // Cancel any prior debounce Task — we only need one pending.
-            disconnectDebounceTask?.cancel()
-            let vm = viewModel
-            disconnectDebounceTask = Task { @MainActor in
-                try? await Task.sleep(for: .seconds(1))
-                guard !Task.isCancelled else { return }
-                vm.markAllAgentsDisconnected()
-            }
+            viewModel.beginDisconnectDebounce()
 
         case .connected:
-            disconnectDebounceTask?.cancel()
-            disconnectDebounceTask = nil
-            viewModel.clearDisconnectedState()
+            viewModel.resolveReconnect()
             if let sid = viewModel.sessionId {
                 relay?.flushQueuedSpriteMessages(for: sid)
                 relay?.requestSpriteState(for: sid)

--- a/ios/MajorTom/Features/Office/Views/OfficeView.swift
+++ b/ios/MajorTom/Features/Office/Views/OfficeView.swift
@@ -63,6 +63,13 @@ struct OfficeView: View {
     /// Snapshot of sprite progress metrics for diffing.
     @State private var previousProgressMetrics: [String: OfficeViewModel.ProgressMetrics] = [:]
 
+    /// Snapshot of sprite IDs currently grayed out as disconnected, for diffing.
+    @State private var previousDisconnectedIds: Set<String> = []
+
+    /// Pending Task that applies the disconnect gray-out after the 1s debounce.
+    /// Held so a quick reconnect can cancel it without flashing gray sprites.
+    @State private var disconnectDebounceTask: Task<Void, Never>?
+
     /// Activated scene — populated in onAppear, avoids side effects in body.
     @State private var activatedScene: OfficeScene?
 
@@ -150,6 +157,9 @@ struct OfficeView: View {
                 .onChange(of: viewModel.spriteProgressMetrics, initial: true) { _, metrics in
                     syncProgressMetrics(metrics: metrics, scene: scene)
                 }
+                .onChange(of: viewModel.disconnectedSpriteIds, initial: true) { _, ids in
+                    syncDisconnectedStates(ids: ids, scene: scene)
+                }
                 .onChange(of: ObjectIdentifier(scene)) { _, _ in
                     // Scene identity changed (cold rebuild after LRU eviction) —
                     // reset diffing state so all currently-unread glows/previews
@@ -159,6 +169,7 @@ struct OfficeView: View {
                     previousAuraIds = []
                     previousToolLabels = [:]
                     previousProgressMetrics = [:]
+                    previousDisconnectedIds = []
                     toolBubbleHolds = []
                     for (_, task) in toolBubbleHoldTasks { task.cancel() }
                     toolBubbleHoldTasks = [:]
@@ -167,11 +178,10 @@ struct OfficeView: View {
                     syncRoleAuras(ids: viewModel.spriteAuraActive, viewModel: viewModel, scene: scene)
                     syncToolBubbles(labels: viewModel.spriteToolLabels, scene: scene)
                     syncProgressMetrics(metrics: viewModel.spriteProgressMetrics, scene: scene)
+                    syncDisconnectedStates(ids: viewModel.disconnectedSpriteIds, scene: scene)
                 }
                 .onChange(of: relay?.connectionState) { _, newState in
-                    if newState == .connected, let sid = viewModel.sessionId {
-                        relay?.flushQueuedSpriteMessages(for: sid)
-                    }
+                    handleConnectionStateChange(newState, viewModel: viewModel)
                 }
 
             // Top overlay: agent count + controls
@@ -568,6 +578,58 @@ struct OfficeView: View {
         previousProgressMetrics = metrics
     }
 
+    // MARK: - Wave 6 Sync Helpers
+
+    /// Apply gray-out / restore to sprites based on `disconnectedSpriteIds`.
+    /// Additions get the desaturated "reconnecting" treatment; removals have
+    /// the treatment cleared so the sprite returns to full color.
+    private func syncDisconnectedStates(ids: Set<String>, scene: OfficeScene) {
+        let additions = ids.subtracting(previousDisconnectedIds)
+        let removals = previousDisconnectedIds.subtracting(ids)
+        for id in additions {
+            scene.showDisconnectedState(on: id)
+        }
+        for id in removals {
+            scene.hideDisconnectedState(on: id)
+        }
+        previousDisconnectedIds = ids
+    }
+
+    /// Debounced disconnect/reconnect handler (S4).
+    ///
+    /// - On `.disconnected` or `.reconnecting`: schedule a 1-second Task that
+    ///   gray-outs all non-idle sprites. A quick reconnect inside the window
+    ///   cancels the Task so nothing flashes.
+    /// - On `.connected`: cancel any pending gray-out, clear any existing
+    ///   gray-out, flush queued sprite messages, and re-request sprite state
+    ///   from the relay so the scene reconciles any subagents that
+    ///   completed/spawned during the drop.
+    private func handleConnectionStateChange(_ newState: ConnectionState?, viewModel: OfficeViewModel) {
+        switch newState {
+        case .disconnected, .reconnecting:
+            // Cancel any prior debounce Task — we only need one pending.
+            disconnectDebounceTask?.cancel()
+            let vm = viewModel
+            disconnectDebounceTask = Task { @MainActor in
+                try? await Task.sleep(for: .seconds(1))
+                guard !Task.isCancelled else { return }
+                vm.markAllAgentsDisconnected()
+            }
+
+        case .connected:
+            disconnectDebounceTask?.cancel()
+            disconnectDebounceTask = nil
+            viewModel.clearDisconnectedState()
+            if let sid = viewModel.sessionId {
+                relay?.flushQueuedSpriteMessages(for: sid)
+                relay?.requestSpriteState(for: sid)
+            }
+
+        case .connecting, nil:
+            break
+        }
+    }
+
     // MARK: - Scene Sync
 
     private func syncScene(with agents: [AgentState], viewModel: OfficeViewModel, scene: OfficeScene) {
@@ -578,6 +640,9 @@ struct OfficeView: View {
             if let deskIndex = agent.deskIndex {
                 scene.highlightDesk(deskIndex, occupied: true)
                 scene.moveAgentToDesk(id: agent.id, deskIndex: deskIndex)
+            } else if let overflowPosition = agent.overflowPosition {
+                // S5: programmatic overflow placement in Command Bridge floor space.
+                scene.moveAgentToOverflow(id: agent.id, position: overflowPosition)
             }
         }
 
@@ -609,6 +674,9 @@ struct OfficeView: View {
             viewModel.activityAnimator.stopPhase(for: agent.id, furnitureNodes: scene.furnitureNodes)
             if let deskIndex = agent.deskIndex {
                 scene.moveAgentToDesk(id: agent.id, deskIndex: deskIndex)
+            } else if let overflowPosition = agent.overflowPosition {
+                // S5: overflow fallback — walk to the claimed floor position.
+                scene.moveAgentToOverflow(id: agent.id, position: overflowPosition)
             } else {
                 scene.updateAgentStatus(id: agent.id, status: .working)
             }

--- a/ios/MajorTom/Features/Office/Views/SpriteInspectorView.swift
+++ b/ios/MajorTom/Features/Office/Views/SpriteInspectorView.swift
@@ -36,6 +36,11 @@ struct SpriteInspectorView: View {
     /// despawns while the user had the inspector open (scenario 9 downgrade).
     @State private var agentCompletedToast: String?
 
+    /// Pending hide Task for the toast. Stored so a second toast firing inside
+    /// the 2.5s window cancels the stale hide Task — otherwise the older timer
+    /// clears the newer toast early.
+    @State private var agentCompletedToastHideTask: Task<Void, Never>?
+
     private enum Mode {
         case linked
         case dog
@@ -637,13 +642,19 @@ struct SpriteInspectorView: View {
 
     /// Surface a short "agent completed" banner, clear the draft, and auto-hide
     /// after 2.5s. Triggered when the inspector's linked sprite despawned mid-type.
+    ///
+    /// Cancels any prior hide Task so a second toast firing inside the 2.5s
+    /// window doesn't let a stale timer clear the newer toast early.
     private func showAgentCompletedToast() {
         draft = ""
         HapticService.impact(.soft)
         agentCompletedToast = "Agent completed — /btw isn't available anymore."
-        Task { @MainActor in
+        agentCompletedToastHideTask?.cancel()
+        agentCompletedToastHideTask = Task { @MainActor in
             try? await Task.sleep(for: .seconds(2.5))
+            guard !Task.isCancelled else { return }
             agentCompletedToast = nil
+            agentCompletedToastHideTask = nil
         }
     }
 }

--- a/ios/MajorTom/Features/Office/Views/SpriteInspectorView.swift
+++ b/ios/MajorTom/Features/Office/Views/SpriteInspectorView.swift
@@ -32,28 +32,45 @@ struct SpriteInspectorView: View {
     @State private var questionExpanded: Bool = false
     @State private var spriteScene: InspectorSpriteScene?
 
+    /// Transient "agent completed" banner shown for ~2.5s when a linked agent
+    /// despawns while the user had the inspector open (scenario 9 downgrade).
+    @State private var agentCompletedToast: String?
+
     private enum Mode {
         case linked
         case dog
         case idleHuman
     }
 
+    /// Live lookup of the current agent from the view model. If the agent has
+    /// been despawned (agent.complete fired while the inspector was open), we
+    /// fall back to the cached `agent` so the view can still render the sheet
+    /// while showing the "agent completed" toast.
+    private var currentAgent: AgentState {
+        viewModel.agents.first(where: { $0.id == agent.id }) ?? agent
+    }
+
+    /// Scenario 9: mode is computed from the LIVE agent state. A sprite that
+    /// was idle when tapped but became linked before send is now `.linked`.
+    /// Conversely, a sprite that was linked at tap but has since completed is
+    /// now `.idleHuman` (or `.dog`).
     private var mode: Mode {
-        if agent.linkedSubagentId != nil {
+        let live = currentAgent
+        if live.linkedSubagentId != nil {
             return .linked
         }
-        if agent.characterType.isDog {
+        if live.characterType.isDog {
             return .dog
         }
         return .idleHuman
     }
 
     private var messagingState: SpriteMessagingState {
-        viewModel.messagingState(for: agent.id)
+        viewModel.messagingState(for: currentAgent.id)
     }
 
     private var hasQueuedLocally: Bool {
-        guard let subagentId = agent.linkedSubagentId else { return false }
+        guard let subagentId = currentAgent.linkedSubagentId else { return false }
         return viewModel.queuedSpriteMessages.contains(where: { $0.subagentId == subagentId })
     }
 
@@ -72,6 +89,10 @@ struct SpriteInspectorView: View {
             }
 
             detailRows
+
+            if let toast = agentCompletedToast {
+                agentCompletedBanner(toast)
+            }
 
             Spacer(minLength: MajorTomTheme.Spacing.sm)
 
@@ -103,6 +124,30 @@ struct SpriteInspectorView: View {
             responseExpanded = false
             questionExpanded = false
         }
+        // Scenario 9 downgrade — was linked at tap, now idle.
+        .onChange(of: currentAgent.linkedSubagentId) { oldValue, newValue in
+            // We only care about the linked → unlinked transition on the same sprite.
+            if oldValue != nil, newValue == nil, !draft.isEmpty {
+                showAgentCompletedToast()
+            }
+        }
+    }
+
+    /// Inline banner surfaced when the linked sprite despawned mid-type.
+    private func agentCompletedBanner(_ text: String) -> some View {
+        HStack(spacing: MajorTomTheme.Spacing.sm) {
+            Image(systemName: "checkmark.seal.fill")
+                .foregroundStyle(MajorTomTheme.Colors.warning)
+                .font(.system(size: 12))
+            Text(text)
+                .font(MajorTomTheme.Typography.caption)
+                .foregroundStyle(MajorTomTheme.Colors.textSecondary)
+            Spacer()
+        }
+        .padding(MajorTomTheme.Spacing.sm)
+        .background(MajorTomTheme.Colors.warning.opacity(0.12))
+        .clipShape(RoundedRectangle(cornerRadius: MajorTomTheme.Radius.small))
+        .transition(.opacity)
     }
 
     // MARK: - Header
@@ -143,10 +188,11 @@ struct SpriteInspectorView: View {
     private var statusBadge: some View {
         let label: String
         let color: Color
+        let live = currentAgent
         switch mode {
         case .linked:
-            label = agent.status.rawValue.uppercased()
-            color = statusColor(for: agent.status)
+            label = live.status.rawValue.uppercased()
+            color = statusColor(for: live.status)
         case .dog:
             label = "DOG"
             color = MajorTomTheme.Colors.accent
@@ -177,17 +223,18 @@ struct SpriteInspectorView: View {
     // MARK: - Role + Task
 
     private var roleAndTask: some View {
-        VStack(alignment: .leading, spacing: MajorTomTheme.Spacing.sm) {
+        let live = currentAgent
+        return VStack(alignment: .leading, spacing: MajorTomTheme.Spacing.sm) {
             HStack(spacing: MajorTomTheme.Spacing.sm) {
                 Image(systemName: "person.badge.key.fill")
                     .font(.system(size: 14))
                     .foregroundStyle(MajorTomTheme.Colors.accent)
-                Text((agent.canonicalRole ?? agent.role).capitalized)
+                Text((live.canonicalRole ?? live.role).capitalized)
                     .font(MajorTomTheme.Typography.headline)
                     .foregroundStyle(MajorTomTheme.Colors.textPrimary)
             }
 
-            if let task = agent.currentTask {
+            if let task = live.currentTask {
                 HStack(alignment: .top, spacing: MajorTomTheme.Spacing.sm) {
                     Image(systemName: "chevron.right.circle.fill")
                         .font(.system(size: 12))
@@ -221,10 +268,15 @@ struct SpriteInspectorView: View {
     }
 
     private var detailRows: some View {
-        VStack(alignment: .leading, spacing: MajorTomTheme.Spacing.sm) {
-            detailRow(label: "Agent ID", value: String(agent.id.prefix(12)) + "...")
-            detailRow(label: "Desk", value: agent.deskIndex.map { "Desk \($0 + 1)" } ?? "None")
-            detailRow(label: "Uptime", value: agent.uptime)
+        let live = currentAgent
+        return VStack(alignment: .leading, spacing: MajorTomTheme.Spacing.sm) {
+            detailRow(label: "Agent ID", value: String(live.id.prefix(12)) + "...")
+            detailRow(
+                label: "Desk",
+                value: live.deskIndex.map { "Desk \($0 + 1)" }
+                    ?? (live.overflowPosition != nil ? "Overflow" : "None")
+            )
+            detailRow(label: "Uptime", value: live.uptime)
         }
     }
 
@@ -242,15 +294,49 @@ struct SpriteInspectorView: View {
 
     // MARK: - Mode content
 
+    /// True when the relay disconnected and the sprite was flagged via
+    /// `OfficeViewModel.markAllAgentsDisconnected`. Used to swap the /btw
+    /// input for an informational "relay offline" panel.
+    private var isDisconnected: Bool {
+        viewModel.disconnectedSpriteIds.contains(currentAgent.id)
+    }
+
     @ViewBuilder
     private var content: some View {
-        switch mode {
-        case .linked:
-            linkedModeContent
-        case .dog:
-            dogModeContent
-        case .idleHuman:
-            idleHumanContent
+        if isDisconnected && mode == .linked {
+            disconnectedLinkedContent
+        } else {
+            switch mode {
+            case .linked:
+                linkedModeContent
+            case .dog:
+                dogModeContent
+            case .idleHuman:
+                idleHumanContent
+            }
+        }
+    }
+
+    /// S4 info panel shown while the relay is disconnected and the sprite is
+    /// gray-out. /btw is unavailable until reconnect.
+    private var disconnectedLinkedContent: some View {
+        VStack(alignment: .leading, spacing: MajorTomTheme.Spacing.xs) {
+            HStack(spacing: 6) {
+                Image(systemName: "wifi.exclamationmark")
+                    .font(.system(size: 10))
+                    .foregroundStyle(MajorTomTheme.Colors.warning)
+                Text("Disconnected from relay")
+                    .font(MajorTomTheme.Typography.caption)
+                    .foregroundStyle(MajorTomTheme.Colors.textTertiary)
+                Spacer()
+            }
+            Text("We'll reconnect automatically. /btw will be available again once we're back online.")
+                .font(MajorTomTheme.Typography.caption)
+                .foregroundStyle(MajorTomTheme.Colors.textSecondary)
+                .padding(MajorTomTheme.Spacing.sm)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .background(MajorTomTheme.Colors.background)
+                .clipShape(RoundedRectangle(cornerRadius: MajorTomTheme.Radius.small))
         }
     }
 
@@ -502,11 +588,21 @@ struct SpriteInspectorView: View {
     // MARK: - Send actions
 
     private func sendLinkedDraft() {
-        guard let handle = agent.spriteHandle,
-              let subagentId = agent.linkedSubagentId,
+        // Scenario 9 — re-check linkage at send time using the live agent.
+        // If the sprite is STILL linked, proceed with the /btw send. If it
+        // flipped to idle mid-type (subagent finished), surface a brief toast
+        // and clear the draft so the user understands the downgrade.
+        let live = currentAgent
+        guard let handle = live.spriteHandle,
+              let subagentId = live.linkedSubagentId,
               let send = onSendLinkedMessage,
               !draft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-        else { return }
+        else {
+            if live.linkedSubagentId == nil {
+                showAgentCompletedToast()
+            }
+            return
+        }
 
         let text = draft
         draft = ""
@@ -514,7 +610,7 @@ struct SpriteInspectorView: View {
 
         // Always transition to .pending; the caller decides send vs queue.
         guard let queued = viewModel.beginPendingMessage(
-            spriteId: agent.id,
+            spriteId: live.id,
             spriteHandle: handle,
             subagentId: subagentId,
             text: text,
@@ -535,7 +631,20 @@ struct SpriteInspectorView: View {
         let text = draft
         draft = ""
         HapticService.impact(.light)
-        viewModel.sendDogCannedMessage(spriteId: agent.id, text: text, character: agent.characterType)
+        let live = currentAgent
+        viewModel.sendDogCannedMessage(spriteId: live.id, text: text, character: live.characterType)
+    }
+
+    /// Surface a short "agent completed" banner, clear the draft, and auto-hide
+    /// after 2.5s. Triggered when the inspector's linked sprite despawned mid-type.
+    private func showAgentCompletedToast() {
+        draft = ""
+        HapticService.impact(.soft)
+        agentCompletedToast = "Agent completed — /btw isn't available anymore."
+        Task { @MainActor in
+            try? await Task.sleep(for: .seconds(2.5))
+            agentCompletedToast = nil
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

Wave 6 of the sprite-agent wiring phase — edge cases + battle test on iOS. Final wave.

- **S5 Desk overflow** — when all 8 desks are occupied, new agent sprites claim a position from a 21-slot grid on the Command Bridge floor (below the lower desk row). Tappable, `/btw`-able, and properly released on despawn.
- **S4 Disconnect / reconnect** — 1-second debounced gray-out + pulsing "~" indicator on every non-idle sprite when the WebSocket drops or enters `.reconnecting`. On reconnect: clears gray, flushes queued `/btw` messages, and re-fires `sprite.state.request` so the ViewModel reconciles any subagents that spawned/despawned during the drop. The inspector swaps the `/btw` input for a "Disconnected from relay" info panel while offline.
- **S6 Fast-complete animation** — `spawnTimestamps` + `minDisplayDurationSeconds` (1.5s) guarantee spawn + walk-to-desk + work animations run to completion before the celebration/leaving chain starts. Prevents the "flash-appear / flash-gone" UX for sub-second subagents. Reused by `handleAgentComplete`, `handleAgentDismissed`, and `handleSpriteUnlink`.
- **Scenario 9 race** — `SpriteInspectorView` now reads `currentAgent` live from the ViewModel so mode (linked/dog/idle) and send payload always reflect state at send time. Race-win: idle-at-tap, linked-at-send → routed via `sprite.message` path. Race-lose: linked-at-tap, idle-at-send → brief "Agent completed" toast, draft cleared, idle inspector replaces messaging UI.
- **Verification pass** — scenarios #2 (draft discard), #3 (pending blocks), #5 (offline queue), #7 (idle human no input), #8 (empty disabled), #10 (long message expand/collapse), M1 (single-pending gate), M2 (cross-session banner), M3 (bubble priority), S1/S2 (despawn animations) — all confirmed wired.

## Test plan

- [ ] Spawn ≥9 concurrent subagents → 8 sit at desks, rest land in overflow grid without overlap
- [ ] Tap an overflow sprite → inspector opens, /btw works as expected
- [ ] Kill the relay mid-session → sprites gray out after ~1s, "~" indicator pulses
- [ ] Quickly stop/start the relay (<1s outage) → no gray flash
- [ ] Relay reconnects with new state → gray clears, completed subagents despawn, new ones show up
- [ ] Spawn a subagent that completes in <1s → sprite shows spawn + work + celebration + poof for at least 1.5s
- [ ] Tap an idle human → no input (info panel), tap a dog → canned response, tap a linked agent → /btw
- [ ] Send /btw while offline → queued, flushes on reconnect
- [ ] Open inspector on a linked agent, wait for it to complete → "Agent completed" toast, draft cleared
- [ ] With /btw modal pending, tap same sprite again → input read-only until Cool Beans

## Notes / deviations

- S3 dismiss-from-inspector (kill subagent from relay) was not wired — would require a new relay wire type and the task explicitly forbids touching `relay/` or introducing new wire types. Skipped by design.
- Relay-side Wave 6 work (reconnect fan-out, S4 disconnected-client queue behavior) is covered by the parallel `sprite-wiring/wave6-relay` PR — no cross-cutting coordination needed from this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)