### PR TITLE
fix(ios): auto-pop Office view when tab is torn down (QA-FIXES #8)

### DIFF
--- a/ios/MajorTom/Features/Office/Views/OfficeView.swift
+++ b/ios/MajorTom/Features/Office/Views/OfficeView.swift
@@ -104,12 +104,15 @@ struct OfficeView: View {
                     Image(systemName: "building.2.slash")
                         .font(.system(size: 48))
                         .foregroundStyle(MajorTomTheme.Colors.textTertiary)
+                        .accessibilityHidden(true)
                     Text("Office closed")
                         .font(.system(.body, design: .monospaced))
                         .foregroundStyle(MajorTomTheme.Colors.textSecondary)
                 }
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
                 .background(MajorTomTheme.Colors.background)
+                .accessibilityElement(children: .combine)
+                .accessibilityLabel("Office closed")
             }
         }
         .task {

--- a/ios/MajorTom/Features/Office/Views/OfficeView.swift
+++ b/ios/MajorTom/Features/Office/Views/OfficeView.swift
@@ -95,12 +95,16 @@ struct OfficeView: View {
             if let viewModel, let scene = currentScene {
                 officeContent(viewModel: viewModel, scene: scene)
             } else {
-                // Office was closed or not yet created — show placeholder
+                // Office was closed or not yet created — brief placeholder while
+                // we dismiss back to the Office Manager (QA-FIXES #8). The
+                // onChange handler below fires the pop once viewModel flips to
+                // nil (tab torn down while we were foregrounded) or the initial
+                // .task resolves with no Office (cold-tap of a dead tabId).
                 VStack(spacing: MajorTomTheme.Spacing.lg) {
                     Image(systemName: "building.2.slash")
                         .font(.system(size: 48))
                         .foregroundStyle(MajorTomTheme.Colors.textTertiary)
-                    Text("Office not available")
+                    Text("Office closed")
                         .font(.system(.body, design: .monospaced))
                         .foregroundStyle(MajorTomTheme.Colors.textSecondary)
                 }
@@ -113,6 +117,21 @@ struct OfficeView: View {
             // branch rendered (content vs placeholder). If the scene was LRU-evicted,
             // this triggers a cold rebuild and populates @State so the view re-renders.
             activatedScene = sceneManager.activateOffice(for: tabId)
+            // QA-FIXES #8 — cold-tap of a tabId whose Office is already gone
+            // (shell exited, tab closed in the background) should route
+            // straight back to the Office Manager instead of stranding the
+            // user on a dead placeholder. The dismiss here pops from the
+            // NavigationStack back to the Manager root.
+            if sceneManager.viewModel(for: tabId) == nil {
+                dismiss()
+            }
+        }
+        .onChange(of: sceneManager.viewModel(for: tabId) == nil) { _, isGone in
+            // Tab torn down while the Office view is foregrounded (user is
+            // watching the walk-off when the shell exits). Auto-pop after the
+            // viewModel vanishes so the user lands on the Manager instead of
+            // the "Office closed" placeholder.
+            if isGone { dismiss() }
         }
         .navigationBarTitleDisplayMode(.inline)
         .toolbar {


### PR DESCRIPTION
## Summary

Wave D PR 3 — closes the user-visible half of **QA-FIXES #8** (Office teardown UX). When a terminal tab is torn down (shell exit, manual kill, PTY grace expiry) the NavigationStack inside the Office bottom-tab still holds the dead tabId on its path; returning to the Office tab previously landed the user on an "Office not available" placeholder and forced a manual Back tap to reach the Office Manager.

**Fix in `OfficeView.swift`:**
- On initial `.task`, dismiss if the scene manager has no `viewModel` for `tabId` (cold-tap case — tab torn down while user was on a different bottom-tab).
- `.onChange(of: sceneManager.viewModel(for: tabId) == nil)` auto-pops live — user watching the Office when the shell exits gets routed back to the Manager after teardown completes.
- Placeholder copy changed from "Office not available" → "Office closed" for the brief frame it renders before dismiss fires.

**Explicitly out of scope:** the walk-off animation timing half of QA-FIXES #8 (extending the walk-off to ~5s when the Office is foregrounded). That's a timing tuning exercise that wants device QA to get the feel right — better as a separate follow-up once this PR's routing fix is verified.

## Test plan

- [x] `XcodeBuildMCP build_sim` clean for `MajorTom` scheme on iPhone 17 simulator.
- [ ] **Device QA:**
  - [ ] Open an Office for an active tab. Exit the shell in the Terminal tab. Wait ~1s. Tap the Office bottom-tab. Expect: land on the Office Manager (not the placeholder).
  - [ ] Open an Office for an active tab. While watching the Office, exit the shell. Expect: Office view auto-pops to the Manager after the sprites walk off.
  - [ ] Open an Office that's still alive. Switch to another bottom-tab, come back. Expect: return to the Office view, no unwanted dismiss.
  - [ ] Cold-launch the app with a previously-torn-down tabId cached in NavigationPath (if that path is possible). Expect: Manager, not placeholder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
