### PR TITLE
feat(ios): Wave 3 — Tab-Keyed Offices protocol + feature flag

### DIFF
--- a/ios/MajorTom.xcodeproj/project.pbxproj
+++ b/ios/MajorTom.xcodeproj/project.pbxproj
@@ -28,6 +28,7 @@
 		1FB9124E49F11A762382E6A9 /* SpecialtyKeyGrid.swift in Sources */ = {isa = PBXBuildFile; fileRef = 908E6CFCF4E1F5F05D0AE4C3 /* SpecialtyKeyGrid.swift */; };
 		2211645B8B3E1BF5093FE2CD /* MoodEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 579C4AF5EF7599467490F248 /* MoodEngine.swift */; };
 		3A1B2C4D5E6F78901234ABCD /* CrewRoster.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B7C8D9E0F1A23456789BCDE /* CrewRoster.swift */; };
+		890C7E4C9845454480C8F9DB /* TabRegistryStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2698B28DF9074DC5917B6F3D /* TabRegistryStore.swift */; };
 		87DD0EFFCB5F38F604D8E89D /* RoleMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35CE152195BD660297FCDF44 /* RoleMapper.swift */; };
 		F5A7B9C1D3E526A728193B5D /* SpriteAura.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5A7B9C1D3E526A728193B4C /* SpriteAura.swift */; };
 		A2B3C4D5E6F70819304A5B6D /* ToolHumanizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2B3C4D5E6F70819304A5B6C /* ToolHumanizer.swift */; };
@@ -284,6 +285,7 @@
 		5795954485F00C86256F6533 /* LiveActivityManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveActivityManager.swift; sourceTree = "<group>"; };
 		579C4AF5EF7599467490F248 /* MoodEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MoodEngine.swift; sourceTree = "<group>"; };
 		6B7C8D9E0F1A23456789BCDE /* CrewRoster.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CrewRoster.swift; sourceTree = "<group>"; };
+		2698B28DF9074DC5917B6F3D /* TabRegistryStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabRegistryStore.swift; sourceTree = "<group>"; };
 		35CE152195BD660297FCDF44 /* RoleMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoleMapper.swift; sourceTree = "<group>"; };
 		F5A7B9C1D3E526A728193B4C /* SpriteAura.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpriteAura.swift; sourceTree = "<group>"; };
 		A2B3C4D5E6F70819304A5B6C /* ToolHumanizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolHumanizer.swift; sourceTree = "<group>"; };
@@ -838,6 +840,7 @@
 				B2A5F6ECD6AEA9681C140DA3 /* OfficeLayout.swift */,
 				BB2C3D4E5F6A7B8C9D0E1F2A /* StationLayout.swift */,
 				433F8F4160504FECAA91BBC2 /* SpriteMessagingState.swift */,
+				2698B28DF9074DC5917B6F3D /* TabRegistryStore.swift */,
 				765796A3C1DAD173DB56A1CC /* ThemeEngine.swift */,
 				BB1C2D3E4F607182939D0E1A /* WaypointPathfinder.swift */,
 			);
@@ -1732,6 +1735,7 @@
 				1ECF57AD1993033DCCF73DB5 /* OfficeViewModel.swift in Sources */,
 				6FAAD79E27E62840B5B1C665 /* DogCannedResponses.swift in Sources */,
 				E2515F6B841E4F68C14D0419 /* SpriteMessagingState.swift in Sources */,
+				890C7E4C9845454480C8F9DB /* TabRegistryStore.swift in Sources */,
 				C113A701F7910BAD57011D40 /* SpriteInspectorView.swift in Sources */,
 				78DC1DD071D269A3B9774687 /* SpriteResponseBanner.swift in Sources */,
 				3320719E65C7D12EC787C929 /* PairingView.swift in Sources */,

--- a/ios/MajorTom.xcodeproj/project.pbxproj
+++ b/ios/MajorTom.xcodeproj/project.pbxproj
@@ -97,6 +97,7 @@
 		818FA51F81C18CFE08B3C097 /* PairingViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 526DF9EAD13F47F747C7ACC3 /* PairingViewModel.swift */; };
 		8294293F9EF30CBEED38BFC6 /* HapticService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7794C5813F5964F288D432AD /* HapticService.swift */; };
 		39E76A83321DEBACFD4BB7DE /* PerfHUDPreferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1972DF8FED85D9290EA3F331 /* PerfHUDPreferences.swift */; };
+		59066C471C6849C68A1466DA /* FeatureFlags.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72E9104D85D94935AD94E196 /* FeatureFlags.swift */; };
 		83C02DEBD2B6488A47A08A65 /* ModePickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66594811ED284A67510E10AE /* ModePickerView.swift */; };
 		85574E49192424FB81A91CA9 /* MarkdownText.swift in Sources */ = {isa = PBXBuildFile; fileRef = D91A9F673395FFFDE1E3A220 /* MarkdownText.swift */; };
 		855E5820EB1F99D820AFF91A /* SessionListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EE6178C1ADCC581A8CEDD6E /* SessionListView.swift */; };
@@ -327,6 +328,7 @@
 		765796A3C1DAD173DB56A1CC /* ThemeEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeEngine.swift; sourceTree = "<group>"; };
 		7794C5813F5964F288D432AD /* HapticService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HapticService.swift; sourceTree = "<group>"; };
 		1972DF8FED85D9290EA3F331 /* PerfHUDPreferences.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PerfHUDPreferences.swift; sourceTree = "<group>"; };
+		72E9104D85D94935AD94E196 /* FeatureFlags.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureFlags.swift; sourceTree = "<group>"; };
 		794D98FF20DC91F49542FE7D /* OfficeViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OfficeViewModel.swift; sourceTree = "<group>"; };
 		794D99002EDC92F59643FF8E /* OfficeSceneManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OfficeSceneManager.swift; sourceTree = "<group>"; };
 		7A8199AB9D26A914D6633EF0 /* PermissionModeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionModeView.swift; sourceTree = "<group>"; };
@@ -852,6 +854,7 @@
 			children = (
 				A2873A7A68C25BFA4E7C9756 /* AuthService.swift */,
 				10F013B10B2AA2CD96B19588 /* DangerScoring.swift */,
+				72E9104D85D94935AD94E196 /* FeatureFlags.swift */,
 				7794C5813F5964F288D432AD /* HapticService.swift */,
 				A9BD8A95DFAD6160FF41E83F /* KeychainService.swift */,
 				1972DF8FED85D9290EA3F331 /* PerfHUDPreferences.swift */,
@@ -1701,6 +1704,7 @@
 				C73A60CB24EFABD14D9C2A2F /* GodModeConfirmation.swift in Sources */,
 				8294293F9EF30CBEED38BFC6 /* HapticService.swift in Sources */,
 				39E76A83321DEBACFD4BB7DE /* PerfHUDPreferences.swift in Sources */,
+				59066C471C6849C68A1466DA /* FeatureFlags.swift in Sources */,
 				8A47BE851B898A4D0899F183 /* KeySpec.swift in Sources */,
 				22A50E5C5D84EFE896C415FF /* KeybarCustomizer.swift in Sources */,
 				6894059C83BB1BFF450749C2 /* KeybarViewModel.swift in Sources */,

--- a/ios/MajorTom/Core/Models/Message.swift
+++ b/ios/MajorTom/Core/Models/Message.swift
@@ -848,6 +848,8 @@ struct AgentDismissedEvent: Codable {
     let type: String
     let sessionId: String
     let agentId: String
+    /// Tab-Keyed Offices (Wave 3) — tab this session lives in, if any.
+    var tabId: String?
 }
 
 // MARK: - Sprite-Agent Wiring Events (Wave 2)

--- a/ios/MajorTom/Core/Models/Message.swift
+++ b/ios/MajorTom/Core/Models/Message.swift
@@ -802,6 +802,10 @@ struct AgentSpawnEvent: Codable, Identifiable {
     var parentId: String?
     let task: String
     let role: String
+    /// Tab-Keyed Offices (Wave 3) — tab this session lives in, if any.
+    /// Populated by the relay for `cli-external` sessions; omitted for
+    /// legacy `cli`/`vscode` sessions.
+    var tabId: String?
 
     var id: String { agentId }
 }
@@ -815,6 +819,8 @@ struct AgentWorkingEvent: Codable {
     var toolCount: Int?
     /// Token count consumed by the subagent so far (relay Wave 5 field).
     var tokenCount: Int?
+    /// Tab-Keyed Offices (Wave 3) — tab this session lives in, if any.
+    var tabId: String?
 }
 
 struct AgentIdleEvent: Codable {
@@ -825,6 +831,8 @@ struct AgentIdleEvent: Codable {
     var toolCount: Int?
     /// Final token count at this idle checkpoint (relay Wave 5 field).
     var tokenCount: Int?
+    /// Tab-Keyed Offices (Wave 3) — tab this session lives in, if any.
+    var tabId: String?
 }
 
 struct AgentCompleteEvent: Codable {
@@ -832,6 +840,8 @@ struct AgentCompleteEvent: Codable {
     let sessionId: String
     let agentId: String
     let result: String
+    /// Tab-Keyed Offices (Wave 3) — tab this session lives in, if any.
+    var tabId: String?
 }
 
 struct AgentDismissedEvent: Codable {
@@ -852,6 +862,10 @@ struct SpriteLinkEvent: Codable {
     let canonicalRole: String
     let task: String
     var parentId: String?
+    /// Tab-Keyed Offices (Wave 3) — tab this session lives in, if any.
+    /// Populated by the relay for `cli-external` sessions; omitted for
+    /// legacy `cli`/`vscode` sessions.
+    var tabId: String?
 }
 
 /// Relay → iOS: unlink a sprite from a subagent (agent completed/dismissed).
@@ -863,6 +877,8 @@ struct SpriteUnlinkEvent: Codable {
     let subagentId: String
     let reason: String  // "completed", "dismissed", "failed", "session_ended"
     var result: String?
+    /// Tab-Keyed Offices (Wave 3) — tab this session lives in, if any.
+    var tabId: String?
 }
 
 /// Relay → iOS: bulk restore all sprite mappings (reconnect / session attach).
@@ -871,6 +887,8 @@ struct SpriteStateEvent: Codable {
     let type: String
     let sessionId: String
     let mappings: [SpriteMapping]
+    /// Tab-Keyed Offices (Wave 3) — tab this session lives in, if any.
+    var tabId: String?
 
     struct SpriteMapping: Codable {
         let spriteHandle: String
@@ -914,6 +932,8 @@ struct SpriteResponseEvent: Codable {
     let text: String
     let status: String  // "delivered" | "queued" | "dropped"
     var dropReason: String?
+    /// Tab-Keyed Offices (Wave 3) — tab this session lives in, if any.
+    var tabId: String?
 }
 
 // MARK: - Tab-Keyed Offices Events (Wave 3)
@@ -1020,6 +1040,10 @@ struct SessionMetaInfo: Codable, Identifiable {
     let outputTokens: Int
     let turnCount: Int
     let totalDuration: Int
+    /// Tab-Keyed Offices (Wave 3) — tab this session lives in, if any.
+    /// Populated by the relay for `cli-external` sessions that bind a
+    /// terminal tab; omitted for legacy `cli`/`vscode` sessions.
+    var tabId: String?
 }
 
 struct SessionListResponseEvent: Codable {

--- a/ios/MajorTom/Core/Models/Message.swift
+++ b/ios/MajorTom/Core/Models/Message.swift
@@ -53,6 +53,7 @@ enum MessageType: String, Codable {
     case ciRunDetail = "ci.run.detail"
     case spriteStateRequest = "sprite.state.request"
     case spriteMessage = "sprite.message"
+    case tabList = "tab.list"
 
     // Server → Client
     case output
@@ -123,6 +124,12 @@ enum MessageType: String, Codable {
     case spriteState = "sprite.state"
     case spriteResponse = "sprite.response"
 
+    // Tab-Keyed Offices (Wave 3)
+    case tabSessionStarted = "tab.session.started"
+    case tabSessionEnded = "tab.session.ended"
+    case tabClosed = "tab.closed"
+    case tabListResponse = "tab.list.response"
+
     case error
 }
 
@@ -177,6 +184,12 @@ struct SessionEndMessage: Codable {
 
 struct SessionListRequestMessage: Codable {
     let type: String = "session.list"
+}
+
+/// Tab-Keyed Offices (Wave 3) — request current list of registered tabs.
+/// Relay responds with a `tab.list.response` event containing all known tabs.
+struct TabListRequestMessage: Codable {
+    let type: String = "tab.list"
 }
 
 struct AgentMessageMessage: Codable {
@@ -901,6 +914,63 @@ struct SpriteResponseEvent: Codable {
     let text: String
     let status: String  // "delivered" | "queued" | "dropped"
     var dropReason: String?
+}
+
+// MARK: - Tab-Keyed Offices Events (Wave 3)
+
+/// Relay → iOS: a claude session inside a terminal tab started.
+/// Matches relay `TabSessionStartedMessage`.
+struct TabSessionStartedEvent: Codable {
+    let type: String
+    let tabId: String
+    let sessionId: String
+    let workingDirName: String
+    let startedAt: String
+}
+
+/// Relay → iOS: a claude session ended via the Stop hook.
+/// The tab itself survives until PTY grace expires.
+/// Matches relay `TabSessionEndedMessage`.
+struct TabSessionEndedEvent: Codable {
+    let type: String
+    let tabId: String
+    let sessionId: String
+    let endedAt: String
+}
+
+/// Relay → iOS: a tab's PTY grace expired (or the tab was killed).
+/// Office Manager removes the tab from the list on receipt.
+/// Matches relay `TabClosedMessage`.
+struct TabClosedEvent: Codable {
+    let type: String
+    let tabId: String
+}
+
+/// Per-session summary inside a `TabMeta`. Matches relay
+/// `TabSessionSummaryMessage`. Intentionally minimal in Wave 3.
+struct TabSessionSummary: Codable {
+    let sessionId: String
+    let startedAt: String
+}
+
+/// A tab known to the relay. Matches relay `TabMetaMessage`.
+struct TabMeta: Codable, Identifiable {
+    let tabId: String
+    /// Basename of the tab's working directory, or empty if not captured yet.
+    let workingDirName: String
+    let status: String  // "active" | "idle" | "closed"
+    let createdAt: String
+    let lastSeenAt: String
+    let sessions: [TabSessionSummary]
+
+    var id: String { tabId }
+}
+
+/// Relay → iOS: full list of known tabs (response to `tab.list` request).
+/// Matches relay `TabListResponseMessage`.
+struct TabListResponseEvent: Codable {
+    let type: String
+    let tabs: [TabMeta]
 }
 
 struct ConnectionStatusEvent: Codable {

--- a/ios/MajorTom/Core/Services/FeatureFlags.swift
+++ b/ios/MajorTom/Core/Services/FeatureFlags.swift
@@ -1,0 +1,37 @@
+import Foundation
+
+/// Feature flags for in-development phases of the app.
+///
+/// Stored in `UserDefaults` so flips survive app restarts without a rebuild.
+/// Flags default to `false` — each keyed-off flag represents an in-flight
+/// phase that is not yet ready to light up for real users. When a phase
+/// ships in full, the flag is removed alongside the old code path.
+enum FeatureFlags {
+
+    // MARK: - Tab-Keyed Offices (Wave 3/4)
+
+    /// Route sprite + agent events by `tabId` (when present on the wire)
+    /// instead of `sessionId`.
+    ///
+    /// **Wave 3 (this phase):** flag is exposed but unused — Offices still
+    /// key by `sessionId`. The flag lets Wave 4 land the routing flip
+    /// behind a toggle that can be dark-launched per device.
+    ///
+    /// **Wave 4:** `OfficeSceneManager` reads this and either routes by
+    /// `event.tabId ?? event.sessionId` (flag on) or stays sessionId-first
+    /// (flag off) for one release of backwards compatibility, after which
+    /// the flag is removed.
+    static var tabKeyedOffices: Bool {
+        get { UserDefaults.standard.bool(forKey: Keys.tabKeyedOffices) }
+        set {
+            guard newValue != UserDefaults.standard.bool(forKey: Keys.tabKeyedOffices) else { return }
+            UserDefaults.standard.set(newValue, forKey: Keys.tabKeyedOffices)
+        }
+    }
+
+    // MARK: - Defaults Keys
+
+    private enum Keys {
+        static let tabKeyedOffices = "featureFlag.tabKeyedOffices"
+    }
+}

--- a/ios/MajorTom/Core/Services/RelayService.swift
+++ b/ios/MajorTom/Core/Services/RelayService.swift
@@ -231,6 +231,14 @@ final class RelayService {
         try await webSocket.send(message)
     }
 
+    /// Tab-Keyed Offices (Wave 3) — ask the relay for the full list of
+    /// registered tabs. Relay broadcasts `tab.list.response`, which is
+    /// decoded into `tabRegistryStore` by the message router.
+    func requestTabList() async throws {
+        let message = TabListRequestMessage()
+        try await webSocket.send(message)
+    }
+
     // MARK: - Chat
 
     func sendPrompt(_ text: String, context: [String]? = nil) async throws {

--- a/ios/MajorTom/Core/Services/RelayService.swift
+++ b/ios/MajorTom/Core/Services/RelayService.swift
@@ -111,6 +111,12 @@ final class RelayService {
     /// Agent.* and sprite.* events are routed to the session-specific OfficeViewModel.
     var officeSceneManager: OfficeSceneManager?
 
+    /// Tab-Keyed Offices (Wave 3) — client-side cache of tabs registered with
+    /// the relay. Populated by `tab.*` events; consumed by the Office Manager
+    /// UI in a later wave. Present as a plain property mirror of the
+    /// `sessionList` pattern (no back-reference / forwarding callbacks yet).
+    let tabRegistryStore = TabRegistryStore()
+
     /// Auth service for token management
     var authService: AuthService?
 
@@ -1261,6 +1267,29 @@ final class RelayService {
                     // window (~10s); relay re-queues beyond that.
                     postBtwResponseNotificationIfBackgrounded(event: event, vm: vm)
                 }
+            }
+
+        // MARK: Tab-Keyed Offices (Wave 3)
+
+        case .tabSessionStarted:
+            if let event = try? MessageCodec.decode(TabSessionStartedEvent.self, from: data) {
+                tabRegistryStore.apply(started: event)
+            }
+
+        case .tabSessionEnded:
+            if let event = try? MessageCodec.decode(TabSessionEndedEvent.self, from: data) {
+                tabRegistryStore.apply(ended: event)
+            }
+
+        case .tabClosed:
+            if let event = try? MessageCodec.decode(TabClosedEvent.self, from: data) {
+                tabRegistryStore.remove(tabId: event.tabId)
+            }
+
+        case .tabListResponse:
+            if let event = try? MessageCodec.decode(TabListResponseEvent.self, from: data) {
+                tabRegistryStore.replaceAll(with: event)
+                responseCounter &+= 1
             }
 
         case .error:

--- a/ios/MajorTom/Features/Office/Models/TabRegistryStore.swift
+++ b/ios/MajorTom/Features/Office/Models/TabRegistryStore.swift
@@ -1,0 +1,91 @@
+import Foundation
+import Observation
+
+/// Client-side cache of tabs registered with the relay.
+///
+/// Tab-Keyed Offices (Wave 3) — the Office Manager UI will eventually read
+/// from this store instead of `sessionList`. Wave 3 only populates the cache;
+/// Wave 4 wires it into the UI.
+///
+/// The store is keyed by `tabId` (not `sessionId`) — a tab can host multiple
+/// concurrent claude sessions (Gate A in the phase spec), so sessions live
+/// inside each `TabMeta`.
+@Observable
+@MainActor
+final class TabRegistryStore {
+    /// All tabs known to the relay, keyed by `tabId`.
+    private(set) var tabs: [String: TabMeta] = [:]
+
+    // MARK: - Mutation
+
+    /// Replace the full cache with a fresh `tab.list.response` payload.
+    func replaceAll(with response: TabListResponseEvent) {
+        tabs = Dictionary(uniqueKeysWithValues: response.tabs.map { ($0.tabId, $0) })
+    }
+
+    /// Insert or update a full `TabMeta` (e.g., pushed ad-hoc by the relay).
+    func upsert(_ tab: TabMeta) {
+        tabs[tab.tabId] = tab
+    }
+
+    /// Drop a tab from the cache outright. Called on `tab.closed`.
+    func remove(tabId: String) {
+        tabs.removeValue(forKey: tabId)
+    }
+
+    /// Apply a `tab.session.started` event. If the tab is already in the
+    /// cache, bump `lastSeenAt` and add the session to its roster. If not,
+    /// seed a minimal `TabMeta` so the event isn't lost — a subsequent
+    /// `tab.list.response` will fill in the real metadata.
+    func apply(started event: TabSessionStartedEvent) {
+        let summary = TabSessionSummary(
+            sessionId: event.sessionId,
+            startedAt: event.startedAt
+        )
+
+        if let existing = tabs[event.tabId] {
+            // Dedupe — keep the first startedAt we saw for this session.
+            var sessions = existing.sessions
+            if !sessions.contains(where: { $0.sessionId == event.sessionId }) {
+                sessions.append(summary)
+            }
+            tabs[event.tabId] = TabMeta(
+                tabId: existing.tabId,
+                workingDirName: existing.workingDirName.isEmpty
+                    ? event.workingDirName
+                    : existing.workingDirName,
+                status: "active",
+                createdAt: existing.createdAt,
+                lastSeenAt: event.startedAt,
+                sessions: sessions
+            )
+        } else {
+            // First time seeing this tab — seed a minimal entry. Details
+            // will arrive via the next `tab.list.response`.
+            tabs[event.tabId] = TabMeta(
+                tabId: event.tabId,
+                workingDirName: event.workingDirName,
+                status: "active",
+                createdAt: event.startedAt,
+                lastSeenAt: event.startedAt,
+                sessions: [summary]
+            )
+        }
+    }
+
+    /// Apply a `tab.session.ended` event. Removes the session from the tab's
+    /// roster and touches `lastSeenAt`. The tab itself survives — PTY close
+    /// is what removes it (via `remove(tabId:)`).
+    func apply(ended event: TabSessionEndedEvent) {
+        guard let existing = tabs[event.tabId] else { return }
+        let sessions = existing.sessions.filter { $0.sessionId != event.sessionId }
+        tabs[event.tabId] = TabMeta(
+            tabId: existing.tabId,
+            workingDirName: existing.workingDirName,
+            status: sessions.isEmpty ? "idle" : existing.status,
+            createdAt: existing.createdAt,
+            lastSeenAt: event.endedAt,
+            sessions: sessions
+        )
+    }
+}

--- a/ios/MajorTom/Features/Office/Models/TabRegistryStore.swift
+++ b/ios/MajorTom/Features/Office/Models/TabRegistryStore.swift
@@ -19,8 +19,14 @@ final class TabRegistryStore {
     // MARK: - Mutation
 
     /// Replace the full cache with a fresh `tab.list.response` payload.
+    /// Duplicate `tabId` entries are merged by keeping the last occurrence —
+    /// the relay's TabRegistry should not emit duplicates, but network-fed
+    /// data is defended against runtime traps here.
     func replaceAll(with response: TabListResponseEvent) {
-        tabs = Dictionary(uniqueKeysWithValues: response.tabs.map { ($0.tabId, $0) })
+        tabs = Dictionary(
+            response.tabs.map { ($0.tabId, $0) },
+            uniquingKeysWith: { _, latest in latest }
+        )
     }
 
     /// Insert or update a full `TabMeta` (e.g., pushed ad-hoc by the relay).


### PR DESCRIPTION
## Summary

iOS side of Wave 3: decode the `tab.*` server events Wave 2 ships, cache them in a `TabRegistryStore`, thread optional `tabId` through the sprite + agent event models, and add a feature flag (`tabKeyedOffices`, default off). **No UI rewire** — Office Manager still lists sessions; Wave 4 flips the switch.

See `docs/PHASE-TAB-KEYED-OFFICES.md` §7 (iOS changes) and §10 (Wave 3 row).

## Changes

- `feat(ios): tab protocol message models` — Codable models for `TabSessionStartedEvent`, `TabSessionEndedEvent`, `TabClosedEvent`, `TabMeta`/`TabSessionSummary`, `TabListResponseEvent`, and a `TabListRequestMessage` client type. Registered new `MessageType` cases for `tab.list`, `tab.session.started`, `tab.session.ended`, `tab.closed`, `tab.list.response`.
- `feat(ios): decode tab.* events into TabRegistryStore` — `@Observable` `TabRegistryStore` keyed by `tabId`, with `apply(started:)` / `apply(ended:)` / `remove(tabId:)` / `replaceAll(with:)`. Wired the four `tab.*` events into the `RelayService` router. Cache is live but not yet read by UI.
- `feat(ios): thread optional tabId through sprite and agent event models` — added optional `tabId: String?` to `SpriteLinkEvent`, `SpriteUnlinkEvent`, `SpriteStateEvent`, `SpriteResponseEvent`, `AgentSpawnEvent`, `AgentWorkingEvent`, `AgentIdleEvent`, `AgentCompleteEvent`, and `SessionMetaInfo`. Purely additive.
- `feat(ios): RelayService.requestTabList()` — mirrors the `requestSessionList()` pattern.
- `feat(ios): tabKeyedOffices feature flag (default off)` — `FeatureFlags.swift` with a `UserDefaults`-backed bool at `featureFlag.tabKeyedOffices`. Not yet consumed by call sites.

## Test plan

- [x] `xcodebuild -project MajorTom.xcodeproj -scheme MajorTom -destination 'generic/platform=iOS Simulator' build` clean
- [x] Warning count unchanged from baseline (89 pre-existing warnings, 89 with changes)
- [ ] Manual sanity on simulator (Wave 4 will actually surface tab UI; Wave 3 is wire + cache only)
- [ ] Copilot review (auto)

Generated with Claude Code
