### PR TITLE
feat(relay): PTY-native /btw queue — Wave A root-cause fix

### DIFF
--- a/relay/src/adapters/__tests__/pty-adapter.test.ts
+++ b/relay/src/adapters/__tests__/pty-adapter.test.ts
@@ -190,6 +190,34 @@ describe('PtyAdapter.sendInput / write', () => {
   });
 });
 
+describe('PtyAdapter.onOutput', () => {
+  it('fires registered listeners on every chunk the PTY emits', async () => {
+    const client = makeClient();
+    adapter.attach('tab-1', client, ATTACH_DEFAULTS);
+
+    const chunks: Buffer[] = [];
+    const unsub = adapter.onOutput('tab-1', (c) => chunks.push(c));
+
+    adapter.write('tab-1', 'hello-output\n');
+    await waitFor(() => {
+      const text = Buffer.concat(chunks).toString('utf-8');
+      expect(text).toContain('hello-output');
+    });
+
+    unsub();
+    const before = chunks.length;
+    adapter.write('tab-1', 'after-unsub\n');
+    // Give the PTY a beat to flush and confirm no new chunks after unsubscribe
+    await new Promise((r) => setTimeout(r, 60));
+    expect(chunks.length).toBe(before);
+  });
+
+  it('onOutput on unknown tabId returns a no-op unsubscribe', () => {
+    const unsub = adapter.onOutput('nope', () => {});
+    expect(() => unsub()).not.toThrow();
+  });
+});
+
 describe('PtyAdapter.resize', () => {
   it('resizes the PTY without throwing', () => {
     const client = makeClient();

--- a/relay/src/adapters/pty-adapter.ts
+++ b/relay/src/adapters/pty-adapter.ts
@@ -131,6 +131,12 @@ interface PtySession {
   graceTimer?: ReturnType<typeof setTimeout>;
   lastActivityAt: number;
   exited: boolean;
+  /**
+   * Additive byte-stream subscribers. Fired on every PTY chunk regardless
+   * of viewer state — used by PtyBtwQueue to correlate /btw responses
+   * without interfering with the primary viewer/ring path.
+   */
+  outputListeners: Set<(chunk: Buffer) => void>;
 }
 
 export class PtyAdapter {
@@ -300,6 +306,31 @@ export class PtyAdapter {
   }
 
   /**
+   * Subscribe to raw PTY output chunks for `tabId`. Listener fires on every
+   * chunk the PTY emits for that session, regardless of viewer attach state.
+   * Returns an unsubscribe function. Safe to call before the tab exists —
+   * the subscription is still registered if/when a future `attach` spawns it,
+   * but since sessions are keyed by tabId and adjusted via `spawnSession`,
+   * callers normally only tap after attach.
+   *
+   * Designed to be additive: throws from listeners are caught + logged so a
+   * bad listener can't break the primary viewer/ring path.
+   */
+  onOutput(tabId: string, listener: (chunk: Buffer) => void): () => void {
+    const session = this.sessions.get(tabId);
+    if (!session) {
+      // No session yet — return a no-op unsubscribe. Callers shouldn't rely
+      // on this branch in production; tests may exercise it.
+      return () => {};
+    }
+    session.outputListeners.add(listener);
+    return () => {
+      const s = this.sessions.get(tabId);
+      if (s) s.outputListeners.delete(listener);
+    };
+  }
+
+  /**
    * Snapshot of all live tabs. Backs `GET /shell/tabs`.
    * Sorted by `lastActivityAt` descending so most recent appears first.
    */
@@ -360,6 +391,7 @@ export class PtyAdapter {
       ring: new RingBuffer(this.bufferBytes),
       lastActivityAt: Date.now(),
       exited: false,
+      outputListeners: new Set(),
     };
     this.sessions.set(tabId, session);
 
@@ -379,6 +411,22 @@ export class PtyAdapter {
       } else {
         // No live viewer — buffer for replay on reattach.
         session.ring.push(buf);
+      }
+      // Fan out to any additive output listeners (e.g. PtyBtwQueue). This
+      // runs regardless of viewer state so /btw response correlation works
+      // even when the user is detached. Errors are isolated per listener
+      // so one bad subscriber can't break others or the viewer path.
+      if (session.outputListeners.size > 0) {
+        for (const listener of session.outputListeners) {
+          try {
+            listener(buf);
+          } catch (err) {
+            logger.warn(
+              { err, tabId: session.tabId },
+              'PTY output listener threw — continuing',
+            );
+          }
+        }
       }
     });
 
@@ -408,6 +456,7 @@ export class PtyAdapter {
       clearTimeout(session.graceTimer);
       session.graceTimer = undefined;
     }
+    session.outputListeners.clear();
     this.sessions.delete(tabId);
     if (this.onTabClosed) {
       try {

--- a/relay/src/adapters/pty-adapter.ts
+++ b/relay/src/adapters/pty-adapter.ts
@@ -308,19 +308,22 @@ export class PtyAdapter {
   /**
    * Subscribe to raw PTY output chunks for `tabId`. Listener fires on every
    * chunk the PTY emits for that session, regardless of viewer attach state.
-   * Returns an unsubscribe function. Safe to call before the tab exists —
-   * the subscription is still registered if/when a future `attach` spawns it,
-   * but since sessions are keyed by tabId and adjusted via `spawnSession`,
-   * callers normally only tap after attach.
+   * Returns an unsubscribe function.
    *
-   * Designed to be additive: throws from listeners are caught + logged so a
-   * bad listener can't break the primary viewer/ring path.
+   * Must be called AFTER `attach` has spawned the PTY — if the tab has no
+   * live session, the listener is NOT persisted and the returned unsub is
+   * a no-op. Deferred registration isn't supported; if you need it, queue
+   * the subscribe after `attached` is acknowledged.
+   *
+   * Designed to be additive: throws from listeners are caught + logged so
+   * a bad subscriber can't break the primary viewer/ring path.
    */
   onOutput(tabId: string, listener: (chunk: Buffer) => void): () => void {
     const session = this.sessions.get(tabId);
     if (!session) {
-      // No session yet — return a no-op unsubscribe. Callers shouldn't rely
-      // on this branch in production; tests may exercise it.
+      // No session yet — silently no-op. Callers are expected to subscribe
+      // after attach has spawned the PTY; this path exists only so tests
+      // and mistimed subscribes don't throw.
       return () => {};
     }
     session.outputListeners.add(listener);

--- a/relay/src/app.ts
+++ b/relay/src/app.ts
@@ -457,6 +457,12 @@ export async function buildApp(config: AppConfig) {
 
   app.addHook('onClose', async () => {
     logger.info('Shutting down services...');
+    // Dispose the /btw queue before the adapter so its in-flight timers
+    // and output listeners are cleared while the adapter's sessions map
+    // is still intact. Order matters: `ptyAdapter.dispose()` kills the
+    // PTYs, which would drop our output taps anyway — disposing the
+    // queue first keeps shutdown lint-clean and deterministic.
+    ptyBtwQueue.dispose();
     ptyAdapter.dispose();
     healthMonitor.dispose();
     await achievementService.flush();

--- a/relay/src/app.ts
+++ b/relay/src/app.ts
@@ -55,6 +55,7 @@ import { AuditLog } from './security/audit-log.js';
 import { RateLimiter } from './security/rate-limiter.js';
 import { SpriteMappingPersistence } from './sprites/sprite-mapping-persistence.js';
 import { SpriteMapper } from './sprites/sprite-mapper.js';
+import { PtyBtwQueue } from './sprites/pty-btw-queue.js';
 import { runSpriteMappingMigration } from './sprites/migrations.js';
 import { TabRegistry } from './tabs/tab-registry.js';
 import { TabRegistryPersistence } from './tabs/tab-registry-persistence.js';
@@ -372,10 +373,22 @@ export async function buildApp(config: AppConfig) {
           sweepOrphanedSubagentsForSession(sid, reportLifecycle, 'pty-exit');
         }
       }
+      // Wave A — drop any in-flight /btw entries pinned to this tab so
+      // sprite bubbles don't hang waiting for a response that can't land.
+      ptyBtwQueue.dropForTab(tabId, 'PTY tab closed');
       eventBus.emit('server.message', { type: 'tab.closed', tabId });
     },
   });
   shellApprovalQueue.setHybridWriter((tabId, data) => ptyAdapter.write(tabId, data));
+
+  // Wave A — PTY-native /btw queue. Parallel to fleetManager's SDK
+  // `BtwQueue` (which lives per-worker). iOS's primary flow is PTY
+  // sessions with no SDK worker, so `sprite.message` for those sessions
+  // routes here instead of into `fleetManager.enqueueSpriteMessage`.
+  const ptyBtwQueue = new PtyBtwQueue({
+    adapter: ptyAdapter,
+    tabRegistry,
+  });
 
   // Health check (public)
   await app.register(createHealthRoutes({ sessionManager, fleetManager, healthMonitor, ptyAdapter }));
@@ -424,6 +437,7 @@ export async function buildApp(config: AppConfig) {
     spriteMappingPersistence,
     spriteMapper,
     tabRegistry,
+    ptyBtwQueue,
   }));
 
   // Phase 13 Wave 2 — REST endpoints for approvals (cold-start fetch

--- a/relay/src/routes/ws.ts
+++ b/relay/src/routes/ws.ts
@@ -43,6 +43,7 @@ import {
   type PersistedSpriteMappingFile,
 } from '../sprites/sprite-mapping-persistence.js';
 import type { TabRegistry } from '../tabs/tab-registry.js';
+import type { PtyBtwQueue } from '../sprites/pty-btw-queue.js';
 
 interface WsDeps {
   sessionManager: SessionManager;
@@ -73,6 +74,14 @@ interface WsDeps {
   spriteMapper: SpriteMapper;
   /** Tab-Keyed Offices — optional for back-compat during wiring. */
   tabRegistry?: TabRegistry;
+  /**
+   * Wave A — PTY-native /btw queue. PTY sessions have no SDK worker, so
+   * `fleetManager.enqueueSpriteMessage` always returns false for them and
+   * the /btw drops with "No active session." Routing through this queue
+   * writes the framed text directly into the PTY and taps output for the
+   * reply. Optional for back-compat during wiring / unit tests.
+   */
+  ptyBtwQueue?: PtyBtwQueue;
 }
 
 /**
@@ -101,6 +110,7 @@ export function createWsRoute(deps: WsDeps): FastifyPluginAsync {
     spriteMappingPersistence,
     spriteMapper,
     tabRegistry,
+    ptyBtwQueue,
   } = deps;
 
   const notificationDigest = new NotificationDigest(pushManager, notificationConfigManager);
@@ -1024,39 +1034,68 @@ export function createWsRoute(deps: WsDeps): FastifyPluginAsync {
           break;
         }
 
-        // Route the /btw to the worker owning this session. Worker's
-        // BtwQueue injects at the next turn boundary and emits a
-        // terminal `ipc:sprite.response` back to the parent → re-fanned
-        // out via the `sprite-response` listener below.
-        const routed = fleetManager.enqueueSpriteMessage({
-          sessionId: message.sessionId,
-          subagentId: message.subagentId,
-          spriteHandle: message.spriteHandle,
-          messageId: message.messageId,
-          userText: message.text,
-          role: mapping.canonicalRole,
-          task: mapping.task,
-        });
-        if (!routed) {
-          // No worker for the session — treat as dropped. This is the
-          // session-ended race: mapping existed in memory but the SDK
-          // session went away between mapping-check and enqueue.
-          sendToClient(ws, {
-            type: 'sprite.response',
+        // Wave A — branch on session kind. PTY-backed sessions (iOS's
+        // primary flow) have no SDK worker; route those through the
+        // PTY-native queue which writes the framed text directly into
+        // the PTY and taps the output stream for the reply. SDK-worker
+        // sessions keep using the existing fleet path.
+        if (hasWorker) {
+          const routed = fleetManager.enqueueSpriteMessage({
             sessionId: message.sessionId,
-            spriteHandle: message.spriteHandle,
             subagentId: message.subagentId,
+            spriteHandle: message.spriteHandle,
             messageId: message.messageId,
-            text: '',
-            status: 'dropped',
-            dropReason: 'No active session — /btw cannot be delivered',
-            tabId: tabIdFor(message.sessionId),
+            userText: message.text,
+            role: mapping.canonicalRole,
+            task: mapping.task,
           });
-          break;
+          if (!routed) {
+            // SDK session disappeared between mapping check and enqueue.
+            sendToClient(ws, {
+              type: 'sprite.response',
+              sessionId: message.sessionId,
+              spriteHandle: message.spriteHandle,
+              subagentId: message.subagentId,
+              messageId: message.messageId,
+              text: '',
+              status: 'dropped',
+              dropReason: 'No active session — /btw cannot be delivered',
+              tabId: tabIdFor(message.sessionId),
+            });
+            break;
+          }
+        } else {
+          // PTY or dead session. If PtyBtwQueue isn't wired (unit tests
+          // building a minimal route), fall through to the legacy drop
+          // with the clarified reason — this is the same clarity win as
+          // Option 2 in the Wave A plan.
+          const result = ptyBtwQueue?.enqueue({
+            sessionId: message.sessionId,
+            subagentId: message.subagentId,
+            spriteHandle: message.spriteHandle,
+            messageId: message.messageId,
+            userText: message.text,
+            role: mapping.canonicalRole,
+            task: mapping.task,
+          });
+          if (!result || result.kind === 'no-tab') {
+            sendToClient(ws, {
+              type: 'sprite.response',
+              sessionId: message.sessionId,
+              spriteHandle: message.spriteHandle,
+              subagentId: message.subagentId,
+              messageId: message.messageId,
+              text: '',
+              status: 'dropped',
+              dropReason: result?.reason ?? 'Agent dismissed — response unavailable',
+              tabId: tabIdFor(message.sessionId),
+            });
+            break;
+          }
         }
         // Immediate `queued` ack so clients know the relay accepted the
         // message. The terminal `delivered` / `dropped` response follows
-        // when the turn boundary drains the queue.
+        // when the SDK turn boundary or PTY settle-timer drains the queue.
         sendToClient(ws, {
           type: 'sprite.response',
           sessionId: message.sessionId,
@@ -2127,6 +2166,56 @@ export function createWsRoute(deps: WsDeps): FastifyPluginAsync {
       );
     });
 
+    // Wave A — PtyBtwQueue terminal states ride the same `sprite.response`
+    // wire shape as the SDK path. `responded` becomes `status: 'delivered'`;
+    // `dropped` carries the reason through. We broadcast to ALL clients
+    // (not just session-scoped) because PTY sessions are never
+    // `session.attach`-ed on the iOS side — same rationale as the
+    // sprite.link/unlink fix in QA-FIXES.md #11.
+    ptyBtwQueue?.on('responded', (ev) => {
+      broadcastToAll({
+        type: 'sprite.response',
+        sessionId: ev.sessionId,
+        spriteHandle: ev.spriteHandle,
+        subagentId: ev.subagentId,
+        messageId: ev.messageId,
+        text: ev.text,
+        status: 'delivered',
+        tabId: ev.tabId,
+      });
+      logger.info(
+        {
+          sessionId: ev.sessionId,
+          subagentId: ev.subagentId,
+          messageId: ev.messageId,
+          textLength: ev.text.length,
+        },
+        'PtyBtwQueue: response forwarded to clients',
+      );
+    });
+    ptyBtwQueue?.on('dropped', (ev) => {
+      broadcastToAll({
+        type: 'sprite.response',
+        sessionId: ev.sessionId,
+        spriteHandle: ev.spriteHandle,
+        subagentId: ev.subagentId,
+        messageId: ev.messageId,
+        text: '',
+        status: 'dropped',
+        dropReason: ev.reason,
+        tabId: ev.tabId,
+      });
+      logger.info(
+        {
+          sessionId: ev.sessionId,
+          subagentId: ev.subagentId,
+          messageId: ev.messageId,
+          reason: ev.reason,
+        },
+        'PtyBtwQueue: drop forwarded to clients',
+      );
+    });
+
     fleetManager.on('agent-lifecycle', (event) => {
       const sid = event.sessionId;
       switch (event.event) {
@@ -2241,6 +2330,9 @@ export function createWsRoute(deps: WsDeps): FastifyPluginAsync {
               // worker usually fires first and handles this locally, but
               // some lifecycle paths skip SubagentStop — be idempotent.
               fleetManager.dropSpriteForSubagent(sid, event.agentId, 'Subagent completed');
+              // Wave A — PTY-side symmetric drop so bubbles waiting on a
+              // response whose subagent just completed clear immediately.
+              ptyBtwQueue?.dropForSubagent(event.agentId, 'Subagent completed');
             }
           }
           break;
@@ -2281,6 +2373,8 @@ export function createWsRoute(deps: WsDeps): FastifyPluginAsync {
               });
               // Wave 4 — same as 'complete' above, drop any queued /btw.
               fleetManager.dropSpriteForSubagent(sid, event.agentId, 'Subagent dismissed');
+              // Wave A — PTY-side symmetric drop.
+              ptyBtwQueue?.dropForSubagent(event.agentId, 'Subagent dismissed');
             }
           }
           break;

--- a/relay/src/sprites/__tests__/pty-btw-queue.test.ts
+++ b/relay/src/sprites/__tests__/pty-btw-queue.test.ts
@@ -219,21 +219,104 @@ describe('PtyBtwQueue — enqueue & drain', () => {
     expect(adapter.writes[1]!.data).toContain('second');
   });
 
-  it('drains a different subagent in parallel even if another is in flight', async () => {
+  it('serializes two /btws for different subagents on the same PTY tab', async () => {
+    // A PTY has one stdin/stdout, so injecting two /btws in parallel on
+    // the same tab would interleave output and poison response
+    // correlation. The queue holds the second until the first finalizes.
     const adapter = makeStubAdapter();
     adapter.tabs.add('tab-1');
     const registry = makeStubRegistry({ 'sess-1': 'tab-1' });
     const q = new PtyBtwQueue(
       { adapter, tabRegistry: registry },
-      { settleMs: 1_000, maxWaitMs: 10_000, minWaitMs: 1 },
+      { settleMs: 30, maxWaitMs: 1_000, minWaitMs: 1 },
     );
 
     q.enqueue({ ...SAMPLE_INPUT, subagentId: 'agent-A', messageId: 'mA' });
     q.enqueue({ ...SAMPLE_INPUT, subagentId: 'agent-B', messageId: 'mB' });
     await Promise.resolve();
 
-    // Both subagents' head /btw should have been written
+    // Only one subagent's /btw should have been written so far
+    expect(adapter.writes).toHaveLength(1);
+
+    // Settle the first, then the second should drain
+    adapter.chunks('tab-1', 'reply to A\n');
+    await vi.advanceTimersByTimeAsync(40);
+    await Promise.resolve();
     expect(adapter.writes).toHaveLength(2);
+  });
+
+  it('drains in parallel across different tabs', async () => {
+    // Different tabs = different PTY streams = safe to inject concurrently.
+    const adapter = makeStubAdapter();
+    adapter.tabs.add('tab-1');
+    adapter.tabs.add('tab-2');
+    const registry = makeStubRegistry({ 'sess-1': 'tab-1', 'sess-2': 'tab-2' });
+    const q = new PtyBtwQueue(
+      { adapter, tabRegistry: registry },
+      { settleMs: 1_000, maxWaitMs: 10_000, minWaitMs: 1 },
+    );
+
+    q.enqueue({ ...SAMPLE_INPUT, sessionId: 'sess-1', subagentId: 'agent-A', messageId: 'mA' });
+    q.enqueue({ ...SAMPLE_INPUT, sessionId: 'sess-2', subagentId: 'agent-B', messageId: 'mB' });
+    await Promise.resolve();
+
+    expect(adapter.writes).toHaveLength(2);
+    expect(new Set(adapter.writes.map(w => w.tabId))).toEqual(new Set(['tab-1', 'tab-2']));
+  });
+
+  it('routes each chunk to exactly one awaiting entry per tab', async () => {
+    // Proves onChunk uses the tab-scoped inFlight index rather than
+    // fanning to every awaiting entry in the queue.
+    const adapter = makeStubAdapter();
+    adapter.tabs.add('tab-1');
+    adapter.tabs.add('tab-2');
+    const registry = makeStubRegistry({ 'sess-1': 'tab-1', 'sess-2': 'tab-2' });
+    const q = new PtyBtwQueue(
+      { adapter, tabRegistry: registry },
+      { settleMs: 30, maxWaitMs: 10_000, minWaitMs: 1 },
+    );
+
+    const responses: { messageId: string; text: string }[] = [];
+    q.on('responded', (ev) => responses.push({ messageId: ev.messageId, text: ev.text }));
+
+    q.enqueue({ ...SAMPLE_INPUT, sessionId: 'sess-1', subagentId: 'agent-A', messageId: 'mA' });
+    q.enqueue({ ...SAMPLE_INPUT, sessionId: 'sess-2', subagentId: 'agent-B', messageId: 'mB' });
+    await Promise.resolve();
+
+    adapter.chunks('tab-1', 'reply for A only\n');
+    adapter.chunks('tab-2', 'reply for B only\n');
+    await vi.advanceTimersByTimeAsync(40);
+
+    const byId = new Map(responses.map(r => [r.messageId, r.text]));
+    expect(byId.get('mA')).toBe('reply for A only');
+    expect(byId.get('mB')).toBe('reply for B only');
+  });
+
+  it('does not finalize before minWaitMs even if settleMs is smaller', async () => {
+    const adapter = makeStubAdapter();
+    adapter.tabs.add('tab-1');
+    const registry = makeStubRegistry({ 'sess-1': 'tab-1' });
+    const q = new PtyBtwQueue(
+      { adapter, tabRegistry: registry },
+      // settle is tiny but minWait demands 200ms floor
+      { settleMs: 5, maxWaitMs: 5_000, minWaitMs: 200 },
+    );
+
+    const respondedAt: number[] = [];
+    q.on('responded', () => respondedAt.push(Date.now()));
+
+    const startedAt = Date.now();
+    q.enqueue(SAMPLE_INPUT);
+    await Promise.resolve();
+
+    // Fast first chunk — should NOT finalize before minWait
+    adapter.chunks('tab-1', 'very fast reply');
+    await vi.advanceTimersByTimeAsync(50);
+    expect(respondedAt).toHaveLength(0);
+
+    await vi.advanceTimersByTimeAsync(200);
+    expect(respondedAt).toHaveLength(1);
+    expect(respondedAt[0]! - startedAt).toBeGreaterThanOrEqual(200);
   });
 });
 

--- a/relay/src/sprites/__tests__/pty-btw-queue.test.ts
+++ b/relay/src/sprites/__tests__/pty-btw-queue.test.ts
@@ -1,0 +1,380 @@
+/**
+ * Unit tests for `PtyBtwQueue`.
+ *
+ * Uses fake timers + a stub adapter/registry so the 2s settle and 30s
+ * max-wait timers exercise quickly and deterministically. Real PTY
+ * integration is covered by the `PtyAdapter.onOutput` test in
+ * pty-adapter.test.ts.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+  PtyBtwQueue,
+  cleanPtyResponse,
+  stripAnsi,
+  type PtyBtwAdapter,
+  type PtyBtwTabRegistry,
+} from '../pty-btw-queue.js';
+
+// ── Stubs ─────────────────────────────────────────────────────
+
+interface StubWrite {
+  tabId: string;
+  data: string;
+}
+
+interface StubAdapter extends PtyBtwAdapter {
+  writes: StubWrite[];
+  chunks: (tabId: string, chunk: string) => void;
+  hasReturnsFalseFor: Set<string>;
+  tabs: Set<string>;
+}
+
+function makeStubAdapter(): StubAdapter {
+  const listeners = new Map<string, Set<(c: Buffer) => void>>();
+  const writes: StubWrite[] = [];
+  const hasReturnsFalseFor = new Set<string>();
+  const tabs = new Set<string>();
+  return {
+    writes,
+    hasReturnsFalseFor,
+    tabs,
+    has(tabId) {
+      return tabs.has(tabId) && !hasReturnsFalseFor.has(tabId);
+    },
+    write(tabId, data) {
+      if (hasReturnsFalseFor.has(tabId)) return false;
+      writes.push({ tabId, data: typeof data === 'string' ? data : data.toString('utf8') });
+      return true;
+    },
+    onOutput(tabId, listener) {
+      let set = listeners.get(tabId);
+      if (!set) {
+        set = new Set();
+        listeners.set(tabId, set);
+      }
+      set.add(listener);
+      return () => {
+        const s = listeners.get(tabId);
+        if (s) s.delete(listener);
+      };
+    },
+    chunks(tabId, chunk) {
+      const set = listeners.get(tabId);
+      if (!set) return;
+      for (const l of set) l(Buffer.from(chunk, 'utf8'));
+    },
+  };
+}
+
+function makeStubRegistry(sessionToTab: Record<string, string>): PtyBtwTabRegistry {
+  return {
+    getTabForSession(sessionId) {
+      const tabId = sessionToTab[sessionId];
+      return tabId ? { tabId } : undefined;
+    },
+  };
+}
+
+const SAMPLE_INPUT = {
+  sessionId: 'sess-1',
+  subagentId: 'agent-1',
+  spriteHandle: 'sprite-A',
+  messageId: 'msg-1',
+  userText: 'hey whats up',
+  role: 'explore',
+  task: 'map the codebase',
+};
+
+// ── enqueue / drain ───────────────────────────────────────────
+
+describe('PtyBtwQueue — enqueue & drain', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('writes the framed text into the PTY and emits injected', async () => {
+    const adapter = makeStubAdapter();
+    adapter.tabs.add('tab-1');
+    const registry = makeStubRegistry({ 'sess-1': 'tab-1' });
+    const q = new PtyBtwQueue(
+      { adapter, tabRegistry: registry },
+      { settleMs: 50, maxWaitMs: 1_000, minWaitMs: 10 },
+    );
+
+    const injected: unknown[] = [];
+    q.on('injected', (ev) => injected.push(ev));
+
+    const result = q.enqueue(SAMPLE_INPUT);
+    expect(result.kind).toBe('accepted');
+
+    // Microtask drain needs one flush
+    await Promise.resolve();
+    expect(adapter.writes).toHaveLength(1);
+    expect(adapter.writes[0]!.tabId).toBe('tab-1');
+    expect(adapter.writes[0]!.data).toContain('non-blocking observation');
+    expect(adapter.writes[0]!.data.endsWith('\n')).toBe(true);
+    expect(injected).toHaveLength(1);
+  });
+
+  it('returns no-tab when the session has no PTY tab', () => {
+    const adapter = makeStubAdapter();
+    const registry = makeStubRegistry({});
+    const q = new PtyBtwQueue({ adapter, tabRegistry: registry });
+
+    const result = q.enqueue(SAMPLE_INPUT);
+    expect(result.kind).toBe('no-tab');
+    if (result.kind === 'no-tab') {
+      expect(result.reason).toMatch(/dismissed/i);
+    }
+  });
+
+  it('returns no-tab when the tab exists in registry but adapter lost it', () => {
+    const adapter = makeStubAdapter();
+    // Tab present in registry but NOT in adapter.tabs
+    const registry = makeStubRegistry({ 'sess-1': 'tab-gone' });
+    const q = new PtyBtwQueue({ adapter, tabRegistry: registry });
+
+    const result = q.enqueue(SAMPLE_INPUT);
+    expect(result.kind).toBe('no-tab');
+  });
+
+  it('captures output chunks and finalizes after settle with cleaned text', async () => {
+    const adapter = makeStubAdapter();
+    adapter.tabs.add('tab-1');
+    const registry = makeStubRegistry({ 'sess-1': 'tab-1' });
+    const q = new PtyBtwQueue(
+      { adapter, tabRegistry: registry },
+      { settleMs: 50, maxWaitMs: 10_000, minWaitMs: 1 },
+    );
+
+    const responses: { messageId: string; text: string }[] = [];
+    q.on('responded', (ev) => responses.push({ messageId: ev.messageId, text: ev.text }));
+
+    q.enqueue(SAMPLE_INPUT);
+    await Promise.resolve(); // drain microtask
+    // Adapter writes the framed text; fake echo + response in output
+    const framed = adapter.writes[0]!.data;
+    adapter.chunks('tab-1', framed);
+    adapter.chunks('tab-1', '\u001b[32mI am reading ws.ts right now.\u001b[0m\n');
+
+    // Still inside settle window
+    expect(responses).toHaveLength(0);
+    await vi.advanceTimersByTimeAsync(60);
+    expect(responses).toHaveLength(1);
+    expect(responses[0]!.text).toBe('I am reading ws.ts right now.');
+  });
+
+  it('falls back to max-wait finalize when output never settles', async () => {
+    const adapter = makeStubAdapter();
+    adapter.tabs.add('tab-1');
+    const registry = makeStubRegistry({ 'sess-1': 'tab-1' });
+    const q = new PtyBtwQueue(
+      { adapter, tabRegistry: registry },
+      { settleMs: 500, maxWaitMs: 200, minWaitMs: 50 },
+    );
+
+    const responses: string[] = [];
+    q.on('responded', (ev) => responses.push(ev.text));
+
+    q.enqueue(SAMPLE_INPUT);
+    await Promise.resolve();
+    // Keep pushing chunks faster than settleMs so settle never fires first
+    for (let i = 0; i < 20; i++) {
+      adapter.chunks('tab-1', 'still working...\n');
+      await vi.advanceTimersByTimeAsync(20);
+    }
+    // Advance past max-wait
+    await vi.advanceTimersByTimeAsync(250);
+    expect(responses).toHaveLength(1);
+    expect(responses[0]).toMatch(/still working/);
+  });
+
+  it('queues a second /btw for the same subagent until the first finalizes', async () => {
+    const adapter = makeStubAdapter();
+    adapter.tabs.add('tab-1');
+    const registry = makeStubRegistry({ 'sess-1': 'tab-1' });
+    const q = new PtyBtwQueue(
+      { adapter, tabRegistry: registry },
+      { settleMs: 30, maxWaitMs: 1_000, minWaitMs: 1 },
+    );
+
+    q.enqueue({ ...SAMPLE_INPUT, messageId: 'm1', userText: 'first' });
+    q.enqueue({ ...SAMPLE_INPUT, messageId: 'm2', userText: 'second' });
+    await Promise.resolve();
+
+    // Only the first should have been injected
+    expect(adapter.writes).toHaveLength(1);
+    expect(adapter.writes[0]!.data).toContain('first');
+
+    // Settle the first
+    adapter.chunks('tab-1', 'reply to first\n');
+    await vi.advanceTimersByTimeAsync(40);
+    await Promise.resolve();
+
+    // Now the second should drain
+    expect(adapter.writes).toHaveLength(2);
+    expect(adapter.writes[1]!.data).toContain('second');
+  });
+
+  it('drains a different subagent in parallel even if another is in flight', async () => {
+    const adapter = makeStubAdapter();
+    adapter.tabs.add('tab-1');
+    const registry = makeStubRegistry({ 'sess-1': 'tab-1' });
+    const q = new PtyBtwQueue(
+      { adapter, tabRegistry: registry },
+      { settleMs: 1_000, maxWaitMs: 10_000, minWaitMs: 1 },
+    );
+
+    q.enqueue({ ...SAMPLE_INPUT, subagentId: 'agent-A', messageId: 'mA' });
+    q.enqueue({ ...SAMPLE_INPUT, subagentId: 'agent-B', messageId: 'mB' });
+    await Promise.resolve();
+
+    // Both subagents' head /btw should have been written
+    expect(adapter.writes).toHaveLength(2);
+  });
+});
+
+// ── drop paths ────────────────────────────────────────────────
+
+describe('PtyBtwQueue — drop paths', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('dropForSubagent clears queued + in-flight entries', async () => {
+    const adapter = makeStubAdapter();
+    adapter.tabs.add('tab-1');
+    const registry = makeStubRegistry({ 'sess-1': 'tab-1' });
+    const q = new PtyBtwQueue(
+      { adapter, tabRegistry: registry },
+      { settleMs: 5_000, maxWaitMs: 10_000, minWaitMs: 1 },
+    );
+
+    const drops: { messageId: string; reason: string }[] = [];
+    q.on('dropped', (ev) => drops.push({ messageId: ev.messageId, reason: ev.reason }));
+
+    q.enqueue({ ...SAMPLE_INPUT, messageId: 'mA' });
+    q.enqueue({ ...SAMPLE_INPUT, messageId: 'mB' });
+    await Promise.resolve();
+
+    const dropped = q.dropForSubagent('agent-1', 'Subagent dismissed');
+    expect(dropped).toBe(2);
+    expect(drops.map(d => d.messageId).sort()).toEqual(['mA', 'mB']);
+    expect(drops.every(d => d.reason === 'Subagent dismissed')).toBe(true);
+    expect(q.size).toBe(0);
+  });
+
+  it('dropForTab clears entries and force-releases the tap', async () => {
+    const adapter = makeStubAdapter();
+    adapter.tabs.add('tab-1');
+    const registry = makeStubRegistry({ 'sess-1': 'tab-1' });
+    const q = new PtyBtwQueue(
+      { adapter, tabRegistry: registry },
+      { settleMs: 5_000, maxWaitMs: 10_000, minWaitMs: 1 },
+    );
+
+    q.enqueue(SAMPLE_INPUT);
+    await Promise.resolve();
+
+    const dropped = q.dropForTab('tab-1', 'PTY tab closed');
+    expect(dropped).toBe(1);
+    expect(q.size).toBe(0);
+
+    // Subsequent chunks on the (now-gone) tap should be no-ops
+    let rogue = false;
+    q.on('responded', () => {
+      rogue = true;
+    });
+    adapter.chunks('tab-1', 'late noise');
+    await vi.advanceTimersByTimeAsync(6_000);
+    expect(rogue).toBe(false);
+  });
+
+  it('drops when adapter.write returns false mid-flight', async () => {
+    const adapter = makeStubAdapter();
+    adapter.tabs.add('tab-1');
+    const registry = makeStubRegistry({ 'sess-1': 'tab-1' });
+    const q = new PtyBtwQueue({ adapter, tabRegistry: registry });
+
+    const drops: string[] = [];
+    q.on('dropped', (ev) => drops.push(ev.reason));
+
+    adapter.hasReturnsFalseFor.add('tab-1'); // write() now returns false
+    // But has() is still true at enqueue time since we removed tab-1 from the
+    // false-set condition only during write. Work around by tweaking:
+    adapter.hasReturnsFalseFor.delete('tab-1');
+    // Simulate adapter.has true (for the enqueue check) but write false:
+    const origWrite = adapter.write.bind(adapter);
+    adapter.write = (tabId, data) => {
+      if (tabId === 'tab-1') return false;
+      return origWrite(tabId, data);
+    };
+
+    q.enqueue(SAMPLE_INPUT);
+    await Promise.resolve();
+    expect(drops).toHaveLength(1);
+    expect(drops[0]).toMatch(/unavailable/i);
+  });
+
+  it('dispose clears all entries and listeners', async () => {
+    const adapter = makeStubAdapter();
+    adapter.tabs.add('tab-1');
+    const registry = makeStubRegistry({ 'sess-1': 'tab-1' });
+    const q = new PtyBtwQueue(
+      { adapter, tabRegistry: registry },
+      { settleMs: 5_000, maxWaitMs: 10_000, minWaitMs: 1 },
+    );
+
+    q.enqueue(SAMPLE_INPUT);
+    await Promise.resolve();
+    q.dispose();
+    expect(q.size).toBe(0);
+
+    // Any trailing timers should be no-ops
+    await vi.advanceTimersByTimeAsync(11_000);
+  });
+});
+
+// ── helpers ───────────────────────────────────────────────────
+
+describe('stripAnsi', () => {
+  it('strips SGR color codes', () => {
+    expect(stripAnsi('\u001b[31mred\u001b[0m')).toBe('red');
+  });
+  it('strips cursor/erase CSI sequences', () => {
+    expect(stripAnsi('\u001b[2J\u001b[H\u001b[K hello')).toBe(' hello');
+  });
+  it('strips OSC title escapes', () => {
+    expect(stripAnsi('\u001b]0;terminal title\u0007hello')).toBe('hello');
+  });
+  it('leaves plain text intact', () => {
+    expect(stripAnsi('hello world')).toBe('hello world');
+  });
+});
+
+describe('cleanPtyResponse', () => {
+  it('normalizes CR/LF to LF', () => {
+    expect(cleanPtyResponse('line1\r\nline2\r\n', 'framed', 1000)).toBe('line1\nline2');
+  });
+  it('removes echoed framed text when present', () => {
+    const framed =
+      'The user sent a non-blocking observation via sprite tap to subagent "explore"';
+    const raw = `${framed}\nresponse from claude here.\n`;
+    expect(cleanPtyResponse(raw, framed, 1000)).toBe('response from claude here.');
+  });
+  it('truncates from the tail when exceeding maxChars', () => {
+    const raw = 'a'.repeat(500) + 'TAIL-MARKER';
+    const out = cleanPtyResponse(raw, 'unrelated framing', 50);
+    expect(out.length).toBeLessThanOrEqual(50);
+    expect(out.endsWith('TAIL-MARKER')).toBe(true);
+  });
+  it('collapses excessive blank lines', () => {
+    expect(cleanPtyResponse('a\n\n\n\n\nb', 'framed', 1000)).toBe('a\n\nb');
+  });
+});

--- a/relay/src/sprites/pty-btw-queue.ts
+++ b/relay/src/sprites/pty-btw-queue.ts
@@ -1,0 +1,522 @@
+/**
+ * PtyBtwQueue — Per-subagent FIFO for `/btw` sprite messages routed into
+ * PTY-backed claude sessions (the daily iOS flow).
+ *
+ * Why a separate queue from `BtwQueue`:
+ *   `BtwQueue` injects a new user turn via the in-process Anthropic SDK
+ *   session. PTY sessions have no SDK worker — claude runs as a child
+ *   process inside an xterm PTY per tab. The only way to feed it a new
+ *   user turn is to write the framed text to the PTY's stdin as if the
+ *   user typed it.
+ *
+ * Design:
+ *   - One queue per process; keyed by subagentId → FIFO of entries.
+ *   - At enqueue we resolve `sessionId → tabId` via `TabRegistry`. Missing
+ *     tab → drop with `Agent dismissed — response unavailable` (Option 2
+ *     from the Wave A plan; avoids the ambiguous "No active session" text).
+ *   - Only one entry per subagent is awaiting a response at a time.
+ *     Anything queued behind waits until the current entry finalizes.
+ *   - Injection is a direct `adapter.write(tabId, constrainedText + '\n')`.
+ *     We do NOT use a literal `/btw` slash command — the SDK path sends
+ *     `constrainedText` as a normal user turn, and claude TUI accepts the
+ *     same text identically.
+ *   - Response correlation taps `adapter.onOutput(tabId, ...)`. A 2s
+ *     quiet-period settle-timer fires finalize; a hard 30s max-wait
+ *     backs it up in case the subagent is buried in a long-running tool.
+ *     The captured output is stripped of ANSI escapes and truncated to
+ *     the tail (claude's final answer tends to sit at the end).
+ *
+ * Events:
+ *   injected  — the framed text has been written into the PTY
+ *   responded — settle/max-wait fired; `text` carries the cleaned reply
+ *   dropped   — entry was abandoned (tab gone, subagent dismissed, etc.)
+ */
+
+import { EventEmitter } from 'node:events';
+import { logger } from '../utils/logger.js';
+import { buildConstrainedText } from './btw-queue.js';
+
+export type PtyBtwEntryStatus = 'queued' | 'awaiting_response';
+
+export interface PtyBtwEnqueueInput {
+  sessionId: string;
+  subagentId: string;
+  spriteHandle: string;
+  messageId: string;
+  userText: string;
+  role: string;
+  task: string;
+}
+
+export type PtyBtwEnqueueResult =
+  | { kind: 'accepted'; entry: PtyBtwQueueEntry }
+  | { kind: 'no-tab'; reason: string };
+
+export interface PtyBtwQueueEntry {
+  sessionId: string;
+  tabId: string;
+  subagentId: string;
+  spriteHandle: string;
+  messageId: string;
+  userText: string;
+  constrainedText: string;
+  queuedAt: number;
+  status: PtyBtwEntryStatus;
+  injectedAt?: number;
+}
+
+/** Internal mutable state kept alongside an entry but not exposed. */
+interface EntryPrivate {
+  output: string[];
+  settleTimer?: ReturnType<typeof setTimeout>;
+  maxWaitTimer?: ReturnType<typeof setTimeout>;
+}
+
+export interface PtyBtwQueueEventMap {
+  injected: {
+    sessionId: string;
+    tabId: string;
+    subagentId: string;
+    spriteHandle: string;
+    messageId: string;
+  };
+  responded: {
+    sessionId: string;
+    tabId: string;
+    subagentId: string;
+    spriteHandle: string;
+    messageId: string;
+    text: string;
+  };
+  dropped: {
+    sessionId: string;
+    tabId: string;
+    subagentId: string;
+    spriteHandle: string;
+    messageId: string;
+    reason: string;
+  };
+}
+
+export interface PtyBtwQueueOptions {
+  /** Quiet period after last output chunk before we finalize. Default 2s. */
+  settleMs?: number;
+  /** Hard cap from inject to finalize. Default 30s. */
+  maxWaitMs?: number;
+  /** Response text truncation cap. Default 1200 chars. */
+  maxResponseChars?: number;
+  /** Smallest delay between inject and the earliest finalize. Default 250ms. */
+  minWaitMs?: number;
+}
+
+export interface PtyBtwAdapter {
+  write(tabId: string, data: string | Buffer): boolean;
+  onOutput(tabId: string, listener: (chunk: Buffer) => void): () => void;
+  has(tabId: string): boolean;
+}
+
+export interface PtyBtwTabRegistry {
+  getTabForSession(sessionId: string): { tabId: string } | undefined;
+}
+
+export interface PtyBtwQueueDeps {
+  adapter: PtyBtwAdapter;
+  tabRegistry: PtyBtwTabRegistry;
+}
+
+type Listener<T> = (payload: T) => void;
+
+export class PtyBtwQueue extends EventEmitter {
+  private readonly bySubagent = new Map<string, PtyBtwQueueEntry[]>();
+  private readonly byMessageId = new Map<string, PtyBtwQueueEntry>();
+  private readonly privateState = new WeakMap<PtyBtwQueueEntry, EntryPrivate>();
+  /** tabId → { unsub, refCount } — multiplex a single listener per tab. */
+  private readonly tapsByTab = new Map<string, { unsub: () => void; refCount: number }>();
+  private readonly settleMs: number;
+  private readonly maxWaitMs: number;
+  private readonly maxResponseChars: number;
+  private readonly minWaitMs: number;
+
+  constructor(
+    private readonly deps: PtyBtwQueueDeps,
+    opts: PtyBtwQueueOptions = {},
+  ) {
+    super();
+    this.setMaxListeners(50);
+    this.settleMs = opts.settleMs ?? 2_000;
+    this.maxWaitMs = opts.maxWaitMs ?? 30_000;
+    this.maxResponseChars = opts.maxResponseChars ?? 1200;
+    this.minWaitMs = opts.minWaitMs ?? 250;
+  }
+
+  /**
+   * Enqueue a /btw for a PTY-backed session. Resolves `sessionId → tabId`
+   * upfront so the caller learns immediately if the tab is gone (no
+   * separate "queued then quietly dropped" state).
+   */
+  enqueue(input: PtyBtwEnqueueInput): PtyBtwEnqueueResult {
+    const tab = this.deps.tabRegistry.getTabForSession(input.sessionId);
+    if (!tab || !this.deps.adapter.has(tab.tabId)) {
+      return {
+        kind: 'no-tab',
+        reason: 'Agent dismissed — response unavailable',
+      };
+    }
+    const entry: PtyBtwQueueEntry = {
+      sessionId: input.sessionId,
+      tabId: tab.tabId,
+      subagentId: input.subagentId,
+      spriteHandle: input.spriteHandle,
+      messageId: input.messageId,
+      userText: input.userText,
+      constrainedText: buildConstrainedText({
+        role: input.role,
+        task: input.task,
+        userText: input.userText,
+      }),
+      queuedAt: Date.now(),
+      status: 'queued',
+    };
+    this.privateState.set(entry, { output: [] });
+    this.byMessageId.set(entry.messageId, entry);
+    const list = this.bySubagent.get(entry.subagentId) ?? [];
+    list.push(entry);
+    this.bySubagent.set(entry.subagentId, list);
+    logger.info(
+      {
+        sessionId: entry.sessionId,
+        tabId: entry.tabId,
+        subagentId: entry.subagentId,
+        spriteHandle: entry.spriteHandle,
+        messageId: entry.messageId,
+        queueDepth: list.length,
+      },
+      'PtyBtwQueue: enqueued',
+    );
+    // Drain on a microtask so the WS handler can emit the `queued` ack
+    // before the PTY echoes the injected text.
+    queueMicrotask(() => this.drainFor(entry.subagentId));
+    return { kind: 'accepted', entry };
+  }
+
+  private drainFor(subagentId: string): void {
+    const list = this.bySubagent.get(subagentId);
+    if (!list || list.length === 0) return;
+    if (list.some(e => e.status === 'awaiting_response')) return;
+    const head = list.find(e => e.status === 'queued');
+    if (!head) return;
+    this.inject(head);
+  }
+
+  private inject(entry: PtyBtwQueueEntry): void {
+    this.attachTap(entry.tabId);
+    const ok = this.deps.adapter.write(entry.tabId, entry.constrainedText + '\n');
+    if (!ok) {
+      this.detachTap(entry.tabId);
+      this.dropInternal(entry, 'PTY tab unavailable');
+      return;
+    }
+    entry.status = 'awaiting_response';
+    entry.injectedAt = Date.now();
+    const priv = this.privateState.get(entry)!;
+    priv.maxWaitTimer = setTimeout(() => {
+      logger.warn(
+        {
+          sessionId: entry.sessionId,
+          tabId: entry.tabId,
+          subagentId: entry.subagentId,
+          messageId: entry.messageId,
+        },
+        'PtyBtwQueue: max-wait reached, finalizing with whatever was captured',
+      );
+      this.finalize(entry, 'max-wait');
+    }, this.maxWaitMs);
+    // Seed a minWait settle so instant replies still get at least a beat
+    // of capture time before we declare the turn done.
+    priv.settleTimer = setTimeout(() => {
+      this.finalize(entry, 'settled');
+    }, Math.max(this.minWaitMs, this.settleMs));
+    this.emit('injected', {
+      sessionId: entry.sessionId,
+      tabId: entry.tabId,
+      subagentId: entry.subagentId,
+      spriteHandle: entry.spriteHandle,
+      messageId: entry.messageId,
+    });
+    logger.info(
+      {
+        sessionId: entry.sessionId,
+        tabId: entry.tabId,
+        subagentId: entry.subagentId,
+        messageId: entry.messageId,
+        textLen: entry.constrainedText.length,
+      },
+      'PtyBtwQueue: injected',
+    );
+  }
+
+  private attachTap(tabId: string): void {
+    const existing = this.tapsByTab.get(tabId);
+    if (existing) {
+      existing.refCount++;
+      return;
+    }
+    const unsub = this.deps.adapter.onOutput(tabId, (chunk) => this.onChunk(tabId, chunk));
+    this.tapsByTab.set(tabId, { unsub, refCount: 1 });
+  }
+
+  private detachTap(tabId: string): void {
+    const existing = this.tapsByTab.get(tabId);
+    if (!existing) return;
+    existing.refCount -= 1;
+    if (existing.refCount > 0) return;
+    try {
+      existing.unsub();
+    } catch (err) {
+      logger.warn({ err, tabId }, 'PtyBtwQueue: onOutput unsub threw');
+    }
+    this.tapsByTab.delete(tabId);
+  }
+
+  private onChunk(tabId: string, chunk: Buffer): void {
+    const text = chunk.toString('utf8');
+    for (const entry of this.byMessageId.values()) {
+      if (entry.tabId !== tabId) continue;
+      if (entry.status !== 'awaiting_response') continue;
+      const priv = this.privateState.get(entry);
+      if (!priv) continue;
+      priv.output.push(text);
+      if (priv.settleTimer) clearTimeout(priv.settleTimer);
+      priv.settleTimer = setTimeout(() => this.finalize(entry, 'settled'), this.settleMs);
+    }
+  }
+
+  private finalize(entry: PtyBtwQueueEntry, why: 'settled' | 'max-wait'): void {
+    if (entry.status !== 'awaiting_response') return;
+    const priv = this.privateState.get(entry);
+    if (priv) {
+      if (priv.settleTimer) clearTimeout(priv.settleTimer);
+      if (priv.maxWaitTimer) clearTimeout(priv.maxWaitTimer);
+    }
+    const raw = priv ? priv.output.join('') : '';
+    const text = cleanPtyResponse(raw, entry.constrainedText, this.maxResponseChars);
+    const subagentId = entry.subagentId;
+    this.remove(entry);
+    this.detachTap(entry.tabId);
+    this.emit('responded', {
+      sessionId: entry.sessionId,
+      tabId: entry.tabId,
+      subagentId: entry.subagentId,
+      spriteHandle: entry.spriteHandle,
+      messageId: entry.messageId,
+      text:
+        text ||
+        (why === 'max-wait'
+          ? '(Agent did not respond — check the terminal tab)'
+          : '(No response text captured — check the terminal tab)'),
+    });
+    logger.info(
+      {
+        sessionId: entry.sessionId,
+        tabId: entry.tabId,
+        subagentId: entry.subagentId,
+        messageId: entry.messageId,
+        why,
+        rawLen: raw.length,
+        textLen: text.length,
+      },
+      'PtyBtwQueue: finalized response',
+    );
+    queueMicrotask(() => this.drainFor(subagentId));
+  }
+
+  private dropInternal(entry: PtyBtwQueueEntry, reason: string): void {
+    const priv = this.privateState.get(entry);
+    if (priv) {
+      if (priv.settleTimer) clearTimeout(priv.settleTimer);
+      if (priv.maxWaitTimer) clearTimeout(priv.maxWaitTimer);
+    }
+    const wasAwaiting = entry.status === 'awaiting_response';
+    this.remove(entry);
+    if (wasAwaiting) this.detachTap(entry.tabId);
+    this.emit('dropped', {
+      sessionId: entry.sessionId,
+      tabId: entry.tabId,
+      subagentId: entry.subagentId,
+      spriteHandle: entry.spriteHandle,
+      messageId: entry.messageId,
+      reason,
+    });
+    logger.info(
+      {
+        sessionId: entry.sessionId,
+        tabId: entry.tabId,
+        subagentId: entry.subagentId,
+        messageId: entry.messageId,
+        reason,
+        wasAwaiting,
+      },
+      'PtyBtwQueue: dropped',
+    );
+  }
+
+  private remove(entry: PtyBtwQueueEntry): void {
+    this.byMessageId.delete(entry.messageId);
+    const list = this.bySubagent.get(entry.subagentId);
+    if (list) {
+      const idx = list.indexOf(entry);
+      if (idx >= 0) list.splice(idx, 1);
+      if (list.length === 0) this.bySubagent.delete(entry.subagentId);
+    }
+    this.privateState.delete(entry);
+  }
+
+  /** Drop a specific entry by its messageId. Emits 'dropped'. */
+  dropByMessageId(messageId: string, reason: string): PtyBtwQueueEntry | undefined {
+    const entry = this.byMessageId.get(messageId);
+    if (!entry) return undefined;
+    this.dropInternal(entry, reason);
+    return entry;
+  }
+
+  /** Drop all entries for a subagent. Emits 'dropped' per entry. */
+  dropForSubagent(subagentId: string, reason: string): number {
+    const list = this.bySubagent.get(subagentId);
+    if (!list || list.length === 0) return 0;
+    const snapshot = [...list];
+    for (const entry of snapshot) this.dropInternal(entry, reason);
+    return snapshot.length;
+  }
+
+  /** Drop all entries in the session. Emits 'dropped' per entry. */
+  dropForSession(sessionId: string, reason: string): number {
+    let count = 0;
+    for (const entry of [...this.byMessageId.values()]) {
+      if (entry.sessionId !== sessionId) continue;
+      this.dropInternal(entry, reason);
+      count += 1;
+    }
+    return count;
+  }
+
+  /** Drop all entries tied to a PTY tab. Used by onTabClosed. */
+  dropForTab(tabId: string, reason: string): number {
+    let count = 0;
+    for (const entry of [...this.byMessageId.values()]) {
+      if (entry.tabId !== tabId) continue;
+      this.dropInternal(entry, reason);
+      count += 1;
+    }
+    const existing = this.tapsByTab.get(tabId);
+    if (existing) {
+      // The PTY is gone — unsubscribing via the adapter would no-op, but
+      // clear our bookkeeping so a future enqueue with a new tabId of the
+      // same id (unlikely but possible) starts clean.
+      try {
+        existing.unsub();
+      } catch {
+        /* ignore */
+      }
+      this.tapsByTab.delete(tabId);
+    }
+    return count;
+  }
+
+  sizeFor(subagentId: string): number {
+    return this.bySubagent.get(subagentId)?.length ?? 0;
+  }
+
+  get size(): number {
+    return this.byMessageId.size;
+  }
+
+  dispose(): void {
+    for (const entry of [...this.byMessageId.values()]) {
+      const priv = this.privateState.get(entry);
+      if (priv) {
+        if (priv.settleTimer) clearTimeout(priv.settleTimer);
+        if (priv.maxWaitTimer) clearTimeout(priv.maxWaitTimer);
+      }
+    }
+    for (const tap of this.tapsByTab.values()) {
+      try {
+        tap.unsub();
+      } catch {
+        /* ignore */
+      }
+    }
+    this.bySubagent.clear();
+    this.byMessageId.clear();
+    this.tapsByTab.clear();
+    this.removeAllListeners();
+  }
+
+  override on<K extends keyof PtyBtwQueueEventMap>(
+    event: K,
+    listener: Listener<PtyBtwQueueEventMap[K]>,
+  ): this;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  override on(event: string, listener: (...args: any[]) => void): this {
+    return super.on(event, listener);
+  }
+
+  override emit<K extends keyof PtyBtwQueueEventMap>(
+    event: K,
+    payload: PtyBtwQueueEventMap[K],
+  ): boolean;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  override emit(event: string, ...args: any[]): boolean {
+    return super.emit(event, ...args);
+  }
+}
+
+// ── Helpers ────────────────────────────────────────────────────
+
+/**
+ * Strip common ANSI escape sequences from `s`. Covers CSI (`\x1b[...`),
+ * OSC titles (`\x1b]...BEL or ST`), DCS/APC/PM/SOS (`\x1b[PX^_]...\x1b\\`),
+ * and lone single-char escapes (e.g. `\x1b=`). Not a full parser — good
+ * enough for claude TUI output, which is mostly CSI + SGR.
+ */
+export function stripAnsi(s: string): string {
+  return (
+    s
+      // eslint-disable-next-line no-control-regex
+      .replace(/\u001b\][^\u0007]*(?:\u0007|\u001b\\)/g, '')
+      // eslint-disable-next-line no-control-regex
+      .replace(/\u001b[PX^_][\s\S]*?\u001b\\/g, '')
+      // eslint-disable-next-line no-control-regex
+      .replace(/\u001b\[[0-?]*[ -/]*[@-~]/g, '')
+      // eslint-disable-next-line no-control-regex
+      .replace(/\u001b[@-Z\\-_]/g, '')
+  );
+}
+
+/**
+ * Turn raw PTY bytes into something the sprite bubble can render. Strips
+ * ANSI, normalizes CR/LF, drops the echoed framed text if we can find it,
+ * and truncates to the tail (claude's actual answer tends to sit at the
+ * end of the captured block after any tool/thinking output).
+ */
+export function cleanPtyResponse(raw: string, framedText: string, maxChars: number): string {
+  let text = stripAnsi(raw);
+  text = text.replace(/\r\n/g, '\n').replace(/\r/g, '\n');
+  text = text
+    .split('\n')
+    .map(l => l.replace(/[ \t]+$/, ''))
+    .join('\n');
+  // Drop the echoed input if we can find it. The TUI sometimes wraps/re-
+  // flows the line, so we match on the first chunk of the framed text and
+  // trust the length to jump past the rest.
+  const fingerprint = framedText.slice(0, 40).trim();
+  if (fingerprint.length > 0) {
+    const idx = text.indexOf(fingerprint);
+    if (idx >= 0) {
+      const after = text.slice(idx + framedText.length);
+      if (after.trim().length > 0) text = after;
+    }
+  }
+  text = text.replace(/\n{3,}/g, '\n\n').trim();
+  if (text.length > maxChars) text = text.slice(-maxChars);
+  return text;
+}

--- a/relay/src/sprites/pty-btw-queue.ts
+++ b/relay/src/sprites/pty-btw-queue.ts
@@ -132,6 +132,13 @@ export class PtyBtwQueue extends EventEmitter {
   private readonly privateState = new WeakMap<PtyBtwQueueEntry, EntryPrivate>();
   /** tabId → { unsub, refCount } — multiplex a single listener per tab. */
   private readonly tapsByTab = new Map<string, { unsub: () => void; refCount: number }>();
+  /**
+   * tabId → messageId of the single entry currently in-flight on that PTY.
+   * A PTY has one stdin/stdout; multiple concurrent injections on the same
+   * tab would interleave output and poison response correlation. Serialize
+   * per tab (across subagents) so only one entry is awaiting at a time.
+   */
+  private readonly inFlightByTab = new Map<string, string>();
   private readonly settleMs: number;
   private readonly maxWaitMs: number;
   private readonly maxResponseChars: number;
@@ -202,10 +209,30 @@ export class PtyBtwQueue extends EventEmitter {
   private drainFor(subagentId: string): void {
     const list = this.bySubagent.get(subagentId);
     if (!list || list.length === 0) return;
-    if (list.some(e => e.status === 'awaiting_response')) return;
     const head = list.find(e => e.status === 'queued');
     if (!head) return;
+    // Tab-wide serialization: if any entry is already awaiting on this
+    // tab (possibly for a different subagent), wait. A PTY has a single
+    // stdin/stdout — injecting two /btws in parallel would interleave
+    // output and make response correlation ambiguous.
+    if (this.inFlightByTab.has(head.tabId)) return;
     this.inject(head);
+  }
+
+  /**
+   * Drain the oldest queued entry on `tabId` across all subagents, if
+   * nothing is currently in-flight. Called after a finalize/drop so the
+   * next waiting entry on the tab can proceed.
+   */
+  private drainForTab(tabId: string): void {
+    if (this.inFlightByTab.has(tabId)) return;
+    let oldest: PtyBtwQueueEntry | undefined;
+    for (const entry of this.byMessageId.values()) {
+      if (entry.tabId !== tabId) continue;
+      if (entry.status !== 'queued') continue;
+      if (!oldest || entry.queuedAt < oldest.queuedAt) oldest = entry;
+    }
+    if (oldest) this.inject(oldest);
   }
 
   private inject(entry: PtyBtwQueueEntry): void {
@@ -218,6 +245,7 @@ export class PtyBtwQueue extends EventEmitter {
     }
     entry.status = 'awaiting_response';
     entry.injectedAt = Date.now();
+    this.inFlightByTab.set(entry.tabId, entry.messageId);
     const priv = this.privateState.get(entry)!;
     priv.maxWaitTimer = setTimeout(() => {
       logger.warn(
@@ -231,11 +259,11 @@ export class PtyBtwQueue extends EventEmitter {
       );
       this.finalize(entry, 'max-wait');
     }, this.maxWaitMs);
-    // Seed a minWait settle so instant replies still get at least a beat
-    // of capture time before we declare the turn done.
-    priv.settleTimer = setTimeout(() => {
-      this.finalize(entry, 'settled');
-    }, Math.max(this.minWaitMs, this.settleMs));
+    // Seed settle so instant replies still get at least a beat of capture
+    // time. `scheduleSettle` enforces the `injectedAt + minWaitMs` floor on
+    // both the initial seed and every reset from onChunk, so a fast first
+    // chunk cannot finalize before minWait has elapsed.
+    this.scheduleSettle(entry);
     this.emit('injected', {
       sessionId: entry.sessionId,
       tabId: entry.tabId,
@@ -253,6 +281,23 @@ export class PtyBtwQueue extends EventEmitter {
       },
       'PtyBtwQueue: injected',
     );
+  }
+
+  /**
+   * (Re)arm the settle timer for an awaiting entry. The delay is
+   * `max(settleMs, injectedAt + minWaitMs - now)` so a fast first chunk
+   * never finalizes earlier than `minWaitMs` after injection — keeping
+   * the contract even when `settleMs < minWaitMs`.
+   */
+  private scheduleSettle(entry: PtyBtwQueueEntry): void {
+    const priv = this.privateState.get(entry);
+    if (!priv) return;
+    if (priv.settleTimer) clearTimeout(priv.settleTimer);
+    const now = Date.now();
+    const injectedAt = entry.injectedAt ?? now;
+    const minFloor = injectedAt + this.minWaitMs - now;
+    const delay = Math.max(this.settleMs, minFloor);
+    priv.settleTimer = setTimeout(() => this.finalize(entry, 'settled'), delay);
   }
 
   private attachTap(tabId: string): void {
@@ -279,16 +324,17 @@ export class PtyBtwQueue extends EventEmitter {
   }
 
   private onChunk(tabId: string, chunk: Buffer): void {
-    const text = chunk.toString('utf8');
-    for (const entry of this.byMessageId.values()) {
-      if (entry.tabId !== tabId) continue;
-      if (entry.status !== 'awaiting_response') continue;
-      const priv = this.privateState.get(entry);
-      if (!priv) continue;
-      priv.output.push(text);
-      if (priv.settleTimer) clearTimeout(priv.settleTimer);
-      priv.settleTimer = setTimeout(() => this.finalize(entry, 'settled'), this.settleMs);
-    }
+    // Tab-wide serialization guarantees at most one awaiting entry per tab,
+    // so we route the chunk to that entry via `inFlightByTab` instead of
+    // scanning all entries (O(1) vs. O(n)).
+    const messageId = this.inFlightByTab.get(tabId);
+    if (!messageId) return;
+    const entry = this.byMessageId.get(messageId);
+    if (!entry || entry.status !== 'awaiting_response') return;
+    const priv = this.privateState.get(entry);
+    if (!priv) return;
+    priv.output.push(chunk.toString('utf8'));
+    this.scheduleSettle(entry);
   }
 
   private finalize(entry: PtyBtwQueueEntry, why: 'settled' | 'max-wait'): void {
@@ -300,9 +346,10 @@ export class PtyBtwQueue extends EventEmitter {
     }
     const raw = priv ? priv.output.join('') : '';
     const text = cleanPtyResponse(raw, entry.constrainedText, this.maxResponseChars);
-    const subagentId = entry.subagentId;
+    const tabId = entry.tabId;
+    this.releaseInFlight(entry);
     this.remove(entry);
-    this.detachTap(entry.tabId);
+    this.detachTap(tabId);
     this.emit('responded', {
       sessionId: entry.sessionId,
       tabId: entry.tabId,
@@ -327,7 +374,16 @@ export class PtyBtwQueue extends EventEmitter {
       },
       'PtyBtwQueue: finalized response',
     );
-    queueMicrotask(() => this.drainFor(subagentId));
+    // The tab is now free — drain the oldest queued entry on this tab
+    // regardless of subagent.
+    queueMicrotask(() => this.drainForTab(tabId));
+  }
+
+  /** Release this entry's claim on its tab's in-flight slot, if held. */
+  private releaseInFlight(entry: PtyBtwQueueEntry): void {
+    if (this.inFlightByTab.get(entry.tabId) === entry.messageId) {
+      this.inFlightByTab.delete(entry.tabId);
+    }
   }
 
   private dropInternal(entry: PtyBtwQueueEntry, reason: string): void {
@@ -337,8 +393,10 @@ export class PtyBtwQueue extends EventEmitter {
       if (priv.maxWaitTimer) clearTimeout(priv.maxWaitTimer);
     }
     const wasAwaiting = entry.status === 'awaiting_response';
+    const tabId = entry.tabId;
+    this.releaseInFlight(entry);
     this.remove(entry);
-    if (wasAwaiting) this.detachTap(entry.tabId);
+    if (wasAwaiting) this.detachTap(tabId);
     this.emit('dropped', {
       sessionId: entry.sessionId,
       tabId: entry.tabId,
@@ -358,6 +416,9 @@ export class PtyBtwQueue extends EventEmitter {
       },
       'PtyBtwQueue: dropped',
     );
+    // If we just freed an in-flight slot, let another queued entry drain
+    // onto this tab.
+    if (wasAwaiting) queueMicrotask(() => this.drainForTab(tabId));
   }
 
   private remove(entry: PtyBtwQueueEntry): void {
@@ -407,11 +468,11 @@ export class PtyBtwQueue extends EventEmitter {
       this.dropInternal(entry, reason);
       count += 1;
     }
+    // The tab is gone — nothing left can drain onto it, so force-clear
+    // the in-flight slot and the output tap regardless of refCount state.
+    this.inFlightByTab.delete(tabId);
     const existing = this.tapsByTab.get(tabId);
     if (existing) {
-      // The PTY is gone — unsubscribing via the adapter would no-op, but
-      // clear our bookkeeping so a future enqueue with a new tabId of the
-      // same id (unlikely but possible) starts clean.
       try {
         existing.unsub();
       } catch {
@@ -448,6 +509,7 @@ export class PtyBtwQueue extends EventEmitter {
     this.bySubagent.clear();
     this.byMessageId.clear();
     this.tapsByTab.clear();
+    this.inFlightByTab.clear();
     this.removeAllListeners();
   }
 


### PR DESCRIPTION
## Summary

- Adds `PtyBtwQueue` — a PTY-native per-subagent /btw queue that writes framed text directly into the PTY via `PtyAdapter.write(tabId, ...)` and taps `PtyAdapter.onOutput` for reply correlation (2s settle, 30s max-wait, ANSI-stripped + echo-removed tail).
- Adds `PtyAdapter.onOutput(tabId, listener)` subscription API so the queue can see raw bytes without stepping on the viewer/ring path.
- Routes `sprite.message` in `ws.ts` based on `sessionKind`: SDK sessions keep using `fleetManager.enqueueSpriteMessage`, PTY/dead sessions go through `ptyBtwQueue`. Drops now carry the clarified `"Agent dismissed — response unavailable"` reason (folds in Option 2 from the Wave A plan).
- Symmetric drops on subagent complete/dismissed and tab-closed so bubbles don't hang.

## Context

Device QA after PR #158 instrumentation (QA-FIXES #11 Layer 2) showed every dropped /btw had `mappingFound:true, subagentIdKnown:true, sessionKind:pty-or-dead, agentStatus:working`. The mapping is present — `fleetManager.enqueueSpriteMessage` returns `false` because PTY sessions have no SDK worker to route to, so every tap drops with `"No active session — /btw cannot be delivered"` (which iOS renders as `(Agent completed before delivery)`). Grace-widening (Option 2) wouldn't have helped. This PR is Option 1 of the handoff plan.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run build` — clean (390.1 KB bundle)
- [x] `npx vitest run` — 298 tests pass (19 new, 2 added to PtyAdapter)
- [ ] Device QA: spawn Explore subagent in a PTY tab, tap sprite, send `/btw what are you looking at right now?` — expect `queued` status, then within a few seconds a `delivered` status + 1–2 sentence response captured from the PTY and shown on the sprite
- [ ] Device QA: tap a subagent that just dismissed (< 5s after SubagentStop) — expect `dropped` with `"Agent dismissed — response unavailable"` instead of the old `"Agent completed before delivery"`
- [ ] Device QA: tap multiple subagents in parallel — each response should route back to the correct sprite with no interleaving

🤖 Generated with [Claude Code](https://claude.com/claude-code)