### PR TITLE
feat(ios): Wave 5 — Tab-Keyed Offices session cycling + edge cases

### DIFF
--- a/ios/MajorTom/Core/Services/RelayService.swift
+++ b/ios/MajorTom/Core/Services/RelayService.swift
@@ -1316,7 +1316,11 @@ final class RelayService {
         case .tabClosed:
             if let event = try? MessageCodec.decode(TabClosedEvent.self, from: data) {
                 tabRegistryStore.remove(tabId: event.tabId)
-                officeSceneManager?.closeOffice(for: event.tabId)
+                // Wave 5: walk humans off before tearing the Office down.
+                // Covers the hard-kill PTY path where no graceful
+                // `tab.session.ended` precedes `tab.closed`. The scene
+                // manager handles the dismiss-then-close sequence.
+                officeSceneManager?.handleTabClosed(tabId: event.tabId)
             }
 
         case .tabListResponse:

--- a/ios/MajorTom/Core/Services/RelayService.swift
+++ b/ios/MajorTom/Core/Services/RelayService.swift
@@ -831,7 +831,7 @@ final class RelayService {
 
         case .agentSpawn:
             if let event = try? MessageCodec.decode(AgentSpawnEvent.self, from: data) {
-                officeSceneManager?.ensureViewModel(for: event.sessionId, tabId: event.tabId).handleAgentSpawn(id: event.agentId, role: event.role, task: event.task, parentId: event.parentId)
+                officeSceneManager?.ensureViewModel(for: event.sessionId, tabId: event.tabId).handleAgentSpawn(id: event.agentId, role: event.role, task: event.task, parentId: event.parentId, sessionId: event.sessionId)
                 notificationService?.postAgentSpawnNotification(
                     agentId: event.agentId,
                     role: event.role,

--- a/ios/MajorTom/Features/Office/Models/AgentState.swift
+++ b/ios/MajorTom/Features/Office/Models/AgentState.swift
@@ -82,6 +82,26 @@ struct AgentState: Identifiable {
     /// Needed for future multi-session routing (Wave 3).
     var parentId: String?
 
+    // MARK: - Tab-Keyed Offices (Wave 5)
+
+    /// The Claude `sessionId` that originated this agent.
+    ///
+    /// Populated on `agent.spawn` / `sprite.link` / `sprite.state` rehydration
+    /// and **preserved** across every state transition. Used by
+    /// `OfficeSceneManager.handleTabSessionEnded` to walk off only the agents
+    /// whose originating session ended — dogs (idle sprites) and agents
+    /// scoped to any other still-active session in the tab stay put.
+    ///
+    /// `nil` for idle cosmetic sprites (dogs + crew pool) and for agents that
+    /// slipped in before Wave 3 plumbing propagated the sessionId onto their
+    /// spawn path.
+    ///
+    /// NOTE: deliberately **not** included in the custom `Equatable` below —
+    /// sessionId is set once at spawn and never changes afterwards, so
+    /// omitting it keeps `.onChange(of: viewModel.agents)` diffing cheap and
+    /// avoids spurious walk-in triggers.
+    var sessionId: String?
+
     // MARK: - Overflow Placement (Wave 6 — S5)
 
     /// Pre-claimed overflow position when all 8 desks are occupied.
@@ -102,6 +122,7 @@ struct AgentState: Identifiable {
         spriteHandle: String? = nil,
         canonicalRole: String? = nil,
         parentId: String? = nil,
+        sessionId: String? = nil,
         overflowPosition: CGPoint? = nil
     ) {
         self.id = id
@@ -116,6 +137,7 @@ struct AgentState: Identifiable {
         self.spriteHandle = spriteHandle
         self.canonicalRole = canonicalRole
         self.parentId = parentId
+        self.sessionId = sessionId
         self.overflowPosition = overflowPosition
     }
 

--- a/ios/MajorTom/Features/Office/Models/AgentState.swift
+++ b/ios/MajorTom/Features/Office/Models/AgentState.swift
@@ -97,9 +97,10 @@ struct AgentState: Identifiable {
     /// spawn path.
     ///
     /// NOTE: deliberately **not** included in the custom `Equatable` below —
-    /// sessionId is set once at spawn and never changes afterwards, so
-    /// omitting it keeps `.onChange(of: viewModel.agents)` diffing cheap and
-    /// avoids spurious walk-in triggers.
+    /// sessionId may be populated at spawn or latched later when an existing
+    /// agent is upgraded on `sprite.link`, but once set it is expected to
+    /// remain stable. Omitting it keeps `.onChange(of: viewModel.agents)`
+    /// diffing cheap and avoids spurious walk-in triggers.
     var sessionId: String?
 
     // MARK: - Overflow Placement (Wave 6 — S5)

--- a/ios/MajorTom/Features/Office/ViewModels/OfficeSceneManager.swift
+++ b/ios/MajorTom/Features/Office/ViewModels/OfficeSceneManager.swift
@@ -294,6 +294,19 @@ final class OfficeSceneManager {
     /// session in the owning Office's roster (if the Office already exists)
     /// and seeds the session→tab reverse cache so subsequent events for this
     /// session route correctly even if they arrive without a `tabId` hint.
+    ///
+    /// Wave 5 note — **no explicit walk-in animation is fired here.** The
+    /// user-visible "new crew joining" moment is already produced by the
+    /// existing `agent.spawn` path: when the first subagent of the new
+    /// session lands, `OfficeViewModel.handleAgentSpawn` appends an
+    /// AgentState with `.spawning` status, the view inserts the sprite at
+    /// `OfficeLayout.doorPosition` via `OfficeScene.addAgent`, then
+    /// `moveAgentToDesk` pathfinds from the airlock to the assigned desk —
+    /// that airlock-to-desk walk IS the walk-in. A session without any
+    /// subagents produces no visible humans at all (by design), so a
+    /// session-start level animation would be a decoration without a
+    /// subject. If we ever want a pre-spawn "session lit up" feel, the
+    /// right hook is here; today it is deliberately empty.
     func handleTabSessionStarted(tabId: String, sessionId: String) {
         sessionToOfficeKey[sessionId] = tabId
 

--- a/ios/MajorTom/Features/Office/ViewModels/OfficeSceneManager.swift
+++ b/ios/MajorTom/Features/Office/ViewModels/OfficeSceneManager.swift
@@ -313,9 +313,11 @@ final class OfficeSceneManager {
     }
 
     /// Called when the relay broadcasts `tab.session.ended`. Drops the
-    /// session from the Office's roster and walks off any active humans.
-    /// Dogs (idle sprites) stay. The Office itself survives — tab teardown
-    /// happens on `tab.closed` after PTY grace expires.
+    /// session from the Office's roster and walks off any active humans
+    /// **scoped to the ending session**. Dogs (idle sprites) stay, and
+    /// humans belonging to any other session still alive in this tab stay
+    /// too (Gate A — multi-claude in one tab). The Office itself survives;
+    /// tab teardown happens on `tab.closed` after PTY grace expires.
     func handleTabSessionEnded(tabId: String, sessionId: String) {
         sessionToOfficeKey.removeValue(forKey: sessionId)
 
@@ -329,11 +331,16 @@ final class OfficeSceneManager {
             vm.sessionId = vm.activeSessionIds.first
         }
 
-        // Walk off every non-idle agent sprite. Wave 4 intentionally walks
-        // off *all* humans rather than filtering to the ending session —
-        // Wave 5 refines this once agents carry a session binding.
-        let humanIds = vm.agents.filter { !$0.id.hasPrefix("idle-") }.map(\.id)
-        for id in humanIds {
+        // Wave 5: walk off only the agents whose originating session is the
+        // one that just ended. Agents bound to sibling sessions in the same
+        // tab (Gate A) survive, as do dogs (sessionId == nil). Any agent that
+        // slipped in pre-Wave-3 without a sessionId would also survive here —
+        // acceptable since such legacy agents are rare and get cleaned up by
+        // the full-tab walk-off on `tab.closed` (Commit 4).
+        let endingIds = vm.agents
+            .filter { !$0.id.hasPrefix("idle-") && $0.sessionId == sessionId }
+            .map(\.id)
+        for id in endingIds {
             vm.handleAgentDismissed(id: id)
         }
     }

--- a/ios/MajorTom/Features/Office/ViewModels/OfficeSceneManager.swift
+++ b/ios/MajorTom/Features/Office/ViewModels/OfficeSceneManager.swift
@@ -376,9 +376,9 @@ final class OfficeSceneManager {
 
     /// Wave 5: graceful teardown on `tab.closed`. Walks off every agent
     /// scoped to any session in the tab, then tears down the Office after
-    /// `tabClosedTeardownGraceSeconds` so the dismiss animation has time to
-    /// finish (matches the ~1.5s walk-to-door + despawn timeline inside
-    /// `handleAgentDismissed`).
+    /// `tabClosedTeardownGraceMilliseconds` so the dismiss animation has
+    /// time to finish (matches the ~1.5s walk-to-door + despawn timeline
+    /// inside `handleAgentDismissed`).
     ///
     /// Covers the hard-kill PTY path: when the relay broadcasts
     /// `tab.closed` without a preceding `tab.session.ended` (e.g. PTY grace

--- a/ios/MajorTom/Features/Office/ViewModels/OfficeSceneManager.swift
+++ b/ios/MajorTom/Features/Office/ViewModels/OfficeSceneManager.swift
@@ -374,6 +374,54 @@ final class OfficeSceneManager {
         sessionToOfficeKey = sessionToOfficeKey.filter { $0.value != officeKey }
     }
 
+    /// Wave 5: graceful teardown on `tab.closed`. Walks off every agent
+    /// scoped to any session in the tab, then tears down the Office after
+    /// `tabClosedTeardownGraceSeconds` so the dismiss animation has time to
+    /// finish (matches the ~1.5s walk-to-door + despawn timeline inside
+    /// `handleAgentDismissed`).
+    ///
+    /// Covers the hard-kill PTY path: when the relay broadcasts
+    /// `tab.closed` without a preceding `tab.session.ended` (e.g. PTY grace
+    /// expired mid-session), this is the only place humans get walked off
+    /// before the Office evaporates. If `tab.session.ended` already fired
+    /// for a session, its dismiss Tasks are still in flight — we don't
+    /// cancel those, and the idempotent `handleAgentDismissed` guard
+    /// (`guard agents.contains(where:)`) keeps re-firing harmless.
+    func handleTabClosed(tabId: String) {
+        let officeKey = resolvedOfficeKey(tabId)
+
+        guard let vm = offices[officeKey]?.viewModel else {
+            // No Office materialized — nothing to walk off. Clean up the
+            // reverse cache below for consistency.
+            sessionToOfficeKey = sessionToOfficeKey.filter { $0.value != officeKey }
+            return
+        }
+
+        // Walk off every non-idle sprite in the Office regardless of
+        // sessionId. Dogs (idle sprites) stay put for the grace window and
+        // get torn down with the scene.
+        let humanIds = vm.agents
+            .filter { !$0.id.hasPrefix("idle-") }
+            .map(\.id)
+        for id in humanIds {
+            vm.handleAgentDismissed(id: id)
+        }
+
+        // Delay the actual Office teardown so the dismiss animations have
+        // time to play out. If there are no humans to walk off we still
+        // apply the grace (cheap), which keeps the code path trivially
+        // predictable.
+        Task { @MainActor [weak self] in
+            try? await Task.sleep(for: .milliseconds(Self.tabClosedTeardownGraceMilliseconds))
+            self?.closeOffice(for: officeKey)
+        }
+    }
+
+    /// Grace window between the `tab.closed` walk-off and the Office
+    /// teardown. Matches the sprite dismiss animation timeline in
+    /// `handleAgentDismissed` (warmup + 1.5s leaving pose).
+    private static let tabClosedTeardownGraceMilliseconds: Int = 1_500
+
     /// Keys (tabId or synthetic sessionId) of offices that have a full scene.
     /// Excludes lightweight entries created by `ensureViewModel` that were
     /// never upgraded via `createOffice`.

--- a/ios/MajorTom/Features/Office/ViewModels/OfficeViewModel.swift
+++ b/ios/MajorTom/Features/Office/ViewModels/OfficeViewModel.swift
@@ -214,7 +214,11 @@ final class OfficeViewModel {
     /// Clone-not-consume: creates a NEW agent sprite instance without consuming idle sprites.
     /// Uses RoleMapper for deterministic role→CharacterType assignment with session-stable binding.
     /// Dogs are NEVER assigned as agent sprites.
-    func handleAgentSpawn(id: String, role: String, task: String, parentId: String? = nil) {
+    ///
+    /// Wave 5: `sessionId` binds the agent to its originating Claude session so
+    /// `tab.session.ended` can walk off only that session's humans. Preserved
+    /// across every subsequent state transition in this VM.
+    func handleAgentSpawn(id: String, role: String, task: String, parentId: String? = nil, sessionId: String? = nil) {
         guard !agents.contains(where: { $0.id == id }) else { return }
 
         // Resolve CharacterType via role-stable binding (clone-not-consume)
@@ -238,6 +242,7 @@ final class OfficeViewModel {
             linkedSubagentId: id,
             canonicalRole: role,
             parentId: parentId,
+            sessionId: sessionId,
             overflowPosition: placement.overflowPosition
         )
         agents.append(agent)
@@ -553,6 +558,10 @@ final class OfficeViewModel {
             agents[existingIndex].linkedSubagentId = event.subagentId
             agents[existingIndex].canonicalRole = event.canonicalRole
             agents[existingIndex].parentId = event.parentId
+            // Wave 5: latch sessionId if the prior spawn event didn't carry one.
+            if agents[existingIndex].sessionId == nil {
+                agents[existingIndex].sessionId = event.sessionId
+            }
             if !event.task.isEmpty {
                 agents[existingIndex].currentTask = event.task
             }
@@ -587,6 +596,7 @@ final class OfficeViewModel {
             spriteHandle: event.spriteHandle,
             canonicalRole: event.canonicalRole,
             parentId: event.parentId,
+            sessionId: event.sessionId,
             overflowPosition: placement.overflowPosition
         )
         agents.append(agent)
@@ -914,6 +924,10 @@ final class OfficeViewModel {
             // S5 — placement cascade: desk first, then overflow.
             let placement = assignPlacement(to: mapping.subagentId)
 
+            // Wave 5: `SpriteStateEvent.SpriteMapping` does not carry sessionId
+            // or tabId on the wire — only the enclosing event does. Stamp the
+            // event's top-level sessionId onto every rebuilt agent so
+            // `tab.session.ended` walk-off can scope correctly.
             let agent = AgentState(
                 id: mapping.subagentId,
                 name: mapping.canonicalRole.capitalized,
@@ -926,6 +940,7 @@ final class OfficeViewModel {
                 spriteHandle: mapping.spriteHandle,
                 canonicalRole: mapping.canonicalRole,
                 parentId: mapping.parentId,
+                sessionId: event.sessionId,
                 overflowPosition: placement.overflowPosition
             )
             agents.append(agent)

--- a/ios/MajorTom/Features/Office/ViewModels/OfficeViewModel.swift
+++ b/ios/MajorTom/Features/Office/ViewModels/OfficeViewModel.swift
@@ -66,7 +66,27 @@ final class OfficeViewModel {
 
     /// Per-session role→CharacterType bindings (role-stable binding).
     /// First spawn for a canonical role locks the CharacterType for the session.
-    var sessionRoleBindings: RoleMapper.SessionBindings = [:]
+    ///
+    /// Wave 5 (Gate A — multi-claude-in-one-tab): keyed by `sessionId` so
+    /// sibling sessions living in the same Office don't stomp each other's
+    /// role→character maps. The empty-string key holds bindings for events
+    /// that arrive without a `sessionId` (pre-Wave-3 legacy paths) so the
+    /// role-stable guarantee still applies to them in isolation.
+    var sessionRoleBindingsByKey: [String: RoleMapper.SessionBindings] = [:]
+
+    /// Accessor — returns (and lazily creates) the role bindings for a
+    /// specific `sessionId`. `nil` routes to the empty-string bucket so
+    /// legacy events that never carried a sessionId still get a stable
+    /// binding set without contaminating real sessions' maps.
+    private func roleBindings(for sessionId: String?) -> RoleMapper.SessionBindings {
+        sessionRoleBindingsByKey[sessionId ?? ""] ?? [:]
+    }
+
+    /// Write an updated binding set for a specific `sessionId` — symmetric
+    /// with `roleBindings(for:)`.
+    private func setRoleBindings(_ bindings: RoleMapper.SessionBindings, for sessionId: String?) {
+        sessionRoleBindingsByKey[sessionId ?? ""] = bindings
+    }
 
     // MARK: - Sprite Messaging (Wave 4)
 
@@ -221,12 +241,14 @@ final class OfficeViewModel {
     func handleAgentSpawn(id: String, role: String, task: String, parentId: String? = nil, sessionId: String? = nil) {
         guard !agents.contains(where: { $0.id == id }) else { return }
 
-        // Resolve CharacterType via role-stable binding (clone-not-consume)
+        // Resolve CharacterType via role-stable binding (clone-not-consume).
+        // Wave 5 Gate A: bindings are per-session so sibling sessions in the
+        // same tab don't collide on role→character locks.
         let (characterType, updatedBindings) = RoleMapper.resolveCharacterType(
             role: role,
-            sessionBindings: sessionRoleBindings
+            sessionBindings: roleBindings(for: sessionId)
         )
-        sessionRoleBindings = updatedBindings
+        setRoleBindings(updatedBindings, for: sessionId)
 
         // S5 — placement cascade: desk first, then overflow.
         let placement = assignPlacement(to: id)
@@ -573,12 +595,13 @@ final class OfficeViewModel {
             return
         }
 
-        // Resolve CharacterType via role-stable binding
+        // Resolve CharacterType via role-stable binding (Wave 5 Gate A:
+        // scoped to the event's sessionId so sibling sessions don't collide).
         let (characterType, updatedBindings) = RoleMapper.resolveCharacterType(
             role: event.canonicalRole,
-            sessionBindings: sessionRoleBindings
+            sessionBindings: roleBindings(for: event.sessionId)
         )
-        sessionRoleBindings = updatedBindings
+        setRoleBindings(updatedBindings, for: event.sessionId)
 
         // Use subagentId as primary ID so agent.* lifecycle handlers find this agent
         // S5 — placement cascade: desk first, then overflow.
@@ -736,6 +759,15 @@ final class OfficeViewModel {
     /// Begin a pending `/btw` for a linked sprite. Caller (RelayService/view) is
     /// responsible for actually dispatching the WebSocket send when connected.
     /// Returns the queued message descriptor so the caller can submit it.
+    ///
+    /// Wave 5 (Gate A — multi-claude-in-one-tab): the queued message is
+    /// stamped with the **tapped agent's** `sessionId` when available, NOT
+    /// the Office's "primary" `vm.sessionId`. Sibling sessions in the same
+    /// tab each have their own agents, and tapping one of them must route
+    /// its `/btw` back to the owning session even if the VM's primary
+    /// pointer has rotated. Falls back to `vm.sessionId` only when the
+    /// tapped agent has no stamped sessionId (pre-Wave-3 legacy entry or
+    /// stale rehydrate state).
     @discardableResult
     func beginPendingMessage(
         spriteId: String,
@@ -748,7 +780,11 @@ final class OfficeViewModel {
         guard !trimmed.isEmpty else { return nil }
         guard case .idle = messagingState(for: spriteId) else { return nil }
 
-        let sid = sessionId ?? ""
+        // Route per-agent: prefer the tapped sprite's own sessionId, fall
+        // back to the VM's primary sessionId (legacy/unstamped agents), and
+        // finally to an empty string if neither is set.
+        let agentSessionId = agents.first(where: { $0.id == spriteId })?.sessionId
+        let sid = agentSessionId ?? sessionId ?? ""
         let messageId = UUID().uuidString
 
         setMessagingState(.pending(messageId: messageId, question: trimmed), for: spriteId)
@@ -916,19 +952,19 @@ final class OfficeViewModel {
             removeAgent(id: id)
         }
 
-        // Role bindings are keyed per-session downstream of RoleMapper; a
-        // rebuild for one session legitimately replays those bindings. In
-        // the Gate A case role-stable binding still works because the
-        // clone-not-consume model shares CharacterTypes across sessions.
-        sessionRoleBindings = [:]
+        // Wave 5 Gate A: only reset bindings for the session being
+        // rehydrated. Sibling sessions living in the same Office keep their
+        // role→character locks so their subsequent spawn/link events stay
+        // stable.
+        setRoleBindings([:], for: event.sessionId)
 
         // Rebuild from relay mappings — primary key is subagentId
         for mapping in event.mappings {
             let (characterType, updatedBindings) = RoleMapper.resolveCharacterType(
                 role: mapping.canonicalRole,
-                sessionBindings: sessionRoleBindings
+                sessionBindings: roleBindings(for: event.sessionId)
             )
-            sessionRoleBindings = updatedBindings
+            setRoleBindings(updatedBindings, for: event.sessionId)
 
             let status: AgentStatus
             switch mapping.status {

--- a/ios/MajorTom/Features/Office/ViewModels/OfficeViewModel.swift
+++ b/ios/MajorTom/Features/Office/ViewModels/OfficeViewModel.swift
@@ -888,21 +888,38 @@ final class OfficeViewModel {
     }
 
     /// Handle `sprite.state` — bulk restore all sprite mappings (reconnect).
-    /// Clears any existing agent sprites (non-idle) and rebuilds from relay state.
-    /// Uses `subagentId` as the primary AgentState.id so agent.* handlers find them.
+    /// Clears existing agent sprites **belonging to this event's sessionId**
+    /// and rebuilds them from relay state. Uses `subagentId` as the primary
+    /// AgentState.id so agent.* handlers find them.
+    ///
+    /// Wave 5 (Gate A — multi-claude-in-one-tab): the earlier "clear ALL
+    /// non-idle agents" behavior deleted sibling-session sprites from the
+    /// same Office whenever any session sent a sprite.state. Now the clear
+    /// is scoped to agents whose `sessionId` matches the event — agents
+    /// belonging to other concurrent sessions in the tab survive.
     func handleSpriteState(_ event: SpriteStateEvent) {
         // Latch sessionId if not already set (e.g. pre-Wave-3 compat)
         if sessionId == nil {
             sessionId = event.sessionId
         }
 
-        // Remove all existing non-idle agent sprites
-        let nonIdleIds = agents.filter { !isIdleSprite($0.id) }.map(\.id)
-        for id in nonIdleIds {
+        // Remove existing non-idle agent sprites scoped to this session.
+        // Agents with `sessionId == nil` (pre-Wave-3 legacy) are also wiped
+        // here — they share the event's session by virtue of having no
+        // other provenance, and leaving them behind would mask relay state.
+        let scopedIds = agents
+            .filter {
+                !isIdleSprite($0.id) && ($0.sessionId == event.sessionId || $0.sessionId == nil)
+            }
+            .map(\.id)
+        for id in scopedIds {
             removeAgent(id: id)
         }
 
-        // Reset role bindings for this session
+        // Role bindings are keyed per-session downstream of RoleMapper; a
+        // rebuild for one session legitimately replays those bindings. In
+        // the Gate A case role-stable binding still works because the
+        // clone-not-consume model shares CharacterTypes across sessions.
         sessionRoleBindings = [:]
 
         // Rebuild from relay mappings — primary key is subagentId


### PR DESCRIPTION
## Summary

Wave 5 of the Tab-Keyed Offices phase — per-session agent scoping
inside shared tab Offices. References spec §7 (iOS changes), §8 (L1–L12
lifecycle scenarios, specifically L5/L6/L7/L10), §10 (Wave 5 row), §12
(success criteria).

Wave 4 walked off every human in a tab whenever any session ended,
because AgentState had no session binding. Wave 5 threads a `sessionId`
onto each human and uses it to refine the walk-off + teardown paths:

- `tab.session.ended` walks off only the ending session's humans.
  Sibling-session humans (Gate A: multi-claude-in-one-tab) stay.
- `tab.closed` now walks every human off before tearing the Office
  down. Covers the hard-kill PTY path (no graceful `tab.session.ended`
  precedes `tab.closed`).
- Walk-in on a new `tab.session.started` inside an existing Office is
  a no-op commit — the existing airlock-to-desk walk triggered by the
  first subagent's `agent.spawn` already covers it.
- Bonus: Gate A routing bug fix in `handleSpriteState` — rehydration
  from one session no longer nukes sibling sessions' humans.

## Commits

- `c7d164e` — `feat(ios): bind AgentState to originating sessionId`
- `d86189a` — `feat(ios): scope tab.session.ended walk-off to owning session`
- `d836474` — `docs(ios): note existing .spawning animation covers Wave 5 walk-in`
- `66475ff` — `feat(ios): walk humans off before tearing down on tab.closed`
- `8a255f7` — `fix(ios): scope sprite.state rehydration to event sessionId (Gate A)`

## Spec coverage

| §12 success criterion | Covered by |
|---|---|
| AgentState.sessionId populated on spawn/link/state | Commit 1 |
| tab.session.ended walks only the ending session's humans | Commit 2 |
| Walk-in on tab.session.started deliberate or documented | Commit 3 (docstring) |
| tab.closed walks all humans off before teardown | Commit 4 |
| Gate A — multi-claude in one tab | Commits 1+2+5 |

Relay migration cleanup (spec §10 commit #6) and hard-kill relay tests
(commit #7) are out of scope for this PR — separate relay-side PR on
`tab-keyed-offices/wave5-relay`.

## Test plan

Device verification deferred to the parent session. Scenarios to
exercise on a physical device against a live relay:

- [ ] L1 — new terminal tab, no `claude` typed → no Office, no card
- [ ] L2 — `claude` in tab → "Available Tabs" card appears
- [ ] L3 — tap card → Office materializes, dogs walk in
- [ ] L4 — subagent spawn → human fades in at desk via airlock walk
- [ ] L5 — graceful `exit` in claude → only that session's humans walk
      off, dogs + sibling-session humans stay, Office idle survives
- [ ] L6 — restart `claude` in same tab → new humans walk in via the
      existing airlock animation, same dogs, same Office
- [ ] L7 — close terminal tab → humans walk off, then Office tears
      down after ~1.5s grace (hard-kill path)
- [ ] L8 — PTY drop + reattach within 30m → Office + sprites resume
      from relay state (sprite.state rehydration path)
- [ ] L9 — two tabs running `claude` concurrently → two Offices, each
      with its own roster
- [ ] L10 — Gate A: two `claude` invocations inside the same tab →
      one Office, both sessions' humans coexist; ending one leaves the
      other visible
- [ ] L11 — relay restart mid-session → TabRegistry rehydrates +
      sessions recover per normal reconnect flow
- [ ] L12 — `claude` from Ground Control (no tabId) → no Office Manager
      entry (legacy SDK-session path)

Simulator build is clean on the latest commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
