### PR TITLE
fix: Wave D quick wins — PTY cwd restore, tab title suppression, SpriteKit Stats rename

### DIFF
--- a/ios/MajorTom/Features/Office/Scenes/OfficeScene.swift
+++ b/ios/MajorTom/Features/Office/Scenes/OfficeScene.swift
@@ -89,7 +89,7 @@ final class OfficeScene: SKScene {
     /// Guard against `didMove(to:)` being invoked more than once (e.g. SpriteView re-hosting).
     private var hasSetup = false
 
-    /// NotificationCenter token for live Performance HUD toggle updates.
+    /// NotificationCenter token for live SpriteKit Stats toggle updates.
     private var perfHUDObserver: NSObjectProtocol?
 
     // MARK: - Scene Lifecycle
@@ -106,7 +106,7 @@ final class OfficeScene: SKScene {
         // Enable multi-touch for pinch zoom
         view.isMultipleTouchEnabled = true
 
-        // Performance HUD — flipped via Settings → Developer → Performance HUD.
+        // SpriteKit Stats — flipped via Settings → Developer → SpriteKit Stats.
         // Re-applied live when the preference changes so we don't need to
         // leave/return to the Office tab while measuring.
         applyPerfHUD(to: view)
@@ -147,7 +147,7 @@ final class OfficeScene: SKScene {
         }
     }
 
-    // MARK: - Performance HUD
+    // MARK: - SpriteKit Stats
 
     private func applyPerfHUD(to view: SKView) {
         let enabled = PerfHUDPreferences.isEnabled

--- a/ios/MajorTom/Features/Settings/Views/SettingsView.swift
+++ b/ios/MajorTom/Features/Settings/Views/SettingsView.swift
@@ -244,7 +244,7 @@ struct SettingsView: View {
     private var developerSection: some View {
         Section {
             Toggle(isOn: $showsPerfHUD) {
-                Label("Performance HUD", systemImage: "speedometer")
+                Label("SpriteKit Stats", systemImage: "speedometer")
             }
             .onChange(of: showsPerfHUD) { _, newValue in
                 PerfHUDPreferences.isEnabled = newValue
@@ -253,7 +253,7 @@ struct SettingsView: View {
         } header: {
             Text("Developer")
         } footer: {
-            Text("Overlays SpriteKit FPS + node/draw/quad counts on the Office scene. Use during Instruments profiling — see docs/PERF-BASELINE.md.")
+            Text("Overlays SpriteKit FPS + node/draw/quad counts on the Office scene. Use during Instruments profiling — see docs/PERF-BASELINE.md. (Not the iOS Metal Performance HUD — that lives in iOS Settings → Developer and can't be toggled from an app.)")
         }
     }
 

--- a/ios/MajorTom/Features/Terminal/ViewModels/TerminalViewModel.swift
+++ b/ios/MajorTom/Features/Terminal/ViewModels/TerminalViewModel.swift
@@ -481,12 +481,15 @@ final class TerminalViewModel {
         case .bell:
             HapticService.impact(.light)
 
-        case .title(let title):
-            // Update the active tab's title from xterm title escape sequence.
-            let newTitle = title.isEmpty ? "Terminal" : title
-            if let index = tabs.firstIndex(where: { $0.isActive }) {
-                tabs[index].title = newTitle
-            }
+        case .title:
+            // Intentional no-op. claude and other TUIs emit OSC 0/2 title
+            // escape sequences on every turn, which used to clobber the
+            // user-visible tab label with a running commentary on claude's
+            // current task. The tab's default label + the explicit
+            // TabTitleStore rename flow are the source of truth now; the
+            // xterm-supplied title is consumed internally by xterm for its
+            // own bookkeeping but is not propagated to TerminalTab.title.
+            break
 
         case .selection(let text):
             UIPasteboard.general.string = text

--- a/relay/src/adapters/__tests__/pty-adapter.test.ts
+++ b/relay/src/adapters/__tests__/pty-adapter.test.ts
@@ -526,6 +526,126 @@ describe('PtyAdapter spawn env prep', () => {
   });
 });
 
+describe('PtyAdapter cwd override (QA-FIXES #12)', () => {
+  // These tests pin the behavior that respawns after relay restart land in
+  // the tab's prior workingDir (persisted via TabRegistry from SessionStart
+  // hook), falling back to the adapter default when the dir is gone. Without
+  // coverage, a refactor could silently revert to always-HOME.
+
+  it('honors a cwd override when the directory exists', async () => {
+    const { mkdtemp, rm } = await import('node:fs/promises');
+    const { tmpdir } = await import('node:os');
+    const { join } = await import('node:path');
+    const dir = await mkdtemp(join(tmpdir(), 'mt-pty-cwd-'));
+    try {
+      let capturedCwd: string | undefined;
+      let capturedEnv: Record<string, string> | undefined;
+      const fakePty = {
+        pid: 1, cols: 80, rows: 24,
+        onData() {}, onExit() {}, kill: vi.fn(), resize: vi.fn(), write: vi.fn(),
+      };
+      const a = new PtyAdapter({
+        cwd: '/fallback-never-used',
+        env: { SHELL: '/bin/bash' },
+        spawn: ((_file: string, _args: string[], opts: { cwd: string; env: Record<string, string> }) => {
+          capturedCwd = opts.cwd;
+          capturedEnv = opts.env;
+          return fakePty;
+        }) as never,
+      });
+      try {
+        a.attach('tab-1', makeClient(), { ...ATTACH_DEFAULTS, cwd: dir });
+        expect(capturedCwd).toBe(dir);
+        // PWD must mirror spawn cwd so the first prompt expands correctly.
+        expect(capturedEnv?.PWD).toBe(dir);
+      } finally {
+        a.dispose();
+      }
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('falls back to the adapter default when the override directory is missing', () => {
+    let capturedCwd: string | undefined;
+    const fakePty = {
+      pid: 1, cols: 80, rows: 24,
+      onData() {}, onExit() {}, kill: vi.fn(), resize: vi.fn(), write: vi.fn(),
+    };
+    const a = new PtyAdapter({
+      cwd: '/tmp',
+      env: { SHELL: '/bin/bash' },
+      spawn: ((_file: string, _args: string[], opts: { cwd: string }) => {
+        capturedCwd = opts.cwd;
+        return fakePty;
+      }) as never,
+    });
+    try {
+      a.attach('tab-1', makeClient(), {
+        ...ATTACH_DEFAULTS,
+        cwd: '/this/path/does/not/exist/anywhere',
+      });
+      expect(capturedCwd).toBe('/tmp');
+    } finally {
+      a.dispose();
+    }
+  });
+
+  it('falls back when the override path exists but is not a directory', async () => {
+    const { mkdtemp, rm, writeFile } = await import('node:fs/promises');
+    const { tmpdir } = await import('node:os');
+    const { join } = await import('node:path');
+    const dir = await mkdtemp(join(tmpdir(), 'mt-pty-cwd-file-'));
+    const filePath = join(dir, 'not-a-dir.txt');
+    await writeFile(filePath, 'hello');
+    try {
+      let capturedCwd: string | undefined;
+      const fakePty = {
+        pid: 1, cols: 80, rows: 24,
+        onData() {}, onExit() {}, kill: vi.fn(), resize: vi.fn(), write: vi.fn(),
+      };
+      const a = new PtyAdapter({
+        cwd: '/tmp',
+        env: { SHELL: '/bin/bash' },
+        spawn: ((_file: string, _args: string[], opts: { cwd: string }) => {
+          capturedCwd = opts.cwd;
+          return fakePty;
+        }) as never,
+      });
+      try {
+        a.attach('tab-1', makeClient(), { ...ATTACH_DEFAULTS, cwd: filePath });
+        expect(capturedCwd).toBe('/tmp');
+      } finally {
+        a.dispose();
+      }
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('uses the adapter default when no cwd override is supplied', () => {
+    let capturedCwd: string | undefined;
+    const fakePty = {
+      pid: 1, cols: 80, rows: 24,
+      onData() {}, onExit() {}, kill: vi.fn(), resize: vi.fn(), write: vi.fn(),
+    };
+    const a = new PtyAdapter({
+      cwd: '/adapter/default',
+      env: { SHELL: '/bin/bash' },
+      spawn: ((_file: string, _args: string[], opts: { cwd: string }) => {
+        capturedCwd = opts.cwd;
+        return fakePty;
+      }) as never,
+    });
+    try {
+      a.attach('tab-1', makeClient(), ATTACH_DEFAULTS);
+      expect(capturedCwd).toBe('/adapter/default');
+    } finally {
+      a.dispose();
+    }
+  });
+});
+
 describe('PtyAdapter constants', () => {
   it('default input max matches the spec', () => {
     expect(DEFAULT_INPUT_MAX_BYTES).toBe(64 * 1024);

--- a/relay/src/adapters/pty-adapter.ts
+++ b/relay/src/adapters/pty-adapter.ts
@@ -19,6 +19,7 @@
  */
 import * as pty from 'node-pty';
 import type { IPty } from 'node-pty';
+import { statSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { logger } from '../utils/logger.js';
 
@@ -52,6 +53,12 @@ export interface AttachOptions {
    * this (the PTY's env is fixed at spawn time).
    */
   envExtras?: Record<string, string>;
+  /**
+   * Per-spawn cwd override. Consulted on first spawn only; reattach keeps
+   * whatever cwd the PTY already has. When the path is missing or not a
+   * directory, the adapter falls back to its default cwd and logs a WARN.
+   */
+  cwd?: string;
 }
 
 export type AttachOutcome =
@@ -369,18 +376,22 @@ export class PtyAdapter {
     env['TERM'] = env['TERM'] ?? 'xterm-256color';
     env['COLORTERM'] = env['COLORTERM'] ?? 'truecolor';
     env['LANG'] = env['LANG'] ?? 'en_US.UTF-8';
+    // If the caller supplied a cwd override (tab's prior workingDir), verify
+    // the directory still exists before using it — deleted/moved directories
+    // would cause node-pty to fail the spawn. Fall back to adapter default.
+    const spawnCwd = this.resolveSpawnCwd(tabId, opts.cwd);
     // Align PWD with the spawn cwd so shell prompts expanding `\W` (bash)
     // or equivalents render the correct basename on the very first prompt.
     // Without this, bash inherits whatever PWD the relay process has, and
     // the initial PS1 expansion can fall out of sync with the child's
     // actual working directory until the user runs `cd` or equivalent.
-    env['PWD'] = this.cwd;
+    env['PWD'] = spawnCwd;
 
     const ptyProcess = this.spawnFn(this.shell, this.shellArgs, {
       name: 'xterm-256color',
       cols: opts.cols,
       rows: opts.rows,
-      cwd: this.cwd,
+      cwd: spawnCwd,
       env,
       // Binary mode: node-pty's types claim `string` but with `encoding: null`
       // it emits Buffers. See microsoft/node-pty#489.
@@ -450,6 +461,23 @@ export class PtyAdapter {
     });
 
     return session;
+  }
+
+  private resolveSpawnCwd(tabId: string, override: string | undefined): string {
+    if (!override) return this.cwd;
+    try {
+      if (statSync(override).isDirectory()) return override;
+      logger.warn(
+        { tabId, override, fallback: this.cwd },
+        'Tab cwd override exists but is not a directory — falling back',
+      );
+    } catch (err) {
+      logger.warn(
+        { err, tabId, override, fallback: this.cwd },
+        'Tab cwd override unreadable — falling back to default',
+      );
+    }
+    return this.cwd;
   }
 
   private evict(tabId: string): void {

--- a/relay/src/app.ts
+++ b/relay/src/app.ts
@@ -413,7 +413,7 @@ export async function buildApp(config: AppConfig) {
   // Shell WebSocket — registered after `createPreferencesRoutes` so its
   // path doesn't collide with any earlier catch-all. PtyAdapter was
   // constructed earlier so the health route could report tab counts.
-  await app.register(createShellRoute({ ptyAdapter }));
+  await app.register(createShellRoute({ ptyAdapter, tabRegistry }));
 
   // WebSocket (auth via session cookie on upgrade)
   await app.register(createWsRoute({

--- a/relay/src/routes/shell.ts
+++ b/relay/src/routes/shell.ts
@@ -13,11 +13,18 @@ import type { FastifyPluginAsync } from 'fastify';
 import type { WebSocket } from 'ws';
 import { verifySessionToken, SESSION_COOKIE } from '../auth/session.js';
 import type { PtyAdapter, PtyClient } from '../adapters/pty-adapter.js';
+import type { TabRegistry } from '../tabs/tab-registry.js';
 import { MAJOR_TOM_CONFIG_DIR } from '../installer/install-hooks.js';
 import { logger } from '../utils/logger.js';
 
 interface ShellRouteDeps {
   ptyAdapter: PtyAdapter;
+  /**
+   * Used to look up a tab's persisted workingDir (from the last SessionStart
+   * hook) so reconnects after relay restart respawn in the tab's prior cwd
+   * instead of HOME. Optional — when undefined, the adapter uses its default.
+   */
+  tabRegistry?: TabRegistry;
 }
 
 interface ShellAuthResult {
@@ -128,7 +135,7 @@ function buildEnvExtras(tabId: string): Record<string, string> {
 }
 
 export function createShellRoute(deps: ShellRouteDeps): FastifyPluginAsync {
-  const { ptyAdapter } = deps;
+  const { ptyAdapter, tabRegistry } = deps;
 
   return async (fastify) => {
     fastify.get<{
@@ -169,10 +176,16 @@ export function createShellRoute(deps: ShellRouteDeps): FastifyPluginAsync {
         const rows = parsedRows.value ?? 24;
 
         const client = toPtyClient(socket);
+        // Restore the tab's prior workingDir across relay restart / fresh
+        // spawn. TabRegistry captures cwd at SessionStart hook-time and
+        // persists it; the adapter validates the path before use and falls
+        // back to its default if the directory is gone.
+        const persistedCwd = tabRegistry?.getTab(tabId)?.workingDir;
         const outcome = ptyAdapter.attach(tabId, client, {
           cols,
           rows,
           envExtras: buildEnvExtras(tabId),
+          ...(persistedCwd ? { cwd: persistedCwd } : {}),
         });
         if (outcome.kind === 'rejected') {
           try {


### PR DESCRIPTION
## Summary

Wave D quick-wins batch — three small independent P2 polish items from `docs/QA-FIXES.md`, one atomic commit each.

- **QA-FIXES #12** (relay) — respawned PTYs now land in the tab's prior workingDir instead of HOME. TabRegistry already captured cwd on SessionStart; wired through `createShellRoute` -> `PtyAdapter.attach` with a `statSync` safety check and fallback to the adapter default.
- **QA-FIXES #14** (iOS) — claude's OSC 0/2 title escape sequences no longer clobber `TerminalTab.title`. User rename via `TabTitleStore` is the source of truth for tab labels. Bridge message stays wired so the JS/Swift protocol is unchanged; Swift handler is a deliberate no-op with a comment explaining why.
- **QA-FIXES #11b** (iOS) — renamed Settings -> Developer -> "Performance HUD" to "SpriteKit Stats" and clarified the footer so nobody confuses it with the iOS device-level Metal Performance HUD (which no app-level code can suppress). Only label + comments changed; `PerfHUDPreferences` type keeps its name to avoid churn.

## Test plan

- [x] `relay` vitest suite — 35 pty-adapter tests (4 new for cwd override), 17 shell route tests.
- [x] `npx tsc --noEmit` clean in relay/.
- [x] `XcodeBuildMCP build_sim` clean for MajorTom scheme on iPhone 17 simulator.
- [ ] **Device QA on Sean's iPhone**:
  - [ ] #12: open a terminal tab, run `cd /Users/seansimpson/Documents/code/dev/major-tom`, launch claude, restart relay, reattach — new shell prompt should land in `major-tom/`, not `$HOME`.
  - [ ] #12: same flow but move/delete the prior cwd before reconnect — expect `$HOME` fallback with a WARN in `/tmp/relay.log`.
  - [ ] #14: start claude in a tab you haven't renamed — tab label stays "Terminal", never auto-renames to claude's task description.
  - [ ] #14: rename a tab via long-press — user rename still wins and persists.
  - [ ] #11b: Settings -> Developer shows "SpriteKit Stats" with the updated footer. Toggle flips SKView FPS/nodes/draws/quads text on the Office scene.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
