### PR TITLE
feat(relay): instrument sprite.message handler for QA-FIXES #11 Layer 2 (A.1)

### DIFF
--- a/relay/src/routes/ws.ts
+++ b/relay/src/routes/ws.ts
@@ -979,6 +979,36 @@ export function createWsRoute(deps: WsDeps): FastifyPluginAsync {
         const mapping = spriteState?.mappings.find(m =>
           m.subagentId === message.subagentId && m.spriteHandle === message.spriteHandle
         );
+
+        // QA-FIXES #11 — Layer 2 instrumentation. Confirms or rules out
+        // the "mapping missing because subagent was already dismissed"
+        // hypothesis before committing to a PtyBtwQueue vs delivery-via-
+        // parent-prompt direction. Fields let us separately distinguish:
+        //   - subagentId/spriteHandle drift between iOS and relay
+        //     (`subagentIdKnown` true but `mappingFound` false)
+        //   - PTY vs SDK session kind (no worker → PTY path)
+        //   - agent lifecycle state at tap time
+        const subagentIdKnown = spriteState?.mappings.some(
+          m => m.subagentId === message.subagentId,
+        ) ?? false;
+        const liveAgent = agentTracker.get(message.subagentId);
+        const hasWorker =
+          fleetManager.getWorkerForSessionId(message.sessionId) !== undefined;
+        logger.info(
+          {
+            sessionId: message.sessionId,
+            subagentId: message.subagentId,
+            spriteHandle: message.spriteHandle,
+            messageId: message.messageId,
+            mappingFound: !!mapping,
+            subagentIdKnown,
+            mappingCount: spriteState?.mappings.length ?? 0,
+            sessionKind: hasWorker ? 'sdk-worker' : 'pty-or-dead',
+            agentStatus: liveAgent?.status ?? 'not_in_tracker',
+          },
+          'sprite.message — handler entry',
+        );
+
         if (!mapping) {
           // Agent may have completed before message arrived (scenario #4 from spec)
           sendToClient(ws, {

--- a/relay/src/routes/ws.ts
+++ b/relay/src/routes/ws.ts
@@ -992,8 +992,7 @@ export function createWsRoute(deps: WsDeps): FastifyPluginAsync {
           m => m.subagentId === message.subagentId,
         ) ?? false;
         const liveAgent = agentTracker.get(message.subagentId);
-        const hasWorker =
-          fleetManager.getWorkerForSessionId(message.sessionId) !== undefined;
+        const hasWorker = fleetManager.hasSession(message.sessionId);
         logger.info(
           {
             sessionId: message.sessionId,


### PR DESCRIPTION
## Summary

Pre-work for Wave A (QA-FIXES #11 Layer 2). Adds a single `logger.info` at the top of the `sprite.message` handler in `relay/src/routes/ws.ts` so we can confirm the "mapping missing because subagent was already dismissed" hypothesis before committing to a PtyBtwQueue build (Option 1) vs a parent-prompt delivery (Option 3).

Pure addition — no behavior change.

## Fields logged

- `mappingFound` — whether the exact `(subagentId, spriteHandle)` tuple exists.
- `subagentIdKnown` — whether ANY mapping for `subagentId` exists in the session (separates "subagent dismissed" from "subagentId/spriteHandle drift between iOS and relay").
- `mappingCount` — total mappings in the session.
- `sessionKind` — `sdk-worker` if `fleetManager.getWorkerForSessionId` returns a worker, else `pty-or-dead`.
- `agentStatus` — from `agentTracker.get(subagentId)?.status` (or `not_in_tracker`).

## Test plan

- [x] `npm run typecheck` clean.
- [ ] Restart relay, run a PTY `/btw` from iOS, tail `/tmp/relay.log`, confirm the hypothesis (`mappingFound: false`, `subagentIdKnown: false`, `agentStatus: not_in_tracker`) for dismissed-before-tap flows.
- [ ] Also run an SDK `/btw` to confirm the happy-path log shape (`mappingFound: true`, `sessionKind: sdk-worker`, `agentStatus: working`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
