### PR TITLE
fix(ios,relay): rehydrate sprite state on reconnect + Office reopen (QA-FIXES #7)

### DIFF
--- a/ios/MajorTom/App/MajorTomApp.swift
+++ b/ios/MajorTom/App/MajorTomApp.swift
@@ -81,9 +81,13 @@ struct MajorTomApp: App {
             }
             // Wave 4: flush queued /btw messages when the relay reconnects so
             // any messages sent offline are delivered without user action.
+            // QA-FIXES #7: also re-hydrate sprite state for every open Office
+            // so subagents that spawned/died while the WS was down still
+            // render correctly after reconnect.
             .onChange(of: relay.connectionState) { _, newState in
                 if newState == .connected {
                     relay.flushAllQueuedSpriteMessages()
+                    officeSceneManager.refreshAllOpenOffices()
                 }
             }
             // Handle deep links from notifications

--- a/ios/MajorTom/Core/Services/RelayService.swift
+++ b/ios/MajorTom/Core/Services/RelayService.swift
@@ -1339,6 +1339,11 @@ final class RelayService {
             if let event = try? MessageCodec.decode(TabListResponseEvent.self, from: data) {
                 tabRegistryStore.replaceAll(with: event)
                 responseCounter &+= 1
+                // QA-FIXES #7: kill-and-relaunch can land a tap on an Office
+                // card before the tab list arrives. Once the roster is known,
+                // re-request sprite state for any Office whose seeding was
+                // empty at creation time.
+                officeSceneManager?.refreshAllOpenOffices()
             }
 
         case .error:

--- a/ios/MajorTom/Core/Services/RelayService.swift
+++ b/ios/MajorTom/Core/Services/RelayService.swift
@@ -1340,9 +1340,9 @@ final class RelayService {
                 tabRegistryStore.replaceAll(with: event)
                 responseCounter &+= 1
                 // QA-FIXES #7: kill-and-relaunch can land a tap on an Office
-                // card before the tab list arrives. Once the roster is known,
-                // re-request sprite state for any Office whose seeding was
-                // empty at creation time.
+                // card before the tab list arrives. Refresh all currently
+                // open Offices so any that were opened before the roster
+                // arrived can resolve their sprite state.
                 officeSceneManager?.refreshAllOpenOffices()
             }
 

--- a/ios/MajorTom/Features/Office/ViewModels/OfficeSceneManager.swift
+++ b/ios/MajorTom/Features/Office/ViewModels/OfficeSceneManager.swift
@@ -505,6 +505,21 @@ final class OfficeSceneManager {
         }
     }
 
+    /// Ask the relay for fresh sprite state for every Office that currently
+    /// has a live scene. Called on WS reattach and after `tab.list.response`
+    /// lands — both are points where the relay's sprite mappings may have
+    /// drifted from what the client last rendered (QA-FIXES #7).
+    ///
+    /// Re-seeds the session roster from `TabRegistryStore` first to cover
+    /// the race where a user tapped an Office card before the post-
+    /// reconnect tab list arrived (kill-and-relaunch path).
+    func refreshAllOpenOffices() {
+        for (key, entry) in offices where entry.hasOffice {
+            seedRosterFromTabRegistry(vm: entry.viewModel, officeKey: key)
+            requestSpriteStateForAllSessions(in: entry.viewModel)
+        }
+    }
+
     /// Seed the VM's session roster from `TabRegistryStore` metadata so
     /// sprite state requests target real sessionIds immediately — avoiding
     /// the race where `createOffice(for: tabId)` fires before any

--- a/relay/src/routes/ws.ts
+++ b/relay/src/routes/ws.ts
@@ -1055,11 +1055,39 @@ export function createWsRoute(deps: WsDeps): FastifyPluginAsync {
       case 'sprite.state.request': {
         const reqSessionId = message.sessionId;
 
-        // No per-session attach gate: iOS never calls `session.attach` for
+        // No per-session `session.attach` gate: iOS never calls it for
         // PTY-launched claude sessions (same reason `sprite.link`/
-        // `sprite.unlink` switched to `broadcastToAll` in QA-FIXES #11 Layer
-        // 1). Authentication at the WebSocket layer already gates access;
-        // sprite state fans out to every attached client anyway.
+        // `sprite.unlink` switched to `broadcastToAll` in QA-FIXES #11
+        // Layer 1). SandboxGuard still enforces per-user workingDir
+        // access in multi-user mode — mirrors `session.attach` so a
+        // viewer can't query sessions whose cwd is outside their sandbox.
+        // Persisted-only sessions skip the check to match
+        // `session.attach`'s persisted-only path.
+        if (sandboxGuard) {
+          const spriteUserId = presenceManager.getUserId(ws);
+          const spriteUserRole = presenceManager.getUserRole(ws);
+          if (spriteUserId && spriteUserRole) {
+            const liveSession = sessionManager.tryGet(reqSessionId);
+            const spriteWorkDir = liveSession?.workingDir;
+            if (spriteWorkDir) {
+              const canAccess = await sandboxGuard.canAccess(
+                spriteUserId,
+                spriteUserRole,
+                spriteWorkDir,
+              );
+              if (!canAccess) {
+                sendToClient(ws, {
+                  type: 'error',
+                  code: 'SANDBOX_DENIED',
+                  message:
+                    'Access denied: you do not have permission to access this session',
+                });
+                break;
+              }
+            }
+          }
+        }
+
         let state = spriteMappings.get(reqSessionId);
         if (!state) {
           // Try loading from disk (relay may have restarted since last seen)

--- a/relay/src/routes/ws.ts
+++ b/relay/src/routes/ws.ts
@@ -1055,17 +1055,11 @@ export function createWsRoute(deps: WsDeps): FastifyPluginAsync {
       case 'sprite.state.request': {
         const reqSessionId = message.sessionId;
 
-        // Verify the requesting client is attached to this session
-        const attachedSessionId = clientSessions.get(ws);
-        if (attachedSessionId !== reqSessionId) {
-          sendToClient(ws, {
-            type: 'error',
-            code: 'FORBIDDEN',
-            message: 'Cannot query sprite state for a session you are not attached to',
-          });
-          break;
-        }
-
+        // No per-session attach gate: iOS never calls `session.attach` for
+        // PTY-launched claude sessions (same reason `sprite.link`/
+        // `sprite.unlink` switched to `broadcastToAll` in QA-FIXES #11 Layer
+        // 1). Authentication at the WebSocket layer already gates access;
+        // sprite state fans out to every attached client anyway.
         let state = spriteMappings.get(reqSessionId);
         if (!state) {
           // Try loading from disk (relay may have restarted since last seen)


### PR DESCRIPTION
## Summary

Closes QA-FIXES #7 — sprites detaching from subagents after backgrounding, Office close+reopen, or kill-and-relaunch. Fix is split across iOS and relay:

**iOS:**
- New `OfficeSceneManager.refreshAllOpenOffices()` — re-seeds each open Office's session roster from `TabRegistryStore` (covers the race after a fresh app launch) and requests sprite state per session.
- Wired into two places:
  - `MajorTomApp` `onChange(relay.connectionState)` — fires after WS reattach, catching background→foreground and kill-and-relaunch.
  - `RelayService` `.tabListResponse` handler — catches the kill-relaunch race where the user taps an Office card before the post-reconnect tab list lands.

**Relay:**
- Dropped the per-session attach gate in `sprite.state.request`. iOS never calls `session.attach` for PTY-launched sessions, so the old check returned FORBIDDEN for every PTY sprite-state query. Matches the `broadcastToAll` pattern adopted in QA-FIXES #11 Layer 1. WebSocket auth still gates access.

## Test plan

Wave B QA from `project_qa_followups_phase` — run against a fresh relay + fresh device build. Each scenario must show sprites within ~1s of reconnect with no duplicates.

- [ ] **(a) Background + return:** spawn subagents in an Office → home button → wait → return. Sprites present.
- [ ] **(b) Close Office + reopen:** live Office with subagents → context-menu "Close Office" → re-tap card. Sprites present.
- [ ] **(c) Kill-and-relaunch:** live subagents → force-kill app → relaunch → tap Office card. Sprites present.
- [x] iOS simulator build green
- [x] Relay `tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
