### PR TITLE
feat(ios): Wave 4 — Tab-Keyed Offices Office rebind + explicit terminal lifecycle

### DIFF
--- a/ios/MajorTom/App/MajorTomApp.swift
+++ b/ios/MajorTom/App/MajorTomApp.swift
@@ -187,8 +187,10 @@ struct MajorTomApp: App {
 
         // Wave 5 — "Cool Beans" action on /btw response notifications clears
         // the unread state on the matching sprite (same as in-app Cool Beans).
-        notificationService.onBtwCoolBeansAction = { sessionId, subagentId in
-            let vm = officeSceneManager.ensureViewModel(for: sessionId)
+        // Wave 4 — the `tabId` parameter routes multi-session tabs to the
+        // correct Office; nil = legacy cli/vscode session.
+        notificationService.onBtwCoolBeansAction = { sessionId, subagentId, tabId in
+            let vm = officeSceneManager.ensureViewModel(for: sessionId, tabId: tabId)
             // The sprite id equals the subagentId for linked sprites.
             vm.dismissResponse(for: subagentId)
         }

--- a/ios/MajorTom/Core/Services/FeatureFlags.swift
+++ b/ios/MajorTom/Core/Services/FeatureFlags.swift
@@ -6,32 +6,9 @@ import Foundation
 /// Flags default to `false` — each keyed-off flag represents an in-flight
 /// phase that is not yet ready to light up for real users. When a phase
 /// ships in full, the flag is removed alongside the old code path.
+///
+/// This enum is intentionally kept (even when empty) so future flags have
+/// a landing pad without re-introducing a file-level dance.
 enum FeatureFlags {
-
-    // MARK: - Tab-Keyed Offices (Wave 3/4)
-
-    /// Route sprite + agent events by `tabId` (when present on the wire)
-    /// instead of `sessionId`.
-    ///
-    /// **Wave 3 (this phase):** flag is exposed but unused — Offices still
-    /// key by `sessionId`. The flag lets Wave 4 land the routing flip
-    /// behind a toggle that can be dark-launched per device.
-    ///
-    /// **Wave 4:** `OfficeSceneManager` reads this and either routes by
-    /// `event.tabId ?? event.sessionId` (flag on) or stays sessionId-first
-    /// (flag off) for one release of backwards compatibility, after which
-    /// the flag is removed.
-    static var tabKeyedOffices: Bool {
-        get { UserDefaults.standard.bool(forKey: Keys.tabKeyedOffices) }
-        set {
-            guard newValue != UserDefaults.standard.bool(forKey: Keys.tabKeyedOffices) else { return }
-            UserDefaults.standard.set(newValue, forKey: Keys.tabKeyedOffices)
-        }
-    }
-
-    // MARK: - Defaults Keys
-
-    private enum Keys {
-        static let tabKeyedOffices = "featureFlag.tabKeyedOffices"
-    }
+    // No active flags.
 }

--- a/ios/MajorTom/Core/Services/RelayService.swift
+++ b/ios/MajorTom/Core/Services/RelayService.swift
@@ -769,6 +769,9 @@ final class RelayService {
                     liveActivityManager?.handleToolStart(sessionId: sid, toolName: event.tool)
                 }
                 // Wave 5: route per-sprite tool bubble when relay tags the event.
+                // Tool events don't carry `tabId` on the wire; `ensureViewModel`
+                // falls back via the session→tab cache populated by prior
+                // sprite/agent events in the same session.
                 if let subagentId = event.subagentId {
                     officeSceneManager?.ensureViewModel(for: event.sessionId)
                         .handleSpriteToolStart(
@@ -805,6 +808,9 @@ final class RelayService {
                     liveActivityManager?.handleToolComplete(sessionId: sid)
                 }
                 // Wave 5: hide per-sprite tool bubble if relay tagged the event.
+                // Tool events don't carry `tabId` on the wire; `ensureViewModel`
+                // falls back via the session→tab cache populated by prior
+                // sprite/agent events in the same session.
                 if let subagentId = event.subagentId {
                     officeSceneManager?.ensureViewModel(for: event.sessionId)
                         .handleSpriteToolComplete(
@@ -817,7 +823,7 @@ final class RelayService {
 
         case .agentSpawn:
             if let event = try? MessageCodec.decode(AgentSpawnEvent.self, from: data) {
-                officeSceneManager?.ensureViewModel(for: event.sessionId).handleAgentSpawn(id: event.agentId, role: event.role, task: event.task, parentId: event.parentId)
+                officeSceneManager?.ensureViewModel(for: event.sessionId, tabId: event.tabId).handleAgentSpawn(id: event.agentId, role: event.role, task: event.task, parentId: event.parentId)
                 notificationService?.postAgentSpawnNotification(
                     agentId: event.agentId,
                     role: event.role,
@@ -829,7 +835,7 @@ final class RelayService {
 
         case .agentWorking:
             if let event = try? MessageCodec.decode(AgentWorkingEvent.self, from: data) {
-                officeSceneManager?.ensureViewModel(for: event.sessionId)
+                officeSceneManager?.ensureViewModel(for: event.sessionId, tabId: event.tabId)
                     .handleAgentWorking(
                         id: event.agentId,
                         task: event.task,
@@ -840,7 +846,7 @@ final class RelayService {
 
         case .agentIdle:
             if let event = try? MessageCodec.decode(AgentIdleEvent.self, from: data) {
-                officeSceneManager?.ensureViewModel(for: event.sessionId)
+                officeSceneManager?.ensureViewModel(for: event.sessionId, tabId: event.tabId)
                     .handleAgentIdle(
                         id: event.agentId,
                         toolCount: event.toolCount,
@@ -850,7 +856,7 @@ final class RelayService {
 
         case .agentComplete:
             if let event = try? MessageCodec.decode(AgentCompleteEvent.self, from: data) {
-                officeSceneManager?.ensureViewModel(for: event.sessionId).handleAgentComplete(id: event.agentId, result: event.result)
+                officeSceneManager?.ensureViewModel(for: event.sessionId, tabId: event.tabId).handleAgentComplete(id: event.agentId, result: event.result)
                 notificationService?.postAgentCompleteNotification(
                     agentId: event.agentId,
                     result: event.result
@@ -861,7 +867,7 @@ final class RelayService {
 
         case .agentDismissed:
             if let event = try? MessageCodec.decode(AgentDismissedEvent.self, from: data) {
-                officeSceneManager?.ensureViewModel(for: event.sessionId).handleAgentDismissed(id: event.agentId)
+                officeSceneManager?.ensureViewModel(for: event.sessionId, tabId: event.tabId).handleAgentDismissed(id: event.agentId)
                 liveActivityManager?.handleAgentComplete(sessionId: event.sessionId)
                 updateWidgetData()
             }
@@ -1220,22 +1226,22 @@ final class RelayService {
 
         case .spriteLink:
             if let event = try? MessageCodec.decode(SpriteLinkEvent.self, from: data) {
-                officeSceneManager?.ensureViewModel(for: event.sessionId).handleSpriteLink(event)
+                officeSceneManager?.ensureViewModel(for: event.sessionId, tabId: event.tabId).handleSpriteLink(event)
             }
 
         case .spriteUnlink:
             if let event = try? MessageCodec.decode(SpriteUnlinkEvent.self, from: data) {
-                officeSceneManager?.ensureViewModel(for: event.sessionId).handleSpriteUnlink(event)
+                officeSceneManager?.ensureViewModel(for: event.sessionId, tabId: event.tabId).handleSpriteUnlink(event)
             }
 
         case .spriteState:
             if let event = try? MessageCodec.decode(SpriteStateEvent.self, from: data) {
-                officeSceneManager?.ensureViewModel(for: event.sessionId).handleSpriteState(event)
+                officeSceneManager?.ensureViewModel(for: event.sessionId, tabId: event.tabId).handleSpriteState(event)
             }
 
         case .spriteResponse:
             if let event = try? MessageCodec.decode(SpriteResponseEvent.self, from: data) {
-                let vm = officeSceneManager?.ensureViewModel(for: event.sessionId)
+                let vm = officeSceneManager?.ensureViewModel(for: event.sessionId, tabId: event.tabId)
                 vm?.handleSpriteResponse(event)
 
                 // Only `delivered`/`dropped` affect UI; `queued` is informational.

--- a/ios/MajorTom/Core/Services/RelayService.swift
+++ b/ios/MajorTom/Core/Services/RelayService.swift
@@ -1260,8 +1260,9 @@ final class RelayService {
                         // Cross-session (M2) — show banner unless the inspector
                         // for this sprite is open elsewhere (can't happen in
                         // our single-open-inspector model, so we just surface).
-                        let sessionName = sessionList
-                            .first(where: { $0.id == event.sessionId })?.workingDirName
+                        let tabMeta = event.tabId.flatMap { tabRegistryStore.tabs[$0] }
+                        let sessionName = tabMeta?.workingDirName
+                            ?? sessionList.first(where: { $0.id == event.sessionId })?.workingDirName
                             ?? "Terminal"
                         let spriteId = vm?.agents.first(where: {
                             $0.linkedSubagentId == event.subagentId
@@ -1276,6 +1277,7 @@ final class RelayService {
                                 ?? "(Agent completed before delivery)")
                             : event.text
                         officeSceneManager?.showCrossSessionBanner(
+                            tabId: event.tabId,
                             sessionId: event.sessionId,
                             sessionName: sessionName,
                             spriteId: spriteId,
@@ -1363,7 +1365,8 @@ final class RelayService {
             subagentId: event.subagentId,
             role: role,
             spriteName: spriteName,
-            response: event.text
+            response: event.text,
+            tabId: event.tabId
         )
     }
 

--- a/ios/MajorTom/Core/Services/RelayService.swift
+++ b/ios/MajorTom/Core/Services/RelayService.swift
@@ -733,8 +733,16 @@ final class RelayService {
                     currentSession = nil
                     updateWidgetData()
                 }
-                // Clean up the office entry for this session
-                officeSceneManager?.closeOffice(for: event.sessionId)
+                // Clean up the office entry — but only for legacy / synthetic
+                // Offices whose key is this sessionId. Tab-backed Offices are
+                // torn down by `tab.closed` after PTY grace expires; the
+                // walk-off for the ending session is driven by
+                // `tab.session.ended`, which has already fired by this point.
+                let vm = officeSceneManager?.viewModel(for: event.sessionId)
+                let isTabBacked = vm?.tabId != nil && vm?.tabId != event.sessionId
+                if !isTabBacked {
+                    officeSceneManager?.closeOffice(for: event.sessionId)
+                }
             }
 
         case .sessionListResponse:
@@ -1288,16 +1296,25 @@ final class RelayService {
         case .tabSessionStarted:
             if let event = try? MessageCodec.decode(TabSessionStartedEvent.self, from: data) {
                 tabRegistryStore.apply(started: event)
+                officeSceneManager?.handleTabSessionStarted(
+                    tabId: event.tabId,
+                    sessionId: event.sessionId
+                )
             }
 
         case .tabSessionEnded:
             if let event = try? MessageCodec.decode(TabSessionEndedEvent.self, from: data) {
                 tabRegistryStore.apply(ended: event)
+                officeSceneManager?.handleTabSessionEnded(
+                    tabId: event.tabId,
+                    sessionId: event.sessionId
+                )
             }
 
         case .tabClosed:
             if let event = try? MessageCodec.decode(TabClosedEvent.self, from: data) {
                 tabRegistryStore.remove(tabId: event.tabId)
+                officeSceneManager?.closeOffice(for: event.tabId)
             }
 
         case .tabListResponse:

--- a/ios/MajorTom/Features/Notifications/Services/NotificationService.swift
+++ b/ios/MajorTom/Features/Notifications/Services/NotificationService.swift
@@ -32,8 +32,9 @@ final class NotificationService: NSObject {
     var onApprovalAction: ((String, Bool) -> Void)?
 
     /// Wave 5 — invoked when the user taps the "Cool Beans" action on a
-    /// `/btw` response notification. Parameters: sessionId, subagentId.
-    var onBtwCoolBeansAction: ((String, String) -> Void)?
+    /// `/btw` response notification.
+    /// Parameters: sessionId, subagentId, tabId (nil for legacy sessions).
+    var onBtwCoolBeansAction: ((String, String, String?) -> Void)?
 
     private let center = UNUserNotificationCenter.current()
 
@@ -207,12 +208,18 @@ final class NotificationService: NSObject {
     /// Title: `"[{role}] {spriteName}"`, body: first ~120 chars of the response.
     /// Carries session/subagent identifiers so the "Cool Beans" action can
     /// clear the matching unread state.
+    ///
+    /// Tab-Keyed Offices (Wave 4): `tabId` is included in the payload when
+    /// the originating session is bound to a terminal tab. The deep link
+    /// resolves to the owning Office so "Cool Beans" and the default tap
+    /// action land in the right place.
     func postBtwResponseNotification(
         sessionId: String,
         subagentId: String,
         role: String,
         spriteName: String,
-        response: String
+        response: String,
+        tabId: String? = nil
     ) {
         guard isAuthorized else { return }
 
@@ -221,11 +228,16 @@ final class NotificationService: NSObject {
         content.body = Self.truncatedBody(response)
         content.sound = .default
         content.categoryIdentifier = NotificationCategory.btwResponse.rawValue
-        content.userInfo = [
+        let deepLink = tabId.map { "majortom://office/\($0)" } ?? "majortom://office"
+        var userInfo: [AnyHashable: Any] = [
             "sessionId": sessionId,
             "subagentId": subagentId,
-            "deepLink": "majortom://office"
+            "deepLink": deepLink
         ]
+        if let tabId {
+            userInfo["tabId"] = tabId
+        }
+        content.userInfo = userInfo
 
         let request = UNNotificationRequest(
             identifier: "btw-\(subagentId)-\(UUID().uuidString)",
@@ -295,9 +307,13 @@ extension NotificationService: UNUserNotificationCenterDelegate {
 
             case NotificationAction.coolBeans.rawValue:
                 // Wave 5 — clear the unread /btw state for the originating sprite.
+                // Wave 4 — `tabId` lets us route to the exact Office even
+                // when the same subagentId exists across concurrent sessions
+                // in the same tab.
                 if let sessionId = userInfo["sessionId"] as? String,
                    let subagentId = userInfo["subagentId"] as? String {
-                    onBtwCoolBeansAction?(sessionId, subagentId)
+                    let tabId = userInfo["tabId"] as? String
+                    onBtwCoolBeansAction?(sessionId, subagentId, tabId)
                 }
 
             case UNNotificationDefaultActionIdentifier:
@@ -329,7 +345,9 @@ struct NotificationDeepLink: Equatable {
 
     var isApproval: Bool { url.starts(with: "majortom://approval/") }
     var isSession: Bool { url.starts(with: "majortom://session/") }
-    var isOffice: Bool { url == "majortom://office" }
+    var isOffice: Bool {
+        url == "majortom://office" || url.starts(with: "majortom://office/")
+    }
 
     var approvalRequestId: String? {
         guard isApproval else { return nil }
@@ -339,5 +357,15 @@ struct NotificationDeepLink: Equatable {
     var sessionId: String? {
         guard isSession else { return nil }
         return String(url.dropFirst("majortom://session/".count))
+    }
+
+    /// Tab-Keyed Offices (Wave 4): extracts the tabId from
+    /// `majortom://office/{tabId}` deep links. Returns nil for the generic
+    /// `majortom://office` URL.
+    var officeTabId: String? {
+        let prefix = "majortom://office/"
+        guard url.starts(with: prefix) else { return nil }
+        let tabId = String(url.dropFirst(prefix.count))
+        return tabId.isEmpty ? nil : tabId
     }
 }

--- a/ios/MajorTom/Features/Office/Models/TabRegistryStore.swift
+++ b/ios/MajorTom/Features/Office/Models/TabRegistryStore.swift
@@ -39,6 +39,19 @@ final class TabRegistryStore {
         tabs.removeValue(forKey: tabId)
     }
 
+    // MARK: - Lookup
+
+    /// Reverse-lookup: find the tab that hosts a given session, or nil when
+    /// the session belongs to a legacy `cli`/`vscode` adapter or hasn't yet
+    /// been registered in the cache. Used by `OfficeSceneManager` to route
+    /// sprite/agent events whose `tabId` field is missing (Wave 4 fallback
+    /// path — see spec §7.1).
+    func getTabForSession(_ sessionId: String) -> TabMeta? {
+        tabs.values.first { tab in
+            tab.sessions.contains { $0.sessionId == sessionId }
+        }
+    }
+
     /// Apply a `tab.session.started` event. If the tab is already in the
     /// cache, bump `lastSeenAt` and add the session to its roster. If not,
     /// seed a minimal `TabMeta` so the event isn't lost — a subsequent

--- a/ios/MajorTom/Features/Office/ViewModels/OfficeSceneManager.swift
+++ b/ios/MajorTom/Features/Office/ViewModels/OfficeSceneManager.swift
@@ -248,11 +248,17 @@ final class OfficeSceneManager {
             if tabId != nil, existing.viewModel.tabId == nil {
                 existing.viewModel.tabId = officeKey
             }
+            existing.viewModel.activeSessionIds.insert(sessionId)
+            if existing.viewModel.sessionId == nil {
+                existing.viewModel.sessionId = sessionId
+            }
             return existing.viewModel
         }
 
         let vm = OfficeViewModel()
         vm.tabId = officeKey
+        vm.sessionId = sessionId
+        vm.activeSessionIds.insert(sessionId)
 
         let entry = OfficeEntry(
             viewModel: vm,
@@ -261,6 +267,56 @@ final class OfficeSceneManager {
         )
         offices[officeKey] = entry
         return vm
+    }
+
+    // MARK: - Tab Session Lifecycle (Wave 4)
+
+    /// Called when the relay broadcasts `tab.session.started`. Records the
+    /// session in the owning Office's roster (if the Office already exists)
+    /// and seeds the session→tab reverse cache so subsequent events for this
+    /// session route correctly even if they arrive without a `tabId` hint.
+    func handleTabSessionStarted(tabId: String, sessionId: String) {
+        sessionToOfficeKey[sessionId] = tabId
+
+        if let vm = offices[tabId]?.viewModel {
+            vm.activeSessionIds.insert(sessionId)
+            if vm.sessionId == nil {
+                vm.sessionId = sessionId
+            }
+            if vm.tabId == nil {
+                vm.tabId = tabId
+            }
+        }
+        // If the Office hasn't been materialized yet (user hasn't tapped
+        // "Available Tabs" or no agent events have landed), it will be
+        // created lazily by `ensureViewModel` and `createOffice`. The cache
+        // above guarantees those paths land in the right Office key.
+    }
+
+    /// Called when the relay broadcasts `tab.session.ended`. Drops the
+    /// session from the Office's roster and walks off any active humans.
+    /// Dogs (idle sprites) stay. The Office itself survives — tab teardown
+    /// happens on `tab.closed` after PTY grace expires.
+    func handleTabSessionEnded(tabId: String, sessionId: String) {
+        sessionToOfficeKey.removeValue(forKey: sessionId)
+
+        guard let vm = offices[tabId]?.viewModel else { return }
+        vm.activeSessionIds.remove(sessionId)
+
+        // If the session that just ended was the VM's primary sessionId,
+        // rotate to any remaining active session so sprite messaging +
+        // state-request paths still have a valid binding.
+        if vm.sessionId == sessionId {
+            vm.sessionId = vm.activeSessionIds.first
+        }
+
+        // Walk off every non-idle agent sprite. Wave 4 intentionally walks
+        // off *all* humans rather than filtering to the ending session —
+        // Wave 5 refines this once agents carry a session binding.
+        let humanIds = vm.agents.filter { !$0.id.hasPrefix("idle-") }.map(\.id)
+        for id in humanIds {
+            vm.handleAgentDismissed(id: id)
+        }
     }
 
     /// Closes an Office. Destroys both scene and viewModel.

--- a/ios/MajorTom/Features/Office/ViewModels/OfficeSceneManager.swift
+++ b/ios/MajorTom/Features/Office/ViewModels/OfficeSceneManager.swift
@@ -3,8 +3,18 @@ import SpriteKit
 
 // MARK: - Office Scene Manager
 
-/// Manages per-session OfficeViewModel + OfficeScene pairs.
-/// Each active session can have its own Office with independent agent state and scene.
+/// Manages per-tab OfficeViewModel + OfficeScene pairs.
+///
+/// **Tab-Keyed Offices (Wave 4):** the `offices` dictionary is keyed by
+/// **tabId** — the identifier of the iOS terminal tab hosting the Claude
+/// session(s). Each tab has one Office; an Office can host multiple
+/// concurrent sessions (Gate A).
+///
+/// **Legacy / fallback:** sessions that never bind to a tab (the legacy
+/// `cli` and `vscode` adapter paths) fall back to using their `sessionId`
+/// as a synthetic tabId — those Offices continue to work without any
+/// TabRegistry binding.
+///
 /// Scenes are LRU-evicted beyond `maxWarmScenes` to control memory (~30-60MB each).
 @Observable
 @MainActor
@@ -23,8 +33,15 @@ final class OfficeSceneManager {
 
     // MARK: - State
 
-    /// Per-session offices keyed by sessionId.
+    /// Per-tab offices keyed by **tabId** (or by sessionId as a synthetic
+    /// tabId for legacy `cli`/`vscode` sessions — see type docs above).
     private(set) var offices: [String: OfficeEntry] = [:]
+
+    /// Reverse-lookup cache for `sessionId → office key`. Populated whenever
+    /// an event lands with a known `tabId` so later events arriving without
+    /// one still route to the same Office. For legacy sessions the entry is
+    /// `sessionId → sessionId` (self-mapped).
+    private var sessionToOfficeKey: [String: String] = [:]
 
     /// Maximum number of warm (in-memory) scenes before LRU eviction kicks in.
     static let maxWarmScenes = 2
@@ -88,19 +105,27 @@ final class OfficeSceneManager {
 
     // MARK: - Public API
 
-    /// Returns the OfficeViewModel for a session, or nil if no Office exists.
-    func viewModel(for sessionId: String) -> OfficeViewModel? {
-        offices[sessionId]?.viewModel
+    /// Returns the OfficeViewModel for an Office key. The key may be either a
+    /// tabId (tab-backed Office) or a sessionId (legacy synthetic Office).
+    /// A sessionId that has been routed to a real tab resolves via the
+    /// internal session→tab cache.
+    func viewModel(for key: String) -> OfficeViewModel? {
+        if let vm = offices[key]?.viewModel { return vm }
+        if let tabKey = sessionToOfficeKey[key] {
+            return offices[tabKey]?.viewModel
+        }
+        return nil
     }
 
-    /// Creates a new Office for a session (viewModel + scene).
+    /// Creates a new Office keyed by the given tabId. For legacy `cli`/`vscode`
+    /// sessions the caller passes the sessionId directly as a synthetic tabId.
     /// Returns the newly created entry. If an Office already exists, returns it.
     @discardableResult
-    func createOffice(for sessionId: String) -> OfficeEntry {
-        if var existing = offices[sessionId] {
+    func createOffice(for tabId: String) -> OfficeEntry {
+        if var existing = offices[tabId] {
             // If the entry already has a scene (full office), just touch LRU and return.
             if existing.scene != nil {
-                offices[sessionId]?.lastAccessed = Date()
+                offices[tabId]?.lastAccessed = Date()
                 return existing
             }
 
@@ -110,17 +135,17 @@ final class OfficeSceneManager {
             existing.scene = scene
             existing.lastAccessed = Date()
             existing.hasOffice = true
-            offices[sessionId] = existing
+            offices[tabId] = existing
 
             existing.viewModel.populateIdleSprites()
-            relay?.requestSpriteState(for: sessionId)
+            requestSpriteStateForAllSessions(in: existing.viewModel)
 
-            evictIfNeeded(excluding: sessionId)
+            evictIfNeeded(excluding: tabId)
             return existing
         }
 
         let vm = OfficeViewModel()
-        vm.sessionId = sessionId
+        vm.tabId = tabId
 
         let scene = makeScene()
 
@@ -130,35 +155,40 @@ final class OfficeSceneManager {
             lastAccessed: Date(),
             hasOffice: true
         )
-        offices[sessionId] = entry
+        offices[tabId] = entry
 
         // Populate idle sprites for the fresh office
         vm.populateIdleSprites()
 
-        // Request current sprite state from relay for this session
-        relay?.requestSpriteState(for: sessionId)
+        // If events have already cached a session under this key, request state for it.
+        requestSpriteStateForAllSessions(in: vm)
 
-        evictIfNeeded(excluding: sessionId)
+        evictIfNeeded(excluding: tabId)
         return entry
     }
 
     /// Side-effect-free scene peek — returns the current scene (or nil) without
     /// touching LRU timestamps or triggering cold rebuilds.
     /// Safe to call from SwiftUI computed properties / view body.
-    func peekScene(for sessionId: String) -> OfficeScene? {
-        offices[sessionId]?.scene
+    func peekScene(for key: String) -> OfficeScene? {
+        if let scene = offices[key]?.scene { return scene }
+        if let tabKey = sessionToOfficeKey[key] {
+            return offices[tabKey]?.scene
+        }
+        return nil
     }
 
     /// Activates an office for viewing: touches LRU, cold-rebuilds the scene if
     /// evicted, and syncs existing agent state into a fresh scene.
     /// Call from `.onAppear` or other imperative contexts — NOT from view body.
     @discardableResult
-    func activateOffice(for sessionId: String) -> OfficeScene? {
-        guard var entry = offices[sessionId] else { return nil }
+    func activateOffice(for tabId: String) -> OfficeScene? {
+        let key = resolvedOfficeKey(tabId)
+        guard var entry = offices[key] else { return nil }
 
         // Touch LRU timestamp
         entry.lastAccessed = Date()
-        offices[sessionId] = entry
+        offices[key] = entry
 
         // If scene exists, return it
         if let scene = entry.scene {
@@ -167,7 +197,7 @@ final class OfficeSceneManager {
 
         // Cold rebuild: create a new scene, restore from viewModel state
         let scene = makeScene()
-        offices[sessionId]?.scene = scene
+        offices[key]?.scene = scene
 
         // Sync any existing agents into the fresh scene so they render immediately
         // (onChange won't fire for the initial value on a newly created scene).
@@ -191,44 +221,67 @@ final class OfficeSceneManager {
             }
         }
 
-        // If viewModel has no real agents, request state from relay.
+        // If viewModel has no real agents, request state from relay for each
+        // known session in this Office.
         if vm.agents.filter({ !$0.id.hasPrefix("idle-") }).isEmpty {
-            relay?.requestSpriteState(for: sessionId)
+            requestSpriteStateForAllSessions(in: vm)
         }
 
-        evictIfNeeded(excluding: sessionId)
+        evictIfNeeded(excluding: key)
         return scene
     }
 
-    /// Creates a lightweight OfficeViewModel entry (no scene) for a session so
-    /// agent events can accumulate before the user opens an Office.
+    /// Creates a lightweight OfficeViewModel entry (no scene) for the Office
+    /// hosting this session so agent events can accumulate before the user
+    /// opens an Office.
+    ///
+    /// Routes by **tabId** when provided (Wave 4 `cli-external` sessions) and
+    /// falls back to the TabRegistryStore or the sessionId itself for legacy
+    /// `cli`/`vscode` sessions. The session→office key mapping is cached so
+    /// subsequent events without a `tabId` still land in the same Office.
     @discardableResult
-    func ensureViewModel(for sessionId: String) -> OfficeViewModel {
-        if let existing = offices[sessionId] {
+    func ensureViewModel(for sessionId: String, tabId: String? = nil) -> OfficeViewModel {
+        let officeKey = resolveOfficeKey(sessionId: sessionId, tabIdHint: tabId)
+        sessionToOfficeKey[sessionId] = officeKey
+
+        if let existing = offices[officeKey] {
+            if tabId != nil, existing.viewModel.tabId == nil {
+                existing.viewModel.tabId = officeKey
+            }
             return existing.viewModel
         }
+
         let vm = OfficeViewModel()
-        vm.sessionId = sessionId
+        vm.tabId = officeKey
 
         let entry = OfficeEntry(
             viewModel: vm,
             scene: nil,
             lastAccessed: Date()
         )
-        offices[sessionId] = entry
+        offices[officeKey] = entry
         return vm
     }
 
-    /// Closes an Office for a session. Destroys both scene and viewModel.
+    /// Closes an Office. Destroys both scene and viewModel.
     /// Does NOT affect the terminal session on the relay.
-    func closeOffice(for sessionId: String) {
-        guard let entry = offices[sessionId] else { return }
+    ///
+    /// Legacy sessions: pass the sessionId directly (acts as the synthetic
+    /// office key). Tab-backed sessions: pass the tabId.
+    func closeOffice(for key: String) {
+        let officeKey = resolvedOfficeKey(key)
+        guard let entry = offices[officeKey] else { return }
         entry.scene?.isPaused = true
-        offices.removeValue(forKey: sessionId)
+        offices.removeValue(forKey: officeKey)
+
+        // Drop any reverse-lookup entries pointing at this Office so future
+        // events for those sessions don't leak into a stale key.
+        sessionToOfficeKey = sessionToOfficeKey.filter { $0.value != officeKey }
     }
 
-    /// Session IDs that have Offices created (for OfficeManagerView).
-    /// Excludes lightweight entries created by `ensureViewModel` that were never upgraded.
+    /// Keys (tabId or synthetic sessionId) of offices that have a full scene.
+    /// Excludes lightweight entries created by `ensureViewModel` that were
+    /// never upgraded via `createOffice`.
     var linkedSessionIds: Set<String> {
         Set(offices.filter { $0.value.hasOffice }.keys)
     }
@@ -243,9 +296,62 @@ final class OfficeSceneManager {
         return scene
     }
 
+    /// Translate an incoming identifier (tabId or sessionId) into the actual
+    /// `offices` dictionary key. Used by UI-facing entry points where the
+    /// caller may have either flavor.
+    private func resolvedOfficeKey(_ key: String) -> String {
+        if offices[key] != nil { return key }
+        if let mapped = sessionToOfficeKey[key], offices[mapped] != nil {
+            return mapped
+        }
+        return key
+    }
+
+    /// Resolve the Office key for an event tagged with `sessionId` and an
+    /// optional `tabId` hint. Preference order:
+    /// 1. Explicit `tabId` from the wire (Wave 4 `cli-external` sessions).
+    /// 2. Locally cached `sessionToOfficeKey` (from an earlier tagged event).
+    /// 3. `TabRegistryStore.getTabForSession` (the authoritative mapping if
+    ///    the client has already seen a `tab.session.started` broadcast).
+    /// 4. `sessionId` itself — synthetic tabId for legacy sessions that
+    ///    never bind to a terminal tab.
+    private func resolveOfficeKey(sessionId: String, tabIdHint: String?) -> String {
+        if let tabIdHint { return tabIdHint }
+        if let cached = sessionToOfficeKey[sessionId] { return cached }
+        if let tab = relay?.tabRegistryStore.getTabForSession(sessionId) {
+            return tab.tabId
+        }
+        return sessionId
+    }
+
+    /// Ask the relay to re-send sprite state for every session currently
+    /// hosted by this Office. Covers both the single-session common case and
+    /// Wave 5 multi-session tabs. Falls back to the cached
+    /// `sessionToOfficeKey` reverse map when the VM hasn't populated its
+    /// `activeSessionIds` yet (e.g. cold rebuild before the first event).
+    private func requestSpriteStateForAllSessions(in vm: OfficeViewModel) {
+        guard let relay else { return }
+        let tabKey = vm.tabId
+        var sessionIds = vm.activeSessionIds
+        if sessionIds.isEmpty, let tabKey {
+            sessionIds = Set(
+                sessionToOfficeKey
+                    .filter { $0.value == tabKey }
+                    .map(\.key)
+            )
+        }
+        if sessionIds.isEmpty, let tabKey {
+            // Legacy: the key IS the sessionId.
+            sessionIds = [tabKey]
+        }
+        for sid in sessionIds {
+            relay.requestSpriteState(for: sid)
+        }
+    }
+
     /// LRU eviction: destroy scenes beyond maxWarmScenes (keep viewModel alive).
-    private func evictIfNeeded(excluding activeSessionId: String) {
-        let warmEntries = offices.filter { $0.value.scene != nil && $0.key != activeSessionId }
+    private func evictIfNeeded(excluding activeOfficeKey: String) {
+        let warmEntries = offices.filter { $0.value.scene != nil && $0.key != activeOfficeKey }
 
         guard warmEntries.count >= Self.maxWarmScenes else { return }
 

--- a/ios/MajorTom/Features/Office/ViewModels/OfficeSceneManager.swift
+++ b/ios/MajorTom/Features/Office/ViewModels/OfficeSceneManager.swift
@@ -150,6 +150,7 @@ final class OfficeSceneManager {
             existing.hasOffice = true
             offices[tabId] = existing
 
+            seedRosterFromTabRegistry(vm: existing.viewModel, officeKey: tabId)
             existing.viewModel.populateIdleSprites()
             requestSpriteStateForAllSessions(in: existing.viewModel)
 
@@ -169,6 +170,11 @@ final class OfficeSceneManager {
             hasOffice: true
         )
         offices[tabId] = entry
+
+        // Seed the session roster from TabRegistryStore so sprite state requests
+        // target real sessionIds (not the tabId by mistake) when an Office is
+        // materialized straight from the tab list before any tagged event lands.
+        seedRosterFromTabRegistry(vm: vm, officeKey: tabId)
 
         // Populate idle sprites for the fresh office
         vm.populateIdleSprites()
@@ -351,7 +357,10 @@ final class OfficeSceneManager {
     /// Keys (tabId or synthetic sessionId) of offices that have a full scene.
     /// Excludes lightweight entries created by `ensureViewModel` that were
     /// never upgraded via `createOffice`.
-    var linkedSessionIds: Set<String> {
+    ///
+    /// Renamed from `linkedSessionIds` — the returned strings are office
+    /// keys, not sessionIds, after the Wave 4 rekey.
+    var linkedOfficeKeys: Set<String> {
         Set(offices.filter { $0.value.hasOffice }.keys)
     }
 
@@ -395,9 +404,15 @@ final class OfficeSceneManager {
 
     /// Ask the relay to re-send sprite state for every session currently
     /// hosted by this Office. Covers both the single-session common case and
-    /// Wave 5 multi-session tabs. Falls back to the cached
-    /// `sessionToOfficeKey` reverse map when the VM hasn't populated its
-    /// `activeSessionIds` yet (e.g. cold rebuild before the first event).
+    /// Wave 5 multi-session tabs. Falls back through:
+    /// 1. VM's `activeSessionIds` roster — seeded by events and
+    ///    `seedRosterFromTabRegistry`.
+    /// 2. The cached `sessionToOfficeKey` reverse map.
+    /// 3. The Office key itself — **only** when the key is not a known
+    ///    tabId in `TabRegistryStore` (i.e. legacy synthetic-sessionId
+    ///    Office). This prevents requesting sprite state for a bogus
+    ///    sessionId equal to the tabId when a real tab's roster hasn't
+    ///    been populated yet.
     private func requestSpriteStateForAllSessions(in vm: OfficeViewModel) {
         guard let relay else { return }
         let tabKey = vm.tabId
@@ -410,11 +425,33 @@ final class OfficeSceneManager {
             )
         }
         if sessionIds.isEmpty, let tabKey {
-            // Legacy: the key IS the sessionId.
-            sessionIds = [tabKey]
+            // Legacy fallback: the key IS the sessionId — but only when
+            // the key isn't registered as a real tab, otherwise we'd be
+            // asking the relay for sprite state on a tabId (wrong).
+            if relay.tabRegistryStore.tabs[tabKey] == nil {
+                sessionIds = [tabKey]
+            }
         }
         for sid in sessionIds {
             relay.requestSpriteState(for: sid)
+        }
+    }
+
+    /// Seed the VM's session roster from `TabRegistryStore` metadata so
+    /// sprite state requests target real sessionIds immediately — avoiding
+    /// the race where `createOffice(for: tabId)` fires before any
+    /// `tab.session.started` / sprite / agent events have populated the
+    /// in-memory roster.
+    private func seedRosterFromTabRegistry(vm: OfficeViewModel, officeKey: String) {
+        guard let relay, let tab = relay.tabRegistryStore.tabs[officeKey] else {
+            return
+        }
+        for summary in tab.sessions {
+            vm.activeSessionIds.insert(summary.sessionId)
+            sessionToOfficeKey[summary.sessionId] = officeKey
+        }
+        if vm.sessionId == nil {
+            vm.sessionId = tab.sessions.first?.sessionId
         }
     }
 

--- a/ios/MajorTom/Features/Office/ViewModels/OfficeSceneManager.swift
+++ b/ios/MajorTom/Features/Office/ViewModels/OfficeSceneManager.swift
@@ -52,8 +52,13 @@ final class OfficeSceneManager {
     // MARK: - Cross-session Banner (Wave 4 M2)
 
     /// Descriptor for a cross-session `/btw` response banner.
+    ///
+    /// Tab-Keyed Offices (Wave 4) — `tabId` is the primary routing key;
+    /// `sessionId` is kept for legacy cli/vscode sessions whose events
+    /// never carry a `tabId` on the wire.
     struct CrossSessionBanner: Identifiable, Equatable {
         let id: UUID
+        let tabId: String?
         let sessionId: String
         let sessionName: String
         let spriteId: String
@@ -62,6 +67,7 @@ final class OfficeSceneManager {
 
         init(
             id: UUID = UUID(),
+            tabId: String? = nil,
             sessionId: String,
             sessionName: String,
             spriteId: String,
@@ -69,12 +75,17 @@ final class OfficeSceneManager {
             preview: String
         ) {
             self.id = id
+            self.tabId = tabId
             self.sessionId = sessionId
             self.sessionName = sessionName
             self.spriteId = spriteId
             self.spriteName = spriteName
             self.preview = preview
         }
+
+        /// Primary route key for navigation — tabId if the event carried
+        /// one, else sessionId (legacy synthetic tabId).
+        var routeKey: String { tabId ?? sessionId }
     }
 
     /// The banner currently surfaced to the user (nil = hidden). Consumed by
@@ -83,6 +94,7 @@ final class OfficeSceneManager {
 
     /// Surface a banner for a response that arrived in a non-active session.
     func showCrossSessionBanner(
+        tabId: String? = nil,
         sessionId: String,
         sessionName: String,
         spriteId: String,
@@ -90,6 +102,7 @@ final class OfficeSceneManager {
         preview: String
     ) {
         pendingCrossSessionBanner = CrossSessionBanner(
+            tabId: tabId,
             sessionId: sessionId,
             sessionName: sessionName,
             spriteId: spriteId,

--- a/ios/MajorTom/Features/Office/ViewModels/OfficeViewModel.swift
+++ b/ios/MajorTom/Features/Office/ViewModels/OfficeViewModel.swift
@@ -46,7 +46,23 @@ final class OfficeViewModel {
     // MARK: - Sprite-Agent Wiring (Wave 2)
 
     /// Session ID this Office is bound to (set by OfficeSceneManager on creation).
+    ///
+    /// For tab-backed Offices this reflects the most-recently-active session
+    /// in the tab — used by sprite messaging + `sprite.state.request` calls.
+    /// `activeSessionIds` is the authoritative roster of sessions currently
+    /// alive in this Office.
     var sessionId: String?
+
+    /// Tab-Keyed Offices (Wave 4) — the `tabId` this Office is bound to (or
+    /// a synthetic tabId == sessionId for legacy `cli`/`vscode` sessions).
+    /// Drives the new Office Manager UI and the sprite/agent event routing.
+    var tabId: String?
+
+    /// Tab-Keyed Offices (Wave 4) — all Claude sessions currently active
+    /// inside this tab. Humans are scoped `(tabId, sessionId)`; dogs live at
+    /// the tab level. Populated/drained by `tab.session.started` /
+    /// `tab.session.ended` handling in Wave 4 wiring.
+    var activeSessionIds: Set<String> = []
 
     /// Per-session role→CharacterType bindings (role-stable binding).
     /// First spawn for a canonical role locks the CharacterType for the session.

--- a/ios/MajorTom/Features/Office/Views/OfficeManagerView.swift
+++ b/ios/MajorTom/Features/Office/Views/OfficeManagerView.swift
@@ -26,7 +26,7 @@ struct OfficeManagerView: View {
                 .background(MajorTomTheme.Colors.background)
                 .navigationDestination(for: String.self) { tabId in
                     OfficeView(
-                        sessionId: tabId,
+                        tabId: tabId,
                         sceneManager: sceneManager,
                         relay: relay
                     )

--- a/ios/MajorTom/Features/Office/Views/OfficeManagerView.swift
+++ b/ios/MajorTom/Features/Office/Views/OfficeManagerView.swift
@@ -62,10 +62,9 @@ struct OfficeManagerView: View {
 
     private func navigateToBannerSession(_ banner: OfficeSceneManager.CrossSessionBanner) {
         cancelBannerAutoHide()
-        // Banner still carries sessionId today — routed through the smart
-        // lookup on OfficeSceneManager. Wave 4 commit #5 threads tabId
-        // onto the banner so cross-session taps navigate by tabId.
-        let target = banner.sessionId
+        // Prefer tabId from the event (Wave 4); fall back to sessionId for
+        // legacy cli/vscode sessions that never bind to a tab.
+        let target = banner.routeKey
         if sceneManager.viewModel(for: target) == nil
             || sceneManager.peekScene(for: target) == nil {
             sceneManager.createOffice(for: target)

--- a/ios/MajorTom/Features/Office/Views/OfficeManagerView.swift
+++ b/ios/MajorTom/Features/Office/Views/OfficeManagerView.swift
@@ -93,7 +93,7 @@ struct OfficeManagerView: View {
 
     @ViewBuilder
     private var scrollContent: some View {
-        let activeIds = sceneManager.linkedSessionIds
+        let activeIds = sceneManager.linkedOfficeKeys
         let allTabs = sortedTabs(relay.tabRegistryStore.tabs)
         let activeTabs = allTabs.filter { activeIds.contains($0.tabId) }
         let availableTabs = allTabs.filter {

--- a/ios/MajorTom/Features/Office/Views/OfficeManagerView.swift
+++ b/ios/MajorTom/Features/Office/Views/OfficeManagerView.swift
@@ -2,9 +2,15 @@ import SwiftUI
 
 // MARK: - Office Manager View
 
-/// Root view for the Office tab. Displays a card grid of sessions,
-/// letting users create/navigate per-session Offices.
-/// Uses NavigationStack to push into individual OfficeViews.
+/// Root view for the Office tab. Displays a card grid of terminal tabs
+/// hosting Claude sessions, letting users create/navigate per-tab Offices.
+/// Uses NavigationStack to push into individual OfficeViews (keyed by tabId).
+///
+/// Tab-Keyed Offices (Wave 4) — the data source is `relay.tabRegistryStore`,
+/// populated by `tab.list.response` + `tab.session.*` broadcasts from the
+/// relay. Legacy `cli`/`vscode` SDK sessions are not surfaced here (they
+/// continue to work via the synthetic-tabId fallback path inside
+/// `OfficeSceneManager`, but aren't listed as tabs).
 struct OfficeManagerView: View {
     var sceneManager: OfficeSceneManager
     var relay: RelayService
@@ -18,12 +24,20 @@ struct OfficeManagerView: View {
                 .navigationTitle("Offices")
                 .navigationBarTitleDisplayMode(.large)
                 .background(MajorTomTheme.Colors.background)
-                .navigationDestination(for: String.self) { sessionId in
+                .navigationDestination(for: String.self) { tabId in
                     OfficeView(
-                        sessionId: sessionId,
+                        sessionId: tabId,
                         sceneManager: sceneManager,
                         relay: relay
                     )
+                }
+                .task {
+                    // Fetch the latest tab list when the Office tab becomes
+                    // visible. Fixes the "sessionList never populated" bug
+                    // the session-keyed Office Manager had — the old code
+                    // relied on sessionList being pushed by the relay
+                    // pre-connection, which didn't always happen.
+                    try? await relay.requestTabList()
                 }
         }
         .overlay(alignment: .top) {
@@ -48,12 +62,16 @@ struct OfficeManagerView: View {
 
     private func navigateToBannerSession(_ banner: OfficeSceneManager.CrossSessionBanner) {
         cancelBannerAutoHide()
-        if sceneManager.viewModel(for: banner.sessionId) == nil
-            || sceneManager.peekScene(for: banner.sessionId) == nil {
-            sceneManager.createOffice(for: banner.sessionId)
+        // Banner still carries sessionId today — routed through the smart
+        // lookup on OfficeSceneManager. Wave 4 commit #5 threads tabId
+        // onto the banner so cross-session taps navigate by tabId.
+        let target = banner.sessionId
+        if sceneManager.viewModel(for: target) == nil
+            || sceneManager.peekScene(for: target) == nil {
+            sceneManager.createOffice(for: target)
         }
         navigationPath = NavigationPath()
-        navigationPath.append(banner.sessionId)
+        navigationPath.append(target)
     }
 
     private func rescheduleBannerAutoHide(for banner: OfficeSceneManager.CrossSessionBanner?) {
@@ -77,28 +95,32 @@ struct OfficeManagerView: View {
     @ViewBuilder
     private var scrollContent: some View {
         let activeIds = sceneManager.linkedSessionIds
-        let allSessions = relay.sessionList
-        let activeSessions = allSessions.filter { activeIds.contains($0.id) }
-        let unlinkedSessions = allSessions.filter { !activeIds.contains($0.id) }
+        let allTabs = sortedTabs(relay.tabRegistryStore.tabs)
+        let activeTabs = allTabs.filter { activeIds.contains($0.tabId) }
+        let availableTabs = allTabs.filter {
+            !activeIds.contains($0.tabId)
+                && !$0.sessions.isEmpty
+                && $0.status != "closed"
+        }
 
-        if allSessions.isEmpty {
+        if allTabs.isEmpty {
             emptyState
         } else {
             ScrollView {
                 LazyVStack(alignment: .leading, spacing: MajorTomTheme.Spacing.lg) {
-                    // Active offices
-                    if !activeSessions.isEmpty {
+                    // Active offices — tabs the user has already materialized
+                    if !activeTabs.isEmpty {
                         sectionHeader("Active Offices")
-                        ForEach(activeSessions) { session in
-                            activeOfficeCard(session: session)
+                        ForEach(activeTabs) { tab in
+                            activeOfficeCard(tab: tab)
                         }
                     }
 
-                    // Unlinked sessions
-                    if !unlinkedSessions.isEmpty {
-                        sectionHeader("Available Sessions")
-                        ForEach(unlinkedSessions) { session in
-                            unlinkedSessionCard(session: session)
+                    // Available tabs — have active claude sessions, not yet opened
+                    if !availableTabs.isEmpty {
+                        sectionHeader("Available Tabs")
+                        ForEach(availableTabs) { tab in
+                            availableTabCard(tab: tab)
                         }
                     }
                 }
@@ -109,18 +131,28 @@ struct OfficeManagerView: View {
         }
     }
 
+    /// Sort tabs newest-first by `lastSeenAt`, falling back to `createdAt`
+    /// when the relay hasn't populated timestamps yet.
+    private func sortedTabs(_ tabs: [String: TabMeta]) -> [TabMeta] {
+        tabs.values.sorted { lhs, rhs in
+            let lhsKey = lhs.lastSeenAt.isEmpty ? lhs.createdAt : lhs.lastSeenAt
+            let rhsKey = rhs.lastSeenAt.isEmpty ? rhs.createdAt : rhs.lastSeenAt
+            return lhsKey > rhsKey
+        }
+    }
+
     // MARK: - Empty State
 
     private var emptyState: some View {
         VStack(spacing: MajorTomTheme.Spacing.lg) {
             Spacer()
-            Image(systemName: "antenna.radiowaves.left.and.right.slash")
+            Image(systemName: "apple.terminal")
                 .font(.system(size: 48))
                 .foregroundStyle(MajorTomTheme.Colors.textTertiary)
-            Text("No Active Sessions")
+            Text("No Claude Tabs Yet")
                 .font(.system(.title3, design: .monospaced, weight: .semibold))
                 .foregroundStyle(MajorTomTheme.Colors.textSecondary)
-            Text("Connect to a relay and start a session to create an office.")
+            Text("Run `claude` in a terminal tab to spin up an office.")
                 .font(.system(.body, design: .monospaced))
                 .foregroundStyle(MajorTomTheme.Colors.textTertiary)
                 .multilineTextAlignment(.center)
@@ -141,12 +173,14 @@ struct OfficeManagerView: View {
 
     // MARK: - Active Office Card
 
-    private func activeOfficeCard(session: SessionMetaInfo) -> some View {
-        let agentCount = sceneManager.viewModel(for: session.id)?.agents.filter { $0.linkedSubagentId != nil }.count ?? 0
+    private func activeOfficeCard(tab: TabMeta) -> some View {
+        let vm = sceneManager.viewModel(for: tab.tabId)
+        let agentCount = vm?.agents.filter { $0.linkedSubagentId != nil }.count ?? 0
+        let displayName = tab.workingDirName.isEmpty ? "Terminal" : tab.workingDirName
 
         return Button {
             HapticService.selection()
-            navigationPath.append(session.id)
+            navigationPath.append(tab.tabId)
         } label: {
             HStack(spacing: MajorTomTheme.Spacing.md) {
                 // Icon
@@ -159,7 +193,7 @@ struct OfficeManagerView: View {
 
                 // Info
                 VStack(alignment: .leading, spacing: MajorTomTheme.Spacing.xs) {
-                    Text(session.workingDirName)
+                    Text(displayName)
                         .font(.system(.body, design: .monospaced, weight: .semibold))
                         .foregroundStyle(MajorTomTheme.Colors.textPrimary)
                         .lineLimit(1)
@@ -169,7 +203,11 @@ struct OfficeManagerView: View {
                             .font(.system(.caption, design: .monospaced))
                             .foregroundStyle(MajorTomTheme.Colors.textSecondary)
 
-                        statusBadge(session.status)
+                        Label("\(tab.sessions.count)", systemImage: "bubble.left")
+                            .font(.system(.caption, design: .monospaced))
+                            .foregroundStyle(MajorTomTheme.Colors.textSecondary)
+
+                        statusBadge(effectiveStatus(for: tab))
                     }
                 }
 
@@ -190,13 +228,14 @@ struct OfficeManagerView: View {
         .buttonStyle(.plain)
     }
 
-    // MARK: - Unlinked Session Card
+    // MARK: - Available Tab Card
 
-    private func unlinkedSessionCard(session: SessionMetaInfo) -> some View {
-        Button {
+    private func availableTabCard(tab: TabMeta) -> some View {
+        let displayName = tab.workingDirName.isEmpty ? "Terminal" : tab.workingDirName
+        return Button {
             HapticService.selection()
-            sceneManager.createOffice(for: session.id)
-            navigationPath.append(session.id)
+            sceneManager.createOffice(for: tab.tabId)
+            navigationPath.append(tab.tabId)
         } label: {
             HStack(spacing: MajorTomTheme.Spacing.md) {
                 // Icon
@@ -209,14 +248,18 @@ struct OfficeManagerView: View {
 
                 // Info
                 VStack(alignment: .leading, spacing: MajorTomTheme.Spacing.xs) {
-                    Text(session.workingDirName)
+                    Text(displayName)
                         .font(.system(.body, design: .monospaced, weight: .medium))
                         .foregroundStyle(MajorTomTheme.Colors.textSecondary)
                         .lineLimit(1)
 
-                    Text("Tap to create office")
-                        .font(.system(.caption, design: .monospaced))
-                        .foregroundStyle(MajorTomTheme.Colors.textTertiary)
+                    HStack(spacing: MajorTomTheme.Spacing.sm) {
+                        Text("Tap to create office")
+                            .font(.system(.caption, design: .monospaced))
+                            .foregroundStyle(MajorTomTheme.Colors.textTertiary)
+
+                        statusBadge(effectiveStatus(for: tab))
+                    }
                 }
 
                 Spacer()
@@ -237,6 +280,13 @@ struct OfficeManagerView: View {
     }
 
     // MARK: - Status Badge
+
+    /// Normalize the relay-supplied status to one of `active` / `idle` /
+    /// `closed` based on whether any sessions are still running in the tab.
+    private func effectiveStatus(for tab: TabMeta) -> String {
+        if tab.status == "closed" { return "closed" }
+        return tab.sessions.isEmpty ? "idle" : "active"
+    }
 
     private func statusBadge(_ status: String) -> some View {
         let color: Color = switch status {

--- a/ios/MajorTom/Features/Office/Views/OfficeView.swift
+++ b/ios/MajorTom/Features/Office/Views/OfficeView.swift
@@ -22,9 +22,12 @@ private enum OfficeSheetType: Identifiable {
 
 /// SwiftUI wrapper for the SpriteKit office scene.
 /// Manages the bridge between OfficeViewModel state changes and the SKScene.
-/// Now session-aware: gets its viewModel and scene from OfficeSceneManager.
+///
+/// Tab-Keyed Offices (Wave 4) — keyed by `tabId`, not sessionId. A tab can
+/// host multiple concurrent Claude sessions; legacy cli/vscode Offices use
+/// their sessionId as a synthetic tabId (resolved inside `OfficeSceneManager`).
 struct OfficeView: View {
-    let sessionId: String
+    let tabId: String
     var sceneManager: OfficeSceneManager
     var relay: RelayService?
 
@@ -73,12 +76,12 @@ struct OfficeView: View {
 
     /// Resolved viewModel from the scene manager.
     private var viewModel: OfficeViewModel? {
-        sceneManager.viewModel(for: sessionId)
+        sceneManager.viewModel(for: tabId)
     }
 
     /// Resolved scene — reads from @State (set in onAppear) or peeks without side effects.
     private var currentScene: OfficeScene? {
-        activatedScene ?? sceneManager.peekScene(for: sessionId)
+        activatedScene ?? sceneManager.peekScene(for: tabId)
     }
 
     var body: some View {
@@ -103,7 +106,7 @@ struct OfficeView: View {
             // Activate the scene at the top level so it runs regardless of which
             // branch rendered (content vs placeholder). If the scene was LRU-evicted,
             // this triggers a cold rebuild and populates @State so the view re-renders.
-            activatedScene = sceneManager.activateOffice(for: sessionId)
+            activatedScene = sceneManager.activateOffice(for: tabId)
         }
         .navigationBarTitleDisplayMode(.inline)
         .toolbar {
@@ -116,7 +119,7 @@ struct OfficeView: View {
             }
             ToolbarItem(placement: .topBarTrailing) {
                 Button {
-                    sceneManager.closeOffice(for: sessionId)
+                    sceneManager.closeOffice(for: tabId)
                     dismiss()
                 } label: {
                     Label("Close Office", systemImage: "xmark.circle")
@@ -753,7 +756,7 @@ struct OfficeView: View {
 #Preview {
     NavigationStack {
         OfficeView(
-            sessionId: "preview",
+            tabId: "preview",
             sceneManager: {
                 let mgr = OfficeSceneManager()
                 mgr.createOffice(for: "preview")

--- a/ios/MajorTom/Features/Terminal/ViewModels/TerminalViewModel.swift
+++ b/ios/MajorTom/Features/Terminal/ViewModels/TerminalViewModel.swift
@@ -144,34 +144,30 @@ final class TerminalViewModel {
         self.auth = auth
         self.keybarViewModel = KeybarViewModel(auth: auth)
 
-        // Restore persisted tab IDs, or create default.
-        // Previously, every app launch generated a random UUID → new tabId
-        // → fresh PTY on the relay. By persisting and restoring tab IDs we
-        // reconnect to the SAME PTY sessions across launches (assuming the
-        // relay still holds them through its 30-min disconnect grace).
+        // Restore persisted tab IDs. Tab-Keyed Offices (Wave 4) — we no
+        // longer auto-spawn a default tab on empty; the user explicitly
+        // creates every terminal via the "New Terminal" action. Previously
+        // a cold launch without saved tabs materialized an unwanted PTY
+        // (and sometimes an unwanted Office card) before the user did
+        // anything intentional.
         let defaults = UserDefaults.standard
         let savedTabIds = defaults.stringArray(forKey: Self.persistedTabIdsKey) ?? []
         let savedActiveId = defaults.string(forKey: Self.persistedActiveTabIdKey)
         let savedUserTitles = defaults.dictionary(forKey: Self.persistedTabUserTitlesKey) as? [String: String] ?? [:]
 
-        if !savedTabIds.isEmpty {
-            self.tabs = savedTabIds.map { tabId in
-                TerminalTab(
-                    tabId: tabId,
-                    title: "Terminal",
-                    userTitle: savedUserTitles[tabId],
-                    isActive: tabId == savedActiveId
-                )
-            }
-            // Ensure at least one tab is active.
-            if !self.tabs.contains(where: { $0.isActive }) {
-                self.tabs[0].isActive = true
-            }
-        } else {
-            // First launch — create a default tab and persist it.
-            let initialTab = TerminalTab(title: "Terminal", isActive: true)
-            self.tabs = [initialTab]
-            persistTabIds()
+        self.tabs = savedTabIds.map { tabId in
+            TerminalTab(
+                tabId: tabId,
+                title: "Terminal",
+                userTitle: savedUserTitles[tabId],
+                isActive: tabId == savedActiveId
+            )
+        }
+
+        // If there are tabs but none are marked active, activate the first
+        // so a subsequent connect knows which PTY to attach to.
+        if !self.tabs.isEmpty, !self.tabs.contains(where: { $0.isActive }) {
+            self.tabs[0].isActive = true
         }
     }
 
@@ -247,11 +243,11 @@ final class TerminalViewModel {
             let before = tabs.count
             tabs = tabs.filter { relaySessions.contains($0.tabId) }
 
-            // If all our tabs were pruned, create a fresh default.
-            if tabs.isEmpty {
-                let newTab = TerminalTab(title: "Terminal", isActive: true)
-                tabs = [newTab]
-            } else if !tabs.contains(where: { $0.isActive }) {
+            // Tab-Keyed Offices (Wave 4) — if every local tab got pruned we
+            // leave `tabs` empty and let the TerminalView show its empty
+            // state. No more auto-spawning a fresh default PTY the user
+            // never asked for.
+            if !tabs.isEmpty, !tabs.contains(where: { $0.isActive }) {
                 tabs[0].isActive = true
             }
 
@@ -284,20 +280,22 @@ final class TerminalViewModel {
 
     /// Close a tab by its ID.
     ///
-    /// If the closed tab was active, switches to the nearest neighbor.
-    /// If it was the last tab, creates a fresh one (never zero tabs).
+    /// Tab-Keyed Offices (Wave 4) — closing the last tab leaves `tabs`
+    /// empty; TerminalView shows an explicit "New Terminal" empty state
+    /// rather than auto-spawning a fresh PTY. If the closed tab was the
+    /// active one (and others remain), we switch to the nearest neighbor.
     func closeTab(id: UUID) {
         guard let index = tabs.firstIndex(where: { $0.id == id }) else { return }
 
         let wasActive = tabs[index].isActive
         tabs.remove(at: index)
 
-        // Never allow zero tabs — create a fresh one.
         if tabs.isEmpty {
-            let newTab = TerminalTab(title: "Terminal", isActive: true)
-            tabs.append(newTab)
             persistTabIds()
-            pendingTabSwitch = newTab.tabId
+            // Clear any pending switch — there's nothing to connect to.
+            pendingTabSwitch = nil
+            connectionState = .disconnected
+            isReady = false
             return
         }
 

--- a/ios/MajorTom/Features/Terminal/Views/TerminalView.swift
+++ b/ios/MajorTom/Features/Terminal/Views/TerminalView.swift
@@ -362,44 +362,76 @@ struct TerminalView: View {
 
     @ViewBuilder
     private var terminalContent: some View {
-        switch viewModel.connectionState {
-        case .error(let message):
-            errorView(message: message)
-        default:
-            ZStack {
-                TerminalWebView(viewModel: viewModel)
-                    .onLongPressGesture(minimumDuration: 0.5) {
-                        toggleCopyMode()
-                    }
-
-                if viewModel.didTerminate {
-                    recoveryOverlay
-                }
-
-                if !viewModel.isReady {
-                    loadingOverlay
-                }
-
-                // Copy mode indicator overlay
-                if copyModeActive {
-                    VStack {
-                        HStack {
-                            Spacer()
-                            Text("COPY MODE")
-                                .font(.system(size: 10, weight: .bold, design: .monospaced))
-                                .foregroundStyle(MajorTomTheme.Colors.background)
-                                .padding(.horizontal, MajorTomTheme.Spacing.sm)
-                                .padding(.vertical, 2)
-                                .background(MajorTomTheme.Colors.accent)
-                                .clipShape(Capsule())
-                                .padding(MajorTomTheme.Spacing.sm)
+        if viewModel.tabs.isEmpty {
+            emptyTabsView
+        } else {
+            switch viewModel.connectionState {
+            case .error(let message):
+                errorView(message: message)
+            default:
+                ZStack {
+                    TerminalWebView(viewModel: viewModel)
+                        .onLongPressGesture(minimumDuration: 0.5) {
+                            toggleCopyMode()
                         }
-                        Spacer()
+
+                    if viewModel.didTerminate {
+                        recoveryOverlay
                     }
-                    .allowsHitTesting(false)
+
+                    if !viewModel.isReady {
+                        loadingOverlay
+                    }
+
+                    // Copy mode indicator overlay
+                    if copyModeActive {
+                        VStack {
+                            HStack {
+                                Spacer()
+                                Text("COPY MODE")
+                                    .font(.system(size: 10, weight: .bold, design: .monospaced))
+                                    .foregroundStyle(MajorTomTheme.Colors.background)
+                                    .padding(.horizontal, MajorTomTheme.Spacing.sm)
+                                    .padding(.vertical, 2)
+                                    .background(MajorTomTheme.Colors.accent)
+                                    .clipShape(Capsule())
+                                    .padding(MajorTomTheme.Spacing.sm)
+                            }
+                            Spacer()
+                        }
+                        .allowsHitTesting(false)
+                    }
                 }
             }
         }
+    }
+
+    // MARK: - Empty Tabs State (Wave 4)
+
+    /// Shown when there are no terminal tabs — cold launch, after closing
+    /// the last tab, or after `reconcileWithRelay` prunes every local tab.
+    /// The user explicitly creates every terminal from here; we never
+    /// auto-spawn a PTY the user didn't ask for.
+    private var emptyTabsView: some View {
+        ContentUnavailableView {
+            Label("No Terminal Tabs", systemImage: "apple.terminal")
+                .foregroundStyle(MajorTomTheme.Colors.textSecondary)
+        } description: {
+            Text("Open a tab to start a shell session. Running `claude` inside it will surface an Office.")
+                .foregroundStyle(MajorTomTheme.Colors.textTertiary)
+        } actions: {
+            Button {
+                HapticService.buttonTap()
+                viewModel.createTab()
+            } label: {
+                Label("New Terminal", systemImage: "plus")
+                    .font(MajorTomTheme.Typography.body)
+            }
+            .buttonStyle(.borderedProminent)
+            .tint(MajorTomTheme.Colors.accent)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(Color(red: 0.05, green: 0.05, blue: 0.07))
     }
 
     // MARK: - Loading State


### PR DESCRIPTION
## Summary

Wave 4 of Tab-Keyed Offices — the iOS client now keys Offices by
**tabId** instead of Claude sessionId, so Office identity matches the
user's mental model ("an Office lives inside a terminal tab"). Also
rips out the three auto-spawn-on-empty paths in the Terminal tab so
the user explicitly creates every PTY. Relay is unchanged; spec at
[`docs/PHASE-TAB-KEYED-OFFICES.md`](../blob/main/docs/PHASE-TAB-KEYED-OFFICES.md).

Covers spec §7 (iOS changes), §8 (L1–L12 lifecycle scenarios),
§10 (Wave 4 row), and §12 (success criteria).

## Changes

| Commit | Scope |
|---|---|
| `refactor(ios): rekey OfficeSceneManager to tabId with sessionId fallback` | Office key becomes tabId with a synthetic-tabId fallback for legacy cli/vscode sessions. `ensureViewModel` takes an optional `tabId` hint; RelayService forwards `event.tabId` for all tagged sprite/agent messages. |
| `feat(ios): OfficeViewModel tracks activeSessionIds for tab-scoped roster` | `tab.session.started` seeds the roster; `tab.session.ended` walks humans off (dogs stay); `tab.closed` tears the Office down. `session.ended` no-ops for tab-backed Offices so the legacy walk-off path doesn't nuke live tabs. |
| `feat(ios): OfficeManagerView lists tabs via TabRegistryStore` | UI reads from `relay.tabRegistryStore.tabs` and fires `requestTabList()` on appear. Two sections: **Active Offices** + **Available Tabs**. |
| `feat(ios): OfficeView route keyed by tabId` | `OfficeView(tabId:)` replaces `OfficeView(sessionId:)`; preview + navigationDestination updated. |
| `feat(ios): banner + notification routing by tabId` | `CrossSessionBanner.tabId`, `routeKey`, `NotificationService.postBtwResponseNotification(tabId:)`, Cool Beans callback is now `(sessionId, subagentId, tabId?)`, deep link format `majortom://office/{tabId}`. |
| `chore(ios): remove tabKeyedOffices feature flag` | Flag's job was to gate the routing flip; Wave 4 ships it unconditionally. |
| `feat(ios): explicit terminal lifecycle — no auto-spawn on empty` | Cold launch, `reconcileWithRelay` pruning, and `closeTab(last)` all leave `tabs` empty. `TerminalView` renders a `ContentUnavailableView` with an explicit "New Terminal" action. |

## Non-goals (deferred to Wave 5)

- Per-agent session binding (AgentState still has no `sessionId`, so
  `tab.session.ended` walks off **all** humans rather than filtering to
  the ending session). Fine for single-session tabs — Wave 5 refines for
  Gate A multi-claude-in-one-tab.
- Hard-kill PTY edge cases.
- Rekeying the on-disk sprite-mapping files (still sessionId-keyed;
  Office-level aggregation happens at runtime via TabRegistry lookup).
- Auto-navigating into a specific Office on notification tap — the
  payload carries the tabId now, but the TabView/NavigationStack
  coordination is not wired up. Primary tap still lands on the Office
  tab list.

## Test plan

### Compile verification (done)

- [x] iOS Simulator Debug build clean (iPhone 17 Pro).
- [x] iOS Device Debug build clean (Sean's iPhone, wireless, `-allowProvisioningUpdates`).
- [x] No new warnings beyond baseline (pre-existing `CGPoint: Hashable`
  iOS 18 warning + pre-existing `immutable property` Codable warnings
  left untouched).

### L1–L12 lifecycle scenarios (manual, device smoke test)

Deferred to post-merge device verification. Each scenario needs the
relay running + claude running inside a terminal tab, which didn't fit
this session's budget. The code paths exist; they just need eyes on
them.

- [ ] **L1** — Open new terminal tab, type nothing → nothing in Office
  Manager.
- [ ] **L2** — Type `claude` in tab → "Available Tabs" card appears
  within ~1s.
- [ ] **L3** — Tap card → Office opens, dogs walk in.
- [ ] **L4** — Subagent spawns → human fades in at a desk.
- [ ] **L5** — Type `exit` in claude → humans walk off, dogs stay,
  Office survives.
- [ ] **L6** — Run `claude` again in same tab → new humans fade back
  in, same Office, same dogs.
- [ ] **L7** — Close terminal tab → Office tears down after PTY grace.
- [ ] **L8** — Kill app / PTY drops mid-session → Office + sprites
  rehydrate from relay state on reattach (30-min grace).
- [ ] **L9** — Run `claude` in two tabs simultaneously → two Offices,
  independent sprites + /btw routing.
- [ ] **L10** — (deferred, Wave 5) `claude &` spawning a second session
  in the same tab.
- [ ] **L11** — Relay restart mid-session → TabRegistryStore rehydrates,
  humans come back as events re-fire.
- [ ] **L12** — `claude` from Ground Control (no PTY) → does NOT appear
  in Office Manager (legacy path).

### Explicit-lifecycle smoke (done on sim)

- [x] Cold launch with no persisted tabs → empty state with "New
  Terminal" action visible; no PTY connection attempt.
- [ ] Close the last tab → empty state returns (device check).
- [ ] `reconcileWithRelay` after relay was restarted with no matching
  sessions → empty state (device check).

### Notification routing

- [ ] `/btw` response notification while app backgrounded carries
  `tabId` in `userInfo`; "Cool Beans" clears the unread state on the
  correct Office in a two-tab simultaneous-claude scenario (device
  check).

### Regressions to watch

- Wave 2–3 sprite QA matrix — paused during this phase, should resume
  cleanly. No changes to sprite mapping persistence, role mapping, or
  the `/btw` delivery protocol.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
