### PR TITLE
feat(relay): Wave 3 — Tab-Keyed Offices protocol extension

### DIFF
--- a/relay/src/protocol/messages.ts
+++ b/relay/src/protocol/messages.ts
@@ -610,6 +610,12 @@ export interface AgentSpawnMessage {
   parentId?: string;
   task: string;
   role: string;
+  /**
+   * Tab-Keyed Offices (phase §5.2) — tab that owns this session, if bound.
+   * Populated by the relay at emit time via `tabRegistry.getTabForSession`.
+   * Omitted for legacy cli/vscode sessions with no tab binding.
+   */
+  tabId?: string;
 }
 
 export interface AgentWorkingMessage {
@@ -633,6 +639,11 @@ export interface AgentWorkingMessage {
    * here).
    */
   tokenCount?: number;
+  /**
+   * Tab-Keyed Offices (phase §5.2) — tab that owns this session, if bound.
+   * See `AgentSpawnMessage.tabId`.
+   */
+  tabId?: string;
 }
 
 export interface AgentIdleMessage {
@@ -643,6 +654,11 @@ export interface AgentIdleMessage {
   toolCount?: number;
   /** Wave 5 — cumulative tokens. See `AgentWorkingMessage.tokenCount`. */
   tokenCount?: number;
+  /**
+   * Tab-Keyed Offices (phase §5.2) — tab that owns this session, if bound.
+   * See `AgentSpawnMessage.tabId`.
+   */
+  tabId?: string;
 }
 
 export interface AgentCompleteMessage {
@@ -650,6 +666,11 @@ export interface AgentCompleteMessage {
   sessionId: string;
   agentId: string;
   result: string;
+  /**
+   * Tab-Keyed Offices (phase §5.2) — tab that owns this session, if bound.
+   * See `AgentSpawnMessage.tabId`.
+   */
+  tabId?: string;
 }
 
 export interface AgentDismissedMessage {
@@ -667,6 +688,11 @@ export interface AgentDismissedMessage {
    * `AgentWorkingMessage.tokenCount`.
    */
   tokenCount?: number;
+  /**
+   * Tab-Keyed Offices (phase §5.2) — tab that owns this session, if bound.
+   * See `AgentSpawnMessage.tabId`.
+   */
+  tabId?: string;
 }
 
 export interface ConnectionStatusMessage {
@@ -784,6 +810,12 @@ export interface SessionMetaMessage {
   outputTokens: number;
   turnCount: number;
   totalDuration: number;
+  /**
+   * Tab-Keyed Offices (phase §5.2) — tab that owns this session, if bound.
+   * Populated by the relay at emit time via `tabRegistry.getTabForSession`.
+   * Omitted for legacy cli/vscode sessions with no tab binding.
+   */
+  tabId?: string;
 }
 
 export interface SessionListResponseMessage {
@@ -1216,6 +1248,12 @@ export interface SpriteLinkMessage {
   task: string;
   parentId?: string;
   deskIndex?: number;
+  /**
+   * Tab-Keyed Offices (phase §5.2) — tab that owns this session, if bound.
+   * Populated by the relay at emit time via `tabRegistry.getTabForSession`.
+   * Omitted for legacy cli/vscode sessions with no tab binding.
+   */
+  tabId?: string;
 }
 
 export interface SpriteUnlinkMessage {
@@ -1224,6 +1262,11 @@ export interface SpriteUnlinkMessage {
   spriteHandle: string;
   subagentId: string;
   reason: 'completed' | 'dismissed' | 'failed' | 'session_ended';
+  /**
+   * Tab-Keyed Offices (phase §5.2) — tab that owns this session, if bound.
+   * See `SpriteLinkMessage.tabId`.
+   */
+  tabId?: string;
 }
 
 export interface SpriteResponseMessage {
@@ -1235,6 +1278,11 @@ export interface SpriteResponseMessage {
   text: string;
   status: 'delivered' | 'queued' | 'dropped';
   dropReason?: string;
+  /**
+   * Tab-Keyed Offices (phase §5.2) — tab that owns this session, if bound.
+   * See `SpriteLinkMessage.tabId`.
+   */
+  tabId?: string;
 }
 
 export interface SpriteStateMessage {
@@ -1242,6 +1290,11 @@ export interface SpriteStateMessage {
   sessionId: string;
   mappings: SpriteMappingEntry[];
   roleBindings: Record<string, string>;
+  /**
+   * Tab-Keyed Offices (phase §5.2) — tab that owns this session, if bound.
+   * See `SpriteLinkMessage.tabId`.
+   */
+  tabId?: string;
 }
 
 // ── Tab-Keyed Offices (phase §5.3) ───────────────────────────

--- a/relay/src/routes/__tests__/ws-tabid-annotation.test.ts
+++ b/relay/src/routes/__tests__/ws-tabid-annotation.test.ts
@@ -1,0 +1,343 @@
+/**
+ * Wave 3 — Tab-Keyed Offices protocol extension.
+ *
+ * Verifies two things:
+ *   1. Compile-time: sprite.* and agent.* message types + SessionMetaMessage
+ *      all accept an optional `tabId?: string` field (the extensions made
+ *      in this wave). The static typing is the primary gate — if the
+ *      interface drops the field, these tests stop compiling.
+ *   2. Runtime: the `tabIdFor` helper pattern used inside ws.ts returns
+ *      the correct tabId for sessions bound in TabRegistry, and undefined
+ *      for legacy sessions with no binding. `undefined` on an optional
+ *      field is dropped by JSON.stringify, so the wire payload matches
+ *      the "omit when absent" back-compat contract.
+ *
+ * We don't stand up the full WS route here — the annotation logic is a
+ * one-liner lookup that ws.ts threads through every emit call. Verifying
+ * the pattern against the real TabRegistry gives high confidence without
+ * the cost of a WS integration harness.
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import { TabRegistry } from '../../tabs/tab-registry.js';
+import type {
+  SpriteLinkMessage,
+  SpriteUnlinkMessage,
+  SpriteResponseMessage,
+  SpriteStateMessage,
+  AgentSpawnMessage,
+  AgentWorkingMessage,
+  AgentIdleMessage,
+  AgentCompleteMessage,
+  AgentDismissedMessage,
+  SessionMetaMessage,
+} from '../../protocol/messages.js';
+
+/** Mirrors the helper inside createWsRoute — guards for undefined registry
+ * and returns undefined for unbound sessions so the field is dropped on
+ * the wire. */
+function tabIdFor(registry: TabRegistry | undefined, sessionId: string): string | undefined {
+  return registry?.getTabForSession(sessionId)?.tabId;
+}
+
+describe('tabIdFor helper (ws.ts annotation pattern)', () => {
+  let registry: TabRegistry;
+
+  beforeEach(() => {
+    registry = new TabRegistry();
+  });
+
+  it('returns the bound tabId for a session registered via SessionStart', () => {
+    registry.registerSessionStart('sess-1', 'tab-A', '/proj', 'user-1');
+    expect(tabIdFor(registry, 'sess-1')).toBe('tab-A');
+  });
+
+  it('returns undefined for a session that has no TabRegistry binding (legacy cli/vscode)', () => {
+    expect(tabIdFor(registry, 'sess-unknown')).toBeUndefined();
+  });
+
+  it('returns undefined when the registry itself is undefined (WsDeps omits tabRegistry)', () => {
+    expect(tabIdFor(undefined, 'sess-1')).toBeUndefined();
+  });
+
+  it('stops resolving once the session ends even if the tab remains alive', () => {
+    registry.registerSessionStart('sess-1', 'tab-A', '/proj', 'user-1');
+    expect(tabIdFor(registry, 'sess-1')).toBe('tab-A');
+    registry.registerSessionEnd('sess-1');
+    // sessionToTab reverse-index is cleared on SessionEnd — tab persists
+    // (idle) but the session no longer maps to it.
+    expect(tabIdFor(registry, 'sess-1')).toBeUndefined();
+    expect(registry.getTab('tab-A')).toBeDefined();
+  });
+
+  it('resolves multiple sessions sharing a tab (Gate A — multi-claude in one tab)', () => {
+    registry.registerSessionStart('sess-1', 'tab-A', '/proj', 'user-1');
+    registry.registerSessionStart('sess-2', 'tab-A', '/proj', 'user-1');
+    expect(tabIdFor(registry, 'sess-1')).toBe('tab-A');
+    expect(tabIdFor(registry, 'sess-2')).toBe('tab-A');
+  });
+
+  it('clears all sessions when tabClosed runs (PTY grace expired)', () => {
+    registry.registerSessionStart('sess-1', 'tab-A', '/proj', 'user-1');
+    registry.registerSessionStart('sess-2', 'tab-A', '/proj', 'user-1');
+    registry.tabClosed('tab-A');
+    expect(tabIdFor(registry, 'sess-1')).toBeUndefined();
+    expect(tabIdFor(registry, 'sess-2')).toBeUndefined();
+  });
+});
+
+describe('sprite.* protocol messages — tabId annotation', () => {
+  let registry: TabRegistry;
+
+  beforeEach(() => {
+    registry = new TabRegistry();
+    registry.registerSessionStart('sess-bound', 'tab-A', '/proj', 'user-1');
+  });
+
+  it('sprite.link emits tabId when the session is bound', () => {
+    const msg: SpriteLinkMessage = {
+      type: 'sprite.link',
+      sessionId: 'sess-bound',
+      spriteHandle: 'sprite-1',
+      subagentId: 'agent-1',
+      canonicalRole: 'coder',
+      characterType: 'astronaut',
+      task: 'explore',
+      tabId: tabIdFor(registry, 'sess-bound'),
+    };
+    expect(msg.tabId).toBe('tab-A');
+  });
+
+  it('sprite.link omits tabId (undefined) for legacy unbound sessions', () => {
+    const msg: SpriteLinkMessage = {
+      type: 'sprite.link',
+      sessionId: 'sess-legacy',
+      spriteHandle: 'sprite-1',
+      subagentId: 'agent-1',
+      canonicalRole: 'coder',
+      characterType: 'astronaut',
+      task: 'explore',
+      tabId: tabIdFor(registry, 'sess-legacy'),
+    };
+    expect(msg.tabId).toBeUndefined();
+    // JSON serialization drops undefined, preserving back-compat with
+    // clients that don't know about tabId.
+    const serialized = JSON.parse(JSON.stringify(msg));
+    expect('tabId' in serialized).toBe(false);
+  });
+
+  it('sprite.unlink emits tabId when bound', () => {
+    const msg: SpriteUnlinkMessage = {
+      type: 'sprite.unlink',
+      sessionId: 'sess-bound',
+      spriteHandle: 'sprite-1',
+      subagentId: 'agent-1',
+      reason: 'completed',
+      tabId: tabIdFor(registry, 'sess-bound'),
+    };
+    expect(msg.tabId).toBe('tab-A');
+  });
+
+  it('sprite.response emits tabId when bound', () => {
+    const msg: SpriteResponseMessage = {
+      type: 'sprite.response',
+      sessionId: 'sess-bound',
+      spriteHandle: 'sprite-1',
+      subagentId: 'agent-1',
+      messageId: 'msg-1',
+      text: 'hi',
+      status: 'delivered',
+      tabId: tabIdFor(registry, 'sess-bound'),
+    };
+    expect(msg.tabId).toBe('tab-A');
+  });
+
+  it('sprite.state emits tabId when bound', () => {
+    const msg: SpriteStateMessage = {
+      type: 'sprite.state',
+      sessionId: 'sess-bound',
+      mappings: [],
+      roleBindings: {},
+      tabId: tabIdFor(registry, 'sess-bound'),
+    };
+    expect(msg.tabId).toBe('tab-A');
+  });
+});
+
+describe('agent.* protocol messages — tabId annotation', () => {
+  let registry: TabRegistry;
+
+  beforeEach(() => {
+    registry = new TabRegistry();
+    registry.registerSessionStart('sess-bound', 'tab-B', '/proj', 'user-1');
+  });
+
+  it('agent.spawn emits tabId when bound', () => {
+    const msg: AgentSpawnMessage = {
+      type: 'agent.spawn',
+      sessionId: 'sess-bound',
+      agentId: 'agent-1',
+      task: 'research',
+      role: 'subagent',
+      tabId: tabIdFor(registry, 'sess-bound'),
+    };
+    expect(msg.tabId).toBe('tab-B');
+  });
+
+  it('agent.working emits tabId when bound', () => {
+    const msg: AgentWorkingMessage = {
+      type: 'agent.working',
+      sessionId: 'sess-bound',
+      agentId: 'agent-1',
+      task: 'research',
+      tabId: tabIdFor(registry, 'sess-bound'),
+    };
+    expect(msg.tabId).toBe('tab-B');
+  });
+
+  it('agent.idle emits tabId when bound', () => {
+    const msg: AgentIdleMessage = {
+      type: 'agent.idle',
+      sessionId: 'sess-bound',
+      agentId: 'agent-1',
+      tabId: tabIdFor(registry, 'sess-bound'),
+    };
+    expect(msg.tabId).toBe('tab-B');
+  });
+
+  it('agent.complete emits tabId when bound', () => {
+    const msg: AgentCompleteMessage = {
+      type: 'agent.complete',
+      sessionId: 'sess-bound',
+      agentId: 'agent-1',
+      result: 'done',
+      tabId: tabIdFor(registry, 'sess-bound'),
+    };
+    expect(msg.tabId).toBe('tab-B');
+  });
+
+  it('agent.dismissed emits tabId when bound', () => {
+    const msg: AgentDismissedMessage = {
+      type: 'agent.dismissed',
+      sessionId: 'sess-bound',
+      agentId: 'agent-1',
+      tabId: tabIdFor(registry, 'sess-bound'),
+    };
+    expect(msg.tabId).toBe('tab-B');
+  });
+
+  it('agent.spawn omits tabId for legacy unbound sessions', () => {
+    const msg: AgentSpawnMessage = {
+      type: 'agent.spawn',
+      sessionId: 'sess-legacy',
+      agentId: 'agent-1',
+      task: 'research',
+      role: 'subagent',
+      tabId: tabIdFor(registry, 'sess-legacy'),
+    };
+    expect(msg.tabId).toBeUndefined();
+    const serialized = JSON.parse(JSON.stringify(msg));
+    expect('tabId' in serialized).toBe(false);
+  });
+});
+
+describe('session.list.response — SessionMetaMessage tabId annotation', () => {
+  let registry: TabRegistry;
+
+  beforeEach(() => {
+    registry = new TabRegistry();
+    registry.registerSessionStart('sess-bound', 'tab-C', '/proj', 'user-1');
+  });
+
+  it('annotates bound session entries with tabId', () => {
+    const baseMeta: Omit<SessionMetaMessage, 'tabId'> = {
+      id: 'sess-bound',
+      adapter: 'cli-external',
+      workingDirName: 'proj',
+      status: 'active',
+      startedAt: new Date().toISOString(),
+      totalCost: 0,
+      inputTokens: 0,
+      outputTokens: 0,
+      turnCount: 0,
+      totalDuration: 0,
+    };
+    const entry: SessionMetaMessage = {
+      ...baseMeta,
+      tabId: tabIdFor(registry, baseMeta.id),
+    };
+    expect(entry.tabId).toBe('tab-C');
+  });
+
+  it('leaves tabId undefined for legacy sessions with no binding', () => {
+    const baseMeta: Omit<SessionMetaMessage, 'tabId'> = {
+      id: 'sess-legacy',
+      adapter: 'cli',
+      workingDirName: 'proj',
+      status: 'active',
+      startedAt: new Date().toISOString(),
+      totalCost: 0,
+      inputTokens: 0,
+      outputTokens: 0,
+      turnCount: 0,
+      totalDuration: 0,
+    };
+    const entry: SessionMetaMessage = {
+      ...baseMeta,
+      tabId: tabIdFor(registry, baseMeta.id),
+    };
+    expect(entry.tabId).toBeUndefined();
+    // Wire-level back-compat: undefined disappears on JSON.stringify.
+    const serialized = JSON.parse(JSON.stringify(entry));
+    expect('tabId' in serialized).toBe(false);
+  });
+
+  it('mapping a sessions[] list annotates each entry by id', () => {
+    registry.registerSessionStart('sess-1', 'tab-X', '/proj', 'user-1');
+    registry.registerSessionStart('sess-2', 'tab-Y', '/proj', 'user-1');
+    const rawSessions: Omit<SessionMetaMessage, 'tabId'>[] = [
+      {
+        id: 'sess-1',
+        adapter: 'cli-external',
+        workingDirName: 'a',
+        status: 'active',
+        startedAt: 't1',
+        totalCost: 0,
+        inputTokens: 0,
+        outputTokens: 0,
+        turnCount: 0,
+        totalDuration: 0,
+      },
+      {
+        id: 'sess-2',
+        adapter: 'cli-external',
+        workingDirName: 'b',
+        status: 'active',
+        startedAt: 't2',
+        totalCost: 0,
+        inputTokens: 0,
+        outputTokens: 0,
+        turnCount: 0,
+        totalDuration: 0,
+      },
+      {
+        id: 'sess-legacy',
+        adapter: 'cli',
+        workingDirName: 'c',
+        status: 'active',
+        startedAt: 't3',
+        totalCost: 0,
+        inputTokens: 0,
+        outputTokens: 0,
+        turnCount: 0,
+        totalDuration: 0,
+      },
+    ];
+    const annotated: SessionMetaMessage[] = rawSessions.map((meta) => ({
+      ...meta,
+      tabId: tabIdFor(registry, meta.id),
+    }));
+    expect(annotated[0].tabId).toBe('tab-X');
+    expect(annotated[1].tabId).toBe('tab-Y');
+    expect(annotated[2].tabId).toBeUndefined();
+  });
+});

--- a/relay/src/routes/ws.ts
+++ b/relay/src/routes/ws.ts
@@ -1265,7 +1265,15 @@ export function createWsRoute(deps: WsDeps): FastifyPluginAsync {
           }
         }
 
-        sendToClient(ws, { type: 'session.list.response', sessions });
+        // Tab-Keyed Offices (phase §5.2) — annotate each meta with its
+        // bound tabId so iOS can group session-list entries by tab.
+        // Legacy cli/vscode sessions yield undefined and the field is
+        // omitted on the wire (back-compat preserved).
+        const sessionsWithTabId = sessions.map((meta) => ({
+          ...meta,
+          tabId: tabIdFor(meta.id),
+        }));
+        sendToClient(ws, { type: 'session.list.response', sessions: sessionsWithTabId });
         break;
       }
 

--- a/relay/src/routes/ws.ts
+++ b/relay/src/routes/ws.ts
@@ -142,6 +142,13 @@ export function createWsRoute(deps: WsDeps): FastifyPluginAsync {
       ?.mappings.find((m) => m.subagentId === subagentId)?.spriteHandle;
   }
 
+  /** Look up the tabId bound to a session, if any. Returns undefined for
+   * legacy cli/vscode sessions (no TabRegistry binding) so the optional
+   * protocol field is simply omitted on the wire. */
+  function tabIdFor(sessionId: string): string | undefined {
+    return tabRegistry?.getTabForSession(sessionId)?.tabId;
+  }
+
   // ── Per-client metadata for admin status endpoint ──────────
   interface ClientMeta { ip: string; userAgent: string; connectedAt: string }
   const clientMetas = new Map<WebSocket, ClientMeta>();
@@ -678,6 +685,7 @@ export function createWsRoute(deps: WsDeps): FastifyPluginAsync {
               spriteHandle: mapping.spriteHandle,
               subagentId: mapping.subagentId,
               reason: 'session_ended',
+              tabId: tabIdFor(message.sessionId),
             });
           }
         }
@@ -819,6 +827,7 @@ export function createWsRoute(deps: WsDeps): FastifyPluginAsync {
             sessionId: resumeSessionId,
             mappings: resumeSpriteState.mappings.map(toWireMapping),
             roleBindings: resumeSpriteState.roleBindings,
+            tabId: tabIdFor(resumeSessionId),
           });
         }
 
@@ -981,6 +990,7 @@ export function createWsRoute(deps: WsDeps): FastifyPluginAsync {
             text: '',
             status: 'dropped',
             dropReason: 'Agent not found or already completed',
+            tabId: tabIdFor(message.sessionId),
           });
           break;
         }
@@ -1011,6 +1021,7 @@ export function createWsRoute(deps: WsDeps): FastifyPluginAsync {
             text: '',
             status: 'dropped',
             dropReason: 'No active session — /btw cannot be delivered',
+            tabId: tabIdFor(message.sessionId),
           });
           break;
         }
@@ -1025,6 +1036,7 @@ export function createWsRoute(deps: WsDeps): FastifyPluginAsync {
           messageId: message.messageId,
           text: '',
           status: 'queued',
+          tabId: tabIdFor(message.sessionId),
         });
         logger.info(
           {
@@ -1070,6 +1082,7 @@ export function createWsRoute(deps: WsDeps): FastifyPluginAsync {
             ? state.mappings.map(toWireMapping)
             : [],
           roleBindings: state?.roleBindings ?? {},
+          tabId: tabIdFor(reqSessionId),
         });
         logger.debug(
           { sessionId: reqSessionId, mappingCount: state?.mappings.length ?? 0 },
@@ -2040,6 +2053,7 @@ export function createWsRoute(deps: WsDeps): FastifyPluginAsync {
         text: ev.text,
         status: ev.status,
         dropReason: ev.dropReason,
+        tabId: tabIdFor(ev.sessionId),
       });
       logger.info(
         {
@@ -2068,6 +2082,7 @@ export function createWsRoute(deps: WsDeps): FastifyPluginAsync {
             parentId: event.parentId,
             task: event.task ?? '',
             role: event.role ?? 'subagent',
+            tabId: tabIdFor(sid),
           });
 
           // ── Sprite wiring: create mapping + emit sprite.link ──
@@ -2097,6 +2112,7 @@ export function createWsRoute(deps: WsDeps): FastifyPluginAsync {
             task: event.task ?? '',
             parentId: event.parentId,
             deskIndex: mapping.deskIndex >= 0 ? mapping.deskIndex : undefined,
+            tabId: tabIdFor(sid),
           });
           break;
         }
@@ -2110,6 +2126,7 @@ export function createWsRoute(deps: WsDeps): FastifyPluginAsync {
             // Wave 5 — live per-subagent metrics piggyback on this event.
             toolCount: event.toolCount,
             tokenCount: event.tokenCount,
+            tabId: tabIdFor(sid),
           });
           break;
         case 'idle':
@@ -2120,11 +2137,18 @@ export function createWsRoute(deps: WsDeps): FastifyPluginAsync {
             agentId: event.agentId,
             toolCount: event.toolCount,
             tokenCount: event.tokenCount,
+            tabId: tabIdFor(sid),
           });
           break;
         case 'complete': {
           agentTracker.complete(event.agentId, event.result ?? '');
-          broadcastToAll({ type: 'agent.complete', sessionId: sid, agentId: event.agentId, result: event.result ?? '' });
+          broadcastToAll({
+            type: 'agent.complete',
+            sessionId: sid,
+            agentId: event.agentId,
+            result: event.result ?? '',
+            tabId: tabIdFor(sid),
+          });
 
           // ── Sprite wiring: remove mapping + emit sprite.unlink ──
           const completeState = spriteMappings.get(sid);
@@ -2141,6 +2165,7 @@ export function createWsRoute(deps: WsDeps): FastifyPluginAsync {
                 spriteHandle: removed.spriteHandle,
                 subagentId: event.agentId,
                 reason: 'completed',
+                tabId: tabIdFor(sid),
               });
               // Wave 4 — tell worker to drop any queued /btw for this
               // subagent. Scenario #4. The SubagentStop hook inside the
@@ -2162,6 +2187,7 @@ export function createWsRoute(deps: WsDeps): FastifyPluginAsync {
             // that didn't wire metrics, or attribution failure).
             toolCount: event.toolCount,
             tokenCount: event.tokenCount,
+            tabId: tabIdFor(sid),
           });
 
           // ── Sprite wiring: remove mapping + emit sprite.unlink ──
@@ -2179,6 +2205,7 @@ export function createWsRoute(deps: WsDeps): FastifyPluginAsync {
                 spriteHandle: removed.spriteHandle,
                 subagentId: event.agentId,
                 reason: 'dismissed',
+                tabId: tabIdFor(sid),
               });
               // Wave 4 — same as 'complete' above, drop any queued /btw.
               fleetManager.dropSpriteForSubagent(sid, event.agentId, 'Subagent dismissed');


### PR DESCRIPTION
## Summary

Extend the sprite + agent protocol messages with optional `tabId`, populated at emit time from `TabRegistry.getTabForSession(sessionId)`. Lays the wire-level foundation iOS will consume in the sibling Wave 3 PR. Back-compat for legacy cli/vscode sessions — `tabId` is omitted when there is no tab binding.

See `docs/PHASE-TAB-KEYED-OFFICES.md` §5.2 (protocol extension) and §10 (Wave 3 row).

## Changes

- `SessionMetaMessage` + sprite/agent server messages carry optional `tabId`.
- `relay/src/routes/ws.ts` has a `tabIdFor(sessionId)` helper; every sprite/agent + session.list.response emit site calls it.
- Unit tests cover annotation for bound sessions and omission for legacy sessions.

## Wave 3 scope

- Relay — this PR.
- iOS — sibling PR on `tab-keyed-offices/wave3-ios`.
- No UI rewire (Wave 4).
- Sprite mapping still session-keyed (Wave 5).

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm test` — 220/220 green (baseline 200, 20 new tests)
- [ ] Copilot review (auto)

🤖 Generated with [Claude Code](https://claude.com/claude-code)