### PR TITLE
fix: Wave D sprite randomization — relay rolls per spawn, iOS drops role override

### DIFF
--- a/docs/PHASE-SPRITE-AGENT-WIRING.md
+++ b/docs/PHASE-SPRITE-AGENT-WIRING.md
@@ -41,22 +41,26 @@ Each terminal/session gets its own isolated Office (SKScene). Only one scene ren
 - `AgentSpawnEvent` includes `parentId` (no longer discarded)
 - Reconnects restore the mapping from the relay
 
-**Role → sprite mapping (hybrid, 3-tier):**
+**Role classification (still hybrid, 3-tier):**
 1. **Agent `.md` frontmatter** — if the agent file declares `spriteCategory: frontend`, use it directly
 2. **Relay classifier** — regex pattern matching task description against 8 canonical roles: `researcher, architect, qa, devops, frontend, backend, lead, engineer`
-3. **Random from idle pool** — fallback for unrecognized roles
+3. **Fallback** — unrecognized task descriptions default to `engineer`
+
+Canonical role drives: sprite label, role aura color, and analytics tagging. It does **not** drive character choice — see below.
 
 **Clone-not-consume model:**
 - Idle sprites (cosmetic crew wandering around) and agent sprites (active subagent representations at desks) are separate concepts
-- When role=`frontend` spawns, an agent sprite instance is **cloned into existence** with the `frontendDev` CharacterType. It does NOT consume the idle frontendDev sprite.
-- Idle frontendDev can still wander the break room while two agent frontendDev sprites work at two desks.
-- Multiple agents with the same role in one session = multiple identical sprites at different desks. Differentiation via tap-to-inspect (desk position provides spatial identity).
+- When a subagent spawns, an agent sprite instance is **cloned into existence** with whatever CharacterType the relay rolls for it (see randomization below). It does NOT consume any idle sprite of the same CharacterType.
+- Idle crew can still wander the break room while agent sprites of the same CharacterType work at desks.
+- Multiple agents in one session = multiple sprites at different desks. Differentiation via tap-to-inspect (desk position + randomized character both provide spatial/visual identity).
 - Subagent completes → agent sprite despawns (celebration animation → poof).
 
-**Role-stable binding:**
-- First `frontend` spawn in a session reserves the `frontendDev` CharacterType for that role
-- All subsequent `frontend` spawns reuse the same CharacterType
-- Different sessions can independently map `frontend` → different sprites
+**Character randomization (replaces role-stable binding — QA-FIXES #9, 2026-04-22):**
+- The relay picks a random non-dog CharacterType per spawn from a flat pool of 14 crew characters.
+- Within a session, the relay avoids duplicates until the pool is exhausted; the 15th+ concurrent spawn duplicates an in-use character.
+- Role → character is NOT stable across spawns. Two `frontend` subagents in the same session will usually be different characters; two different roles can land on the same character just as easily.
+- iOS receives the CharacterType verbatim via `sprite.link.characterType` and `sprite.state.mappings[].characterType`. There is no client-side role → character lookup.
+- Rationale: the "who am I gonna get?!" roll is a feature. It also kills off a class of client/relay desync bugs (QA-FIXES #6) where iOS's local role→character map disagreed with the relay's.
 
 **Dog fallback REMOVED:**
 - Current code at `OfficeViewModel.swift:138` falls back to dogs when all humans are exhausted. This is incorrect.
@@ -230,7 +234,7 @@ The Office tab no longer opens directly into an SKScene. It opens a **manager sc
 |---|---|---|
 | A | Terminal 1 spawns agents, user on Terminal 2's Office | Terminal 1's Office updates in background (state tracked by relay). Notifications still fire per M2. |
 | B | Switch from Office 1 to Office 2 | Return to Office Manager, tap Office 2 card. Office 1's scene suspends or cold-destroys per lifecycle. |
-| C | Same role spawns in both sessions | Same CharacterType in both Offices (independent pools). No collision. |
+| C | Same role spawns in both sessions | Each Office rolls independently from its own CHARACTER_POOL — post-QA-FIXES #9 there is no role→character lock, so even within one session two same-role spawns usually land on different characters. Cross-session collision is possible and fine. |
 | D | Session ends on Terminal 1 | Office Manager removes that Office's card. If user is viewing it, return to Manager with brief transition. |
 
 ### Sprite allocation scenarios
@@ -298,7 +302,7 @@ Sprite ↔ subagent mappings are persisted to disk (JSON file per session).
 | Mapping persistence format | GREEN | Mirrors `SessionPersistence` pattern. `~/.major-tom/sprite-mappings/{sessionId}.json` |
 | Office Manager SwiftUI | GREEN | NavigationStack, per-session OfficeViewModel, LRU scene cache (2-3 warm, ~50MB each) |
 | Local notification setup | YELLOW | Infra exists, "Cool Beans" action trivial. WebSocket dies ~10s after iOS background. **Compromise: relay queues responses, delivers on reconnect. Local push only during grace period.** |
-| Role → sprite mapping table | GREEN | 14 humans, 8 roles, clean 1:1 mapping with 6 extras for overflow |
+| Role → sprite mapping table | ~~GREEN~~ STRUCK (QA-FIXES #9, 2026-04-22) | Replaced with per-spawn randomization — see "Character randomization" in Q2 above. |
 
 ### Spec adjustments from research
 
@@ -306,20 +310,21 @@ Sprite ↔ subagent mappings are persisted to disk (JSON file per session).
 2. **`/btw` injection** goes through orchestrator session (SDK exposes no subagent handle). Constraint framing tells Claude to relay to specific subagent.
 3. **Cross-cutting blockers** identified for Wave 2: agent events need `sessionId`, relay needs "get agents for session X" query, relay must queue `/btw` responses for disconnected clients.
 
-### Role → CharacterType mapping (LOCKED)
+### Character assignment — randomized (post-QA-FIXES #9, 2026-04-22)
 
-| Canonical Role | CharacterType | Rationale |
-|---|---|---|
-| `researcher` | `.botanist` | Science/discovery vibe |
-| `architect` | `.captain` | Authority, big-picture |
-| `qa` | `.doctor` | Diagnostic precision |
-| `devops` | `.mechanic` | Infrastructure ops |
-| `frontend` | `.frontendDev` | Direct match |
-| `backend` | `.backendEngineer` | Direct match |
-| `lead` | `.pm` | Project leadership |
-| `engineer` | `.claudimusPrime` | Generic = ship's AI |
+The prior locked role→CharacterType table has been struck. Every sprite spawn rolls a random CharacterType from a flat pool of 14 non-dog crew characters; the session-active roster is used as an exclusion set until the pool is exhausted.
 
-Overflow pool (random fallback): `alienDiplomat`, `bowenYang`, `chef`, `dwight`, `kendrick`, `prince`
+**CHARACTER_POOL** (relay source of truth — `relay/src/sprites/sprite-mapper.ts`, keep in lockstep with `ios/.../CharacterType`):
+
+```
+alienDiplomat, backendEngineer, botanist, bowenYang, captain, chef,
+claudimusPrime, doctor, dwight, frontendDev, kendrick, mechanic,
+pm, prince
+```
+
+Dogs (`elvis`, `esteban`, `hoku`, `kai`, `senor`, `steve`, `zuckerbot`) are NEVER assigned as agent sprites — they live at tab scope as pets.
+
+Why randomized: the "who am I gonna get?!" roll each spawn is a feature (L9 QA user call). It also closes out the client/relay role→character desync class of bugs (QA-FIXES #6) by removing the client-side mapping entirely — iOS now trusts the relay's `characterType` field verbatim.
 
 ---
 
@@ -344,7 +349,7 @@ Overflow pool (random fallback): `alienDiplomat`, `bowenYang`, `chef`, `dwight`,
 
 **iOS track** (`sprite-wiring/wave2-ios`):
 - Add `linkedSubagentId` to `AgentState`
-- Role → CharacterType mapper (locked table above)
+- Role → CharacterType mapping (~~locked table~~ STRUCK — randomized per spawn post-QA-FIXES #9)
 - Clone-not-consume sprite allocation model
 - Remove dog fallback in `OfficeViewModel` (duplicate humans instead)
 - Per-session OfficeViewModel routing (prep for Wave 3)

--- a/docs/PHASE-SPRITE-AGENT-WIRING.md
+++ b/docs/PHASE-SPRITE-AGENT-WIRING.md
@@ -63,8 +63,9 @@ Canonical role drives: sprite label, role aura color, and analytics tagging. It 
 - Rationale: the "who am I gonna get?!" roll is a feature. It also kills off a class of client/relay desync bugs (QA-FIXES #6) where iOS's local role→character map disagreed with the relay's.
 
 **Dog fallback REMOVED:**
-- Current code at `OfficeViewModel.swift:138` falls back to dogs when all humans are exhausted. This is incorrect.
-- Dogs are NEVER claimed as agent sprites. If humans are exhausted, duplicate human sprites are used instead.
+- Dogs are NEVER claimed as agent sprites. They live at tab scope as pets (elvis, steve, kai, hoku, senor, esteban, zuckerbot) and can appear as idle sprites wandering the Office, but are unreachable as randomization picks.
+- Both sides enforce this: the relay's `CHARACTER_POOL` omits dog CharacterTypes, and iOS's `characterType(from:)` / `randomNonDogCharacter(excluding:)` helpers reject any dog value the relay might accidentally send.
+- When the randomization pool is exhausted (15+ concurrent agents in one session), the 15th+ spawn duplicates an in-use human character; it never falls through to a dog.
 
 ### Q3 — Messaging: `/btw` observe-only, queue at turn boundary
 

--- a/docs/QA-FIXES.md
+++ b/docs/QA-FIXES.md
@@ -319,24 +319,13 @@ Priority P2 — not functional breakage, just messy UX / misleading label.
 ---
 
 
-### 9. Flip sprite character assignment from role-mapping to randomization
+### 9. Flip sprite character assignment from role-mapping to randomization (FIXED — 2026-04-22)
 
-**User request (L9 QA, 2026-04-19):** current logic maps agent role → fixed character type (researcher→botanist, engineer→claudimusPrime, etc.). User wants to abandon the role-matching entirely and randomize the character per spawn. Rationale: "it's a feature not a bug that the frontend dev is doing database work" — plus the excitement of "who am I gonna get?!" each spawn. Also easier to implement.
+**Shipped in PR 2 of Wave D (2026-04-22).** Relay `sprite-mapper.ts` now picks from a flat `CHARACTER_POOL` (14 non-dog crew characters) with dup-avoidance against the session's active roster — the 15th+ concurrent spawn duplicates. iOS `SpriteLinkEvent` + `SpriteStateEvent.SpriteMapping` added `characterType: String?`, and the three OfficeViewModel call sites that used to call `RoleMapper.resolveCharacterType` now consume the relay's value directly. `RoleMapper` kept `color(forCanonicalRole:)` (Wave 5 aura palette still keyed on role) but the role→character map, overflow pool, and session-stable bindings are gone.
 
-**Fix direction:**
-- Delete `ROLE_CHARACTER_MAP` in `relay/src/sprites/sprite-mapper.ts`. Replace with a `CHARACTER_POOL` (flat list of all CharacterTypes).
-- `resolveCharacterType`: instead of role→type, pick a random CharacterType from the pool, optionally avoiding duplicates in the same session's active roster until the pool is exhausted.
-- Remove the role-stable binding concept — every spawn is a fresh roll.
-- iOS: strip the role-aware override tracked in QA-FIXES #6 (kept surfacing Kendrick / Bowen Yang instead of the locked role character) — with randomization, THAT becomes the feature. Item #6 can be closed as superseded.
-- Sprite labels (QA-FIXES #6) still humanize to canonical role (`researcher`, `engineer`), just decoupled from character choice.
+Closes QA-FIXES **#6** as superseded — the Kendrick/BowenYang-instead-of-botanist divergence was a consequence of iOS's now-dead local role→character lookup.
 
-**Files:**
-- `relay/src/sprites/sprite-mapper.ts` — pool-based picker.
-- `relay/src/sprites/__tests__/*.test.ts` — update mapping tests.
-- `docs/PHASE-SPRITE-AGENT-WIRING.md` — strike the locked role→CharacterType table, replace with randomization spec.
-- iOS `RoleMapper.swift` — remove any client-side role→character lookup; trust `sprite.mapping.created.characterType` from relay.
-
-**Priority:** P2 — not blocking QA. Picks up after the L-matrix. Closing QA-FIXES #6 folds into this change.
+Spec update: `docs/PHASE-SPRITE-AGENT-WIRING.md` — §Q2 "Character randomization" replaced the locked role-stable paragraph; the "Role → CharacterType mapping (LOCKED)" table was struck in-line and replaced with the `CHARACTER_POOL` spec.
 
 ---
 
@@ -391,26 +380,11 @@ Priority P2 — not functional breakage, just messy UX / misleading label.
 
 **Not blocking QA.** Follow-up: instrument state transitions server→client to confirm `.working` flips after spawn.
 
-### 6. Sprite role labels use agent-type names, not humanized roles
+### 6. Sprite role labels / iOS not honoring relay's characterType (SUPERSEDED BY #9 — 2026-04-22)
 
-**Symptom:** role tag above sprites shows raw subagent type (`Explore`, `claude-code-guide`) instead of a friendly role label.
+The secondary concern (iOS ignoring relay's characterType and picking Kendrick / Bowen Yang instead of the role-locked character) is closed as part of QA-FIXES #9: the relay now randomizes per spawn and iOS trusts `sprite.link.characterType` / `sprite.state.mappings[].characterType` verbatim. The client-side `RoleMapper.resolveCharacterType` and its `overflowPool` that were reassigning characters have been deleted.
 
-**Expected:** humanized role labels matching the canonical role (`researcher`, `engineer`). Relay already emits `canonicalRole` per sprite mapping event.
-
-**Fix direction:** iOS label rendering prefers `canonicalRole` (humanize "researcher" → "Researcher") over `agentType`. Fall back to `agentType` only when `canonicalRole` is missing.
-
-**Secondary concern (confirmed, higher priority than "nice-to-have"):** iOS is not using the `characterType` the relay sends. Observed twice across L4 / L5 runs:
-
-| Run | Relay sent (Explore → researcher → botanist) | iOS rendered |
-|---|---|---|
-| L4 | botanist | Kendrick |
-| L5 | botanist | Bowen Yang |
-
-Both Kendrick and Bowen Yang are in `RoleMapper.overflowPool`, not the primary mapping. Sprite-agent Wiring Wave 3/4 (PR #139/#140) was supposed to "clone not consume" using relay's characterType, but iOS appears to be reassigning via its own role-stable binding that skips primary roles and goes straight to overflow. This regresses the Role → CharacterType mapping spec table in `docs/PHASE-SPRITE-AGENT-WIRING.md` §Q5.
-
-**Investigate:** `OfficeViewModel` / `OfficeSceneManager` agent-lifecycle handler — does it honor `sprite.mapping.created.characterType` from the relay event, or does it overwrite with a local RoleMapper lookup? Likely the latter.
-
-**Files:** `AgentSprite.swift` (role label), `RoleMapper.swift` (humanization), `CharacterConfig.swift` (confirm mapping).
+The original "role labels use agent-type instead of humanized role" issue — relay already emits `canonicalRole` and iOS already surfaces it through `AgentState.role.capitalized`; no separate fix was needed.
 
 ---
 

--- a/ios/MajorTom/Core/Models/Message.swift
+++ b/ios/MajorTom/Core/Models/Message.swift
@@ -862,6 +862,12 @@ struct SpriteLinkEvent: Codable {
     let spriteHandle: String
     let subagentId: String
     let canonicalRole: String
+    /// Post-QA-FIXES #9 — relay picks a random CharacterType per spawn (no
+    /// more locked role→character table). iOS trusts this value directly;
+    /// there is no client-side override. Optional for back-compat with
+    /// older relay builds still on the network, but effectively always
+    /// present on post-#9 relays.
+    var characterType: String?
     let task: String
     var parentId: String?
     /// Tab-Keyed Offices (Wave 3) — tab this session lives in, if any.
@@ -896,6 +902,10 @@ struct SpriteStateEvent: Codable {
         let spriteHandle: String
         let subagentId: String
         let canonicalRole: String
+        /// Post-QA-FIXES #9 — carried through so reconnect rehydration
+        /// keeps whatever random CharacterType the relay originally
+        /// assigned. Optional for back-compat with older relays.
+        var characterType: String?
         let task: String
         var parentId: String?
         let status: String  // "working", "idle", "spawning"

--- a/ios/MajorTom/Features/Office/Models/RoleMapper.swift
+++ b/ios/MajorTom/Features/Office/Models/RoleMapper.swift
@@ -2,104 +2,15 @@ import Foundation
 import UIKit
 
 // MARK: - Role Mapper
+//
+// Post-QA-FIXES #9: character assignment is randomized per spawn by the
+// relay, so the old role→CharacterType map + session-stable binding are
+// gone. iOS trusts `sprite.link.characterType` from the relay directly
+// and does not derive CharacterType from the canonical role. What remains
+// here is the role → aura-color palette (Wave 5 spec), which is still
+// keyed on canonicalRole.
 
-/// Maps canonical agent roles to CharacterTypes for sprite assignment.
-///
-/// Locked mapping (from Sprite-Agent Wiring spec):
-///   researcher  -> .botanist
-///   architect   -> .captain
-///   qa          -> .doctor
-///   devops      -> .mechanic
-///   frontend    -> .frontendDev
-///   backend     -> .backendEngineer
-///   lead        -> .pm
-///   engineer    -> .claudimusPrime
-///
-/// Role-stable binding: the first spawn for a given canonical role in a session
-/// locks the CharacterType for that role. All subsequent spawns with the same role
-/// reuse the same CharacterType. Different sessions bind independently.
 enum RoleMapper {
-
-    // MARK: - Canonical Role Mapping
-
-    /// The 8 canonical roles recognized by the classifier.
-    static let canonicalRoles: Set<String> = [
-        "researcher", "architect", "qa", "devops",
-        "frontend", "backend", "lead", "engineer"
-    ]
-
-    /// The overflow pool — used when a role doesn't map to any of the 8 primaries.
-    /// These human CharacterTypes are never assigned as primary role mappings.
-    static let overflowPool: [CharacterType] = [
-        .alienDiplomat, .bowenYang, .chef, .dwight, .kendrick, .prince
-    ]
-
-    /// Direct mapping from canonical role string to CharacterType.
-    static func characterType(forCanonicalRole role: String) -> CharacterType? {
-        switch role.lowercased() {
-        case "researcher": return .botanist
-        case "architect":  return .captain
-        case "qa":         return .doctor
-        case "devops":     return .mechanic
-        case "frontend":   return .frontendDev
-        case "backend":    return .backendEngineer
-        case "lead":       return .pm
-        case "engineer":   return .claudimusPrime
-        default:           return nil
-        }
-    }
-
-    // MARK: - Role-Stable Binding
-
-    /// Session-scoped bindings: maps canonical role -> locked CharacterType.
-    /// Passed in and returned so callers own the storage (per-session).
-    typealias SessionBindings = [String: CharacterType]
-
-    /// Resolve the CharacterType for a role, respecting session-stable bindings.
-    ///
-    /// 1. If `role` was already bound this session, return the bound CharacterType.
-    /// 2. If `role` maps to a canonical primary, bind and return it.
-    /// 3. Otherwise, pick a random CharacterType from the overflow pool (excluding
-    ///    already-bound types) and bind it.
-    ///
-    /// - Parameters:
-    ///   - role: The canonical role string from the relay classifier.
-    ///   - sessionBindings: Current session's role->CharacterType bindings.
-    /// - Returns: The resolved CharacterType and the (potentially updated) bindings.
-    static func resolveCharacterType(
-        role: String,
-        sessionBindings: SessionBindings
-    ) -> (CharacterType, SessionBindings) {
-        let normalizedRole = role.lowercased()
-
-        // Already bound this session — reuse
-        if let bound = sessionBindings[normalizedRole] {
-            return (bound, sessionBindings)
-        }
-
-        var updatedBindings = sessionBindings
-
-        // Try canonical mapping first
-        if let mapped = characterType(forCanonicalRole: normalizedRole) {
-            updatedBindings[normalizedRole] = mapped
-            return (mapped, updatedBindings)
-        }
-
-        // Overflow: pick from pool, excluding already-bound types
-        let boundTypes = Set(updatedBindings.values)
-        let available = overflowPool.filter { !boundTypes.contains($0) }
-
-        let picked: CharacterType
-        if let choice = available.randomElement() {
-            picked = choice
-        } else {
-            // All overflow exhausted — duplicate a random overflow character
-            picked = overflowPool.randomElement() ?? .alienDiplomat
-        }
-
-        updatedBindings[normalizedRole] = picked
-        return (picked, updatedBindings)
-    }
 
     // MARK: - Role Color Palette (Wave 5)
 
@@ -115,6 +26,10 @@ enum RoleMapper {
     ///   lead       (.pm)               → #EAB308 (yellow)
     ///   engineer   (.claudimusPrime)   → #06B6D4 (cyan)
     ///   (fallback)                     → #6B7280 (gray)
+    ///
+    /// Note: the parenthetical characters reference the legacy role→character
+    /// map. They are not authoritative post-QA-FIXES #9 — characters are
+    /// randomized per spawn, but the color-by-role palette is unchanged.
     static func color(forCanonicalRole role: String?) -> UIColor {
         guard let role = role?.lowercased() else {
             return UIColor(red: 0x6B / 255.0, green: 0x72 / 255.0, blue: 0x80 / 255.0, alpha: 1)

--- a/ios/MajorTom/Features/Office/ViewModels/OfficeViewModel.swift
+++ b/ios/MajorTom/Features/Office/ViewModels/OfficeViewModel.swift
@@ -64,28 +64,31 @@ final class OfficeViewModel {
     /// `tab.session.ended` handling in Wave 4 wiring.
     var activeSessionIds: Set<String> = []
 
-    /// Per-session role→CharacterType bindings (role-stable binding).
-    /// First spawn for a canonical role locks the CharacterType for the session.
-    ///
-    /// Wave 5 (Gate A — multi-claude-in-one-tab): keyed by `sessionId` so
-    /// sibling sessions living in the same Office don't stomp each other's
-    /// role→character maps. The empty-string key holds bindings for events
-    /// that arrive without a `sessionId` (pre-Wave-3 legacy paths) so the
-    /// role-stable guarantee still applies to them in isolation.
-    var sessionRoleBindingsByKey: [String: RoleMapper.SessionBindings] = [:]
+    // Post-QA-FIXES #9: relay picks the CharacterType randomly per spawn
+    // and ships it in `sprite.link` / `sprite.state`. iOS trusts that value
+    // verbatim; there is no client-side role→character override, so the
+    // per-session role-binding map that Wave 5 Gate A introduced is gone.
 
-    /// Accessor — returns (and lazily creates) the role bindings for a
-    /// specific `sessionId`. `nil` routes to the empty-string bucket so
-    /// legacy events that never carried a sessionId still get a stable
-    /// binding set without contaminating real sessions' maps.
-    private func roleBindings(for sessionId: String?) -> RoleMapper.SessionBindings {
-        sessionRoleBindingsByKey[sessionId ?? ""] ?? [:]
+    /// Resolve a relay-supplied characterType string to the local enum,
+    /// tolerating unknown values (newer relay shipping a new character
+    /// before iOS catches up) by picking a random non-dog fallback.
+    private func characterType(from relayString: String?) -> CharacterType {
+        if let raw = relayString, let type = CharacterType(rawValue: raw), !type.isDog {
+            return type
+        }
+        return Self.randomNonDogCharacter(excluding: [])
     }
 
-    /// Write an updated binding set for a specific `sessionId` — symmetric
-    /// with `roleBindings(for:)`.
-    private func setRoleBindings(_ bindings: RoleMapper.SessionBindings, for sessionId: String?) {
-        sessionRoleBindingsByKey[sessionId ?? ""] = bindings
+    /// Random crew CharacterType (non-dog) used as a brief placeholder for
+    /// the window between `agent.spawn` and `sprite.link`. The sprite.link
+    /// handler overwrites this with whatever the relay actually rolled, so
+    /// a mild visual flash is the worst-case and only happens under out-of-
+    /// order delivery (both events broadcast from the same relay handler).
+    static func randomNonDogCharacter(excluding used: Set<CharacterType>) -> CharacterType {
+        let pool = CharacterType.allCases.filter { !$0.isDog }
+        let available = pool.filter { !used.contains($0) }
+        let source = available.isEmpty ? pool : available
+        return source.randomElement() ?? .claudimusPrime
     }
 
     // MARK: - Sprite Messaging (Wave 4)
@@ -232,8 +235,12 @@ final class OfficeViewModel {
 
     /// Called when the relay broadcasts `agent.spawn`.
     /// Clone-not-consume: creates a NEW agent sprite instance without consuming idle sprites.
-    /// Uses RoleMapper for deterministic role→CharacterType assignment with session-stable binding.
-    /// Dogs are NEVER assigned as agent sprites.
+    ///
+    /// Post-QA-FIXES #9: `agent.spawn` does not carry a characterType (that
+    /// lives on the paired `sprite.link` event). This handler picks a local
+    /// random non-dog placeholder so the spawn animation can start without
+    /// waiting, and `handleSpriteLink` overwrites it with the relay's
+    /// authoritative pick when the paired event arrives.
     ///
     /// Wave 5: `sessionId` binds the agent to its originating Claude session so
     /// `tab.session.ended` can walk off only that session's humans. Preserved
@@ -241,14 +248,11 @@ final class OfficeViewModel {
     func handleAgentSpawn(id: String, role: String, task: String, parentId: String? = nil, sessionId: String? = nil) {
         guard !agents.contains(where: { $0.id == id }) else { return }
 
-        // Resolve CharacterType via role-stable binding (clone-not-consume).
-        // Wave 5 Gate A: bindings are per-session so sibling sessions in the
-        // same tab don't collide on role→character locks.
-        let (characterType, updatedBindings) = RoleMapper.resolveCharacterType(
-            role: role,
-            sessionBindings: roleBindings(for: sessionId)
-        )
-        setRoleBindings(updatedBindings, for: sessionId)
+        // Placeholder — sprite.link will overwrite with the relay's pick.
+        // Using the session roster as the exclusion set keeps the
+        // placeholder visually distinct from other agents already present.
+        let inUse = Set(agents.map { $0.characterType })
+        let placeholderCharacter = Self.randomNonDogCharacter(excluding: inUse)
 
         // S5 — placement cascade: desk first, then overflow.
         let placement = assignPlacement(to: id)
@@ -257,7 +261,7 @@ final class OfficeViewModel {
             id: id,
             name: role.capitalized,
             role: role,
-            characterType: characterType,
+            characterType: placeholderCharacter,
             status: .spawning,
             currentTask: task,
             deskIndex: placement.deskIndex,
@@ -574,11 +578,17 @@ final class OfficeViewModel {
             sessionId = event.sessionId
         }
 
-        // De-dupe: if agent.spawn already created this agent, upgrade it with sprite link info
+        // De-dupe: if agent.spawn already created this agent, upgrade it with sprite link info.
+        // Post-QA-FIXES #9: this is where the relay's authoritative
+        // characterType overwrites the placeholder the spawn handler
+        // rolled locally. Without this overwrite the client would stay
+        // on the wrong character for the sprite's lifetime (old QA-FIXES
+        // #6 bug — relay said botanist, iOS rendered kendrick).
         if let existingIndex = agents.firstIndex(where: { $0.id == event.subagentId }) {
             agents[existingIndex].spriteHandle = event.spriteHandle
             agents[existingIndex].linkedSubagentId = event.subagentId
             agents[existingIndex].canonicalRole = event.canonicalRole
+            agents[existingIndex].characterType = characterType(from: event.characterType)
             agents[existingIndex].parentId = event.parentId
             // Wave 5: latch sessionId if the prior spawn event didn't carry one.
             if agents[existingIndex].sessionId == nil {
@@ -595,14 +605,6 @@ final class OfficeViewModel {
             return
         }
 
-        // Resolve CharacterType via role-stable binding (Wave 5 Gate A:
-        // scoped to the event's sessionId so sibling sessions don't collide).
-        let (characterType, updatedBindings) = RoleMapper.resolveCharacterType(
-            role: event.canonicalRole,
-            sessionBindings: roleBindings(for: event.sessionId)
-        )
-        setRoleBindings(updatedBindings, for: event.sessionId)
-
         // Use subagentId as primary ID so agent.* lifecycle handlers find this agent
         // S5 — placement cascade: desk first, then overflow.
         let placement = assignPlacement(to: event.subagentId)
@@ -611,7 +613,7 @@ final class OfficeViewModel {
             id: event.subagentId,
             name: event.canonicalRole.capitalized,
             role: event.canonicalRole,
-            characterType: characterType,
+            characterType: characterType(from: event.characterType),
             status: .spawning,
             currentTask: event.task,
             deskIndex: placement.deskIndex,
@@ -952,19 +954,12 @@ final class OfficeViewModel {
             removeAgent(id: id)
         }
 
-        // Wave 5 Gate A: only reset bindings for the session being
-        // rehydrated. Sibling sessions living in the same Office keep their
-        // role→character locks so their subsequent spawn/link events stay
-        // stable.
-        setRoleBindings([:], for: event.sessionId)
+        // Post-QA-FIXES #9: no per-session role bindings to reset — the
+        // relay is the source of truth for characterType.
 
         // Rebuild from relay mappings — primary key is subagentId
         for mapping in event.mappings {
-            let (characterType, updatedBindings) = RoleMapper.resolveCharacterType(
-                role: mapping.canonicalRole,
-                sessionBindings: roleBindings(for: event.sessionId)
-            )
-            setRoleBindings(updatedBindings, for: event.sessionId)
+            let resolvedCharacter = characterType(from: mapping.characterType)
 
             let status: AgentStatus
             switch mapping.status {
@@ -985,7 +980,7 @@ final class OfficeViewModel {
                 id: mapping.subagentId,
                 name: mapping.canonicalRole.capitalized,
                 role: mapping.canonicalRole,
-                characterType: characterType,
+                characterType: resolvedCharacter,
                 status: status,
                 currentTask: mapping.task,
                 deskIndex: placement.deskIndex,

--- a/ios/MajorTom/Features/Office/ViewModels/OfficeViewModel.swift
+++ b/ios/MajorTom/Features/Office/ViewModels/OfficeViewModel.swift
@@ -71,12 +71,17 @@ final class OfficeViewModel {
 
     /// Resolve a relay-supplied characterType string to the local enum,
     /// tolerating unknown values (newer relay shipping a new character
-    /// before iOS catches up) by picking a random non-dog fallback.
+    /// before iOS catches up) with a DETERMINISTIC non-dog fallback
+    /// keyed on the relay string. Stable-by-string is required because
+    /// the same sprite can reach this helper twice — once via
+    /// `sprite.link` and again via `sprite.state` rehydrate on reconnect
+    /// — and a random pick would flicker the sprite's character
+    /// between events.
     private func characterType(from relayString: String?) -> CharacterType {
         if let raw = relayString, let type = CharacterType(rawValue: raw), !type.isDog {
             return type
         }
-        return Self.randomNonDogCharacter(excluding: [])
+        return Self.deterministicFallbackCharacter(for: relayString ?? "")
     }
 
     /// Random crew CharacterType (non-dog) used as a brief placeholder for
@@ -89,6 +94,23 @@ final class OfficeViewModel {
         let available = pool.filter { !used.contains($0) }
         let source = available.isEmpty ? pool : available
         return source.randomElement() ?? .claudimusPrime
+    }
+
+    /// Deterministic non-dog fallback keyed on the relay string — used when
+    /// the relay ships a CharacterType iOS doesn't recognize yet. Same
+    /// input always produces the same output, so reconnect / sprite.state
+    /// replays render the sprite consistently. Uses a simple byte-sum hash
+    /// because Swift's `String.hashValue` is seeded per-launch and would
+    /// defeat the stability guarantee. An empty seed falls through to
+    /// `claudimusPrime` as the ship's-AI default.
+    static func deterministicFallbackCharacter(for seed: String) -> CharacterType {
+        let pool = CharacterType.allCases.filter { !$0.isDog }
+        guard !pool.isEmpty, !seed.isEmpty else { return .claudimusPrime }
+        var sum: UInt32 = 0
+        for scalar in seed.unicodeScalars {
+            sum = sum &+ scalar.value
+        }
+        return pool[Int(sum) % pool.count]
     }
 
     // MARK: - Sprite Messaging (Wave 4)

--- a/relay/src/routes/ws.ts
+++ b/relay/src/routes/ws.ts
@@ -2234,18 +2234,19 @@ export function createWsRoute(deps: WsDeps): FastifyPluginAsync {
           });
 
           // ── Sprite wiring: create mapping + emit sprite.link ──
+          //
+          // Post-QA-FIXES #9: character choice is randomized per spawn, so
+          // there is no stable role→character binding to persist. The
+          // `roleBindings` field on the persisted file stays in the schema
+          // for back-compat with older files on disk but is no longer
+          // consulted or written by this path.
           const spriteState = getOrCreateSpriteState(sid);
-          const { mapping, role: classifiedRole, isNewBinding } = spriteMapper.createMapping(
+          const { mapping } = spriteMapper.createMapping(
             event.agentId,
             event.task ?? '',
-            spriteState.roleBindings,
             spriteState.mappings,
             event.parentId,
           );
-          // Lock role binding if this is a new one
-          if (isNewBinding) {
-            spriteState.roleBindings[classifiedRole] = mapping.characterType;
-          }
           spriteState.mappings.push(mapping);
           spriteState.updatedAt = new Date().toISOString();
           spriteMappingPersistence.save(spriteState);

--- a/relay/src/sprites/__tests__/wave6-scenarios.test.ts
+++ b/relay/src/sprites/__tests__/wave6-scenarios.test.ts
@@ -74,14 +74,12 @@ function newHarness(persistence: SpriteMappingPersistence) {
   /** Simulates ws.ts agent.spawn handler — creates mapping + emits sprite.link. */
   function spawnAgent(sessionId: string, agentId: string, task: string, parentId?: string) {
     const state = getOrCreateSpriteState(sessionId);
-    const { mapping, isNewBinding } = spriteMapper.createMapping(
+    const { mapping } = spriteMapper.createMapping(
       agentId,
       task,
-      state.roleBindings,
       state.mappings,
       parentId,
     );
-    if (isNewBinding) state.roleBindings[mapping.canonicalRole] = mapping.characterType;
     state.mappings.push(mapping);
     state.updatedAt = new Date().toISOString();
     persistence.save(state);
@@ -403,34 +401,53 @@ describe('Wave 6 scenario — S6 subagent spawns + completes in <1s (no lost eve
 });
 
 describe('Wave 6 scenario — S7 all human sprites exhausted (duplication, no dog fallback)', () => {
-  it('SpriteMapper never returns a dog CharacterType as an agent sprite', () => {
+  // Post-QA-FIXES #9: character assignment is randomized per spawn. The
+  // spec now guarantees (a) dogs are never chosen as agent sprites, and
+  // (b) the first 14 spawns in a session each get a distinct character
+  // (CHARACTER_POOL is size 14 with dup-avoidance). The 15th spawn is
+  // forced to duplicate since the pool is exhausted.
+
+  it('never returns a dog CharacterType as an agent sprite, even when the pool is exhausted', () => {
     const mapper = new SpriteMapper();
-    const sessionBindings: Record<string, string> = {};
     const mappings: PersistedSpriteMapping[] = [];
-    // Spawn 14 backend agents — more than MAX_DESKS (6) but fewer than the
-    // full human pool. The spec requires each to receive `backendEngineer`
-    // (role-stable binding), never a dog.
-    for (let i = 0; i < 14; i++) {
+    // Spawn 20 agents — well past both MAX_DESKS (6) and the pool cap (14).
+    for (let i = 0; i < 20; i++) {
       const result = mapper.createMapping(
         `agent-${i}`,
         'wire the relay endpoint',
-        sessionBindings,
         mappings,
       );
-      expect(result.mapping.characterType).toBe('backendEngineer');
-      expect(result.mapping.characterType).not.toMatch(/dog|steve|elvis|kai|hoku|senor|esteban|zuckerbot/i);
-      if (result.isNewBinding) sessionBindings[result.role] = result.mapping.characterType;
+      expect(result.mapping.characterType).not.toMatch(
+        /elvis|steve|kai|hoku|senor|esteban|zuckerbot/,
+      );
       mappings.push(result.mapping);
     }
     // Overflow: first 6 get desks, 7+ get deskIndex === -1.
     expect(mappings.filter((m) => m.deskIndex >= 0)).toHaveLength(6);
-    expect(mappings.filter((m) => m.deskIndex === -1)).toHaveLength(8);
+    expect(mappings.filter((m) => m.deskIndex === -1)).toHaveLength(14);
   });
 
-  it('unknown role falls back to the engineer CharacterType, never a dog', () => {
+  it('first 14 spawns produce distinct characters (dup-avoidance until pool exhausts)', () => {
     const mapper = new SpriteMapper();
-    const out = mapper.resolveCharacterType('unknown_role_xyz', {});
-    expect(out.characterType).toBe('claudimusPrime');
+    const mappings: PersistedSpriteMapping[] = [];
+    for (let i = 0; i < 14; i++) {
+      const result = mapper.createMapping(`agent-${i}`, 'task', mappings);
+      mappings.push(result.mapping);
+    }
+    const uniqueCharacters = new Set(mappings.map((m) => m.characterType));
+    expect(uniqueCharacters.size).toBe(14);
+  });
+
+  it('the 15th spawn duplicates an in-use character (pool fully claimed)', () => {
+    const mapper = new SpriteMapper();
+    const mappings: PersistedSpriteMapping[] = [];
+    for (let i = 0; i < 14; i++) {
+      const result = mapper.createMapping(`agent-${i}`, 'task', mappings);
+      mappings.push(result.mapping);
+    }
+    const inUseBeforeOverflow = new Set(mappings.map((m) => m.characterType));
+    const overflow = mapper.createMapping('agent-overflow', 'task', mappings);
+    expect(inUseBeforeOverflow.has(overflow.mapping.characterType)).toBe(true);
   });
 });
 

--- a/relay/src/sprites/sprite-mapper.ts
+++ b/relay/src/sprites/sprite-mapper.ts
@@ -28,21 +28,37 @@ export const CANONICAL_ROLES = [
 
 export type CanonicalRole = typeof CANONICAL_ROLES[number];
 
-// ── Role → CharacterType mapping (locked in spec) ──────────
-// From the spec: "locked role→CharacterType table"
-// Each role maps to a specific human CharacterType sprite.
-// Dogs are NEVER used as agent sprites.
+// ── Character pool (randomized assignment) ─────────────────
+// Post-QA-FIXES #9: character assignment is randomized per spawn,
+// decoupled from canonical role. The previous role→CharacterType lock
+// ("researcher is always the botanist") was scrapped in favor of a
+// "who am I gonna get?!" roll each spawn. Canonical roles still drive
+// labels, aura colors, and classification — just not character choice.
+//
+// Source of truth for the pool: iOS `CharacterCatalog` crew entries
+// (ios/MajorTom/Features/Office/Models/CharacterConfig.swift). Dogs
+// are NEVER used as agent sprites (they live at tab scope as pets).
+//
+// Keep this list in lockstep with the iOS CharacterType enum's non-dog
+// cases. If iOS ships a new crew character, add it here in the same
+// PR so the relay can assign it.
 
-const ROLE_CHARACTER_MAP: Record<CanonicalRole, string> = {
-  researcher: 'botanist',
-  architect: 'captain',
-  qa: 'doctor',
-  devops: 'mechanic',
-  frontend: 'frontendDev',
-  backend: 'backendEngineer',
-  lead: 'pm',
-  engineer: 'claudimusPrime',
-};
+export const CHARACTER_POOL: readonly string[] = [
+  'alienDiplomat',
+  'backendEngineer',
+  'botanist',
+  'bowenYang',
+  'captain',
+  'chef',
+  'claudimusPrime',
+  'doctor',
+  'dwight',
+  'frontendDev',
+  'kendrick',
+  'mechanic',
+  'pm',
+  'prince',
+] as const;
 
 // ── Role classification regex patterns ─────────────────────
 // Priority order: first match wins. More specific roles before generic.
@@ -78,32 +94,31 @@ export class SpriteMapper {
   }
 
   /**
-   * Resolve a canonical role to a CharacterType string.
-   * Implements role-stable binding: the first spawn for a role in a session
-   * locks the CharacterType for that role for the session's lifetime.
+   * Pick a CharacterType for a new sprite via randomization — post-QA-FIXES
+   * #9 semantics. Avoids characters already in use by active mappings until
+   * the pool is exhausted, then falls back to a random pick with duplicates
+   * allowed (>14 concurrent sprites is deep in overflow territory anyway).
    *
-   * @param role - Canonical role (e.g. 'frontend')
-   * @param sessionBindings - Current role→CharacterType bindings for the session
-   * @returns The CharacterType to use and whether this is a new binding
+   * Role is intentionally NOT consulted — every spawn is a fresh roll. Label,
+   * aura, and other role-derived UX still flow from canonicalRole; character
+   * choice is decoupled.
+   *
+   * @param currentMappings - Active mappings in the session (dup-avoidance).
+   * @returns The chosen CharacterType string.
    */
   resolveCharacterType(
-    role: string,
-    sessionBindings: Record<string, string>,
-  ): { characterType: string; isNew: boolean } {
-    // If we already have a binding for this role in this session, reuse it
-    const existing = sessionBindings[role];
-    if (existing) {
-      return { characterType: existing, isNew: false };
-    }
+    currentMappings: PersistedSpriteMapping[],
+  ): { characterType: string } {
+    const inUse = new Set(currentMappings.map((m) => m.characterType));
+    const available = CHARACTER_POOL.filter((c) => !inUse.has(c));
 
-    // Look up the canonical mapping. If the role isn't recognized (shouldn't happen
-    // if classifyRole was used, but defensive), fall back to 'engineer' CharacterType.
-    const canonicalRole = CANONICAL_ROLES.includes(role as CanonicalRole)
-      ? (role as CanonicalRole)
-      : 'engineer';
-    const characterType = ROLE_CHARACTER_MAP[canonicalRole];
-
-    return { characterType, isNew: true };
+    // Non-null assertion inside both branches: CHARACTER_POOL is a non-empty
+    // readonly array (14 entries), so randomElement is safe. `available`
+    // might be empty when every pool member is already claimed — in that
+    // case we roll from the full pool and accept a duplicate.
+    const source = available.length > 0 ? available : CHARACTER_POOL;
+    const characterType = source[Math.floor(Math.random() * source.length)]!;
+    return { characterType };
   }
 
   /**
@@ -121,23 +136,24 @@ export class SpriteMapper {
 
   /**
    * Create a full sprite mapping for a newly spawned agent.
-   * Orchestrates role classification, character resolution, and desk allocation.
+   * Orchestrates role classification, character resolution (random pick
+   * avoiding active-roster dupes), and desk allocation.
    *
-   * @param agentId - The agent's unique ID
-   * @param task - The agent's task description
-   * @param sessionBindings - Current role→CharacterType bindings for the session
-   * @param currentMappings - Current active mappings for desk allocation
-   * @returns The new mapping and whether the role binding is new
+   * @param agentId - The agent's unique ID.
+   * @param task - The agent's task description (used for role classification).
+   * @param currentMappings - Current active mappings for desk + character dup
+   *   avoidance. Pass the full session roster so the dup-avoid window is
+   *   per-session (prevents the same character appearing twice at once).
+   * @param parentId - Optional parent subagent id for nested spawns.
    */
   createMapping(
     agentId: string,
     task: string,
-    sessionBindings: Record<string, string>,
     currentMappings: PersistedSpriteMapping[],
     parentId?: string,
-  ): { mapping: PersistedSpriteMapping; role: CanonicalRole; isNewBinding: boolean } {
+  ): { mapping: PersistedSpriteMapping; role: CanonicalRole } {
     const role = this.classifyRole(task);
-    const { characterType, isNew } = this.resolveCharacterType(role, sessionBindings);
+    const { characterType } = this.resolveCharacterType(currentMappings);
     const deskIndex = this.allocateDesk(currentMappings);
     const spriteHandle = `sprite-${randomUUID().slice(0, 8)}`;
 
@@ -153,11 +169,11 @@ export class SpriteMapper {
     };
 
     logger.info(
-      { subagentId: agentId, canonicalRole: role, characterType, deskIndex, spriteHandle, isNewBinding: isNew },
+      { subagentId: agentId, canonicalRole: role, characterType, deskIndex, spriteHandle },
       'Sprite mapping created',
     );
 
-    return { mapping, role, isNewBinding: isNew };
+    return { mapping, role };
   }
 
   /**


### PR DESCRIPTION
## Summary

Wave D PR 2 — flips sprite CharacterType assignment from the locked role → character table to per-spawn randomization. Closes **QA-FIXES #9** (the user-requested flip) and **QA-FIXES #6** as superseded (the "iOS rendered Kendrick where relay said botanist" divergence vanishes when iOS stops running its own parallel role→character map).

Three atomic commits:

- **`fix(relay)`** — `sprite-mapper.ts`: `ROLE_CHARACTER_MAP` replaced with a flat `CHARACTER_POOL` of 14 non-dog crew characters. `resolveCharacterType` rolls a random pick with dup-avoidance against the active session roster until the pool is exhausted (the 15th+ concurrent spawn duplicates). `createMapping` loses its `sessionBindings` param and `isNewBinding` return field — there is no role-stable binding anymore. `ws.ts` stops writing to `spriteState.roleBindings`; the field stays in the persistence + wire schema for back-compat but is no longer consulted. `wave6-scenarios.test.ts` rewritten to assert the new invariants (no dogs ever, first 14 distinct, 15th duplicates).
- **`fix(ios)`** — `SpriteLinkEvent` + `SpriteStateEvent.SpriteMapping` gain optional `characterType: String?` (Codable, back-compat). All three `OfficeViewModel` call sites that used `RoleMapper.resolveCharacterType` now consume the relay's value. `handleSpriteLink`'s dedupe path now overwrites `characterType` on the existing agent — this is the specific fix for QA-FIXES #6. `RoleMapper` keeps `color(forCanonicalRole:)` (Wave 5 aura palette unchanged); `resolveCharacterType`, `SessionBindings`, `overflowPool`, `canonicalRoles`, and the per-session binding state in OfficeViewModel are deleted.
- **`docs`** — `PHASE-SPRITE-AGENT-WIRING.md` §Q2 rewritten from "Role-stable binding" to "Character randomization"; the locked role→CharacterType table is struck in-line and replaced with the `CHARACTER_POOL` spec. Scenario C and the Wave 2 research notes get struck-through updates. `QA-FIXES.md` closes #9 (shipped) and #6 (superseded). Required in the same PR as the behavior flip per `feedback_phase_spec_flips.md`.

## Test plan

- [x] Full relay vitest suite — 308 tests pass (20 files).
- [x] `npx tsc --noEmit` clean in `relay/`.
- [x] iOS Simulator build succeeds for `MajorTom` scheme on iPhone 17 sim.
- [ ] **Device QA on Sean's iPhone** (the "who am I gonna get?!" vibe is the acceptance criteria):
  - [ ] Spawn several subagents in one session. Each should render a distinct character; no two working sprites should share a CharacterType until the 15th concurrent spawn.
  - [ ] Repeat the same task (e.g. "explore the relay") twice — the two spawned sprites should usually be different characters (randomized, not role-locked).
  - [ ] Background + reconnect with live sprites — each sprite should keep its original character after `sprite.state` rehydrate (stable through reconnect; randomization only happens at spawn).
  - [ ] Two sessions in the same tab spawn same-role agents — each rolls independently; no cross-session collision rules.
  - [ ] QA-FIXES #6 regression check — no agent ever renders as a dog character (elvis, steve, kai, hoku, senor, esteban, zuckerbot).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
