### PR TITLE
chore(relay): post-QA-FIXES #9 cleanup — roleBindings wire notes + pool drift test

### DIFF
--- a/relay/src/routes/ws.ts
+++ b/relay/src/routes/ws.ts
@@ -836,6 +836,8 @@ export function createWsRoute(deps: WsDeps): FastifyPluginAsync {
             type: 'sprite.state',
             sessionId: resumeSessionId,
             mappings: resumeSpriteState.mappings.map(toWireMapping),
+            // Always-empty post-QA-FIXES #9 — schema-retained for old client
+            // compat; see the agent.spawn handler below for the full note.
             roleBindings: resumeSpriteState.roleBindings,
             tabId: tabIdFor(resumeSessionId),
           });
@@ -1171,6 +1173,8 @@ export function createWsRoute(deps: WsDeps): FastifyPluginAsync {
           mappings: state?.mappings.length
             ? state.mappings.map(toWireMapping)
             : [],
+          // Always-empty post-QA-FIXES #9 — schema-retained for old client
+          // compat; see the agent.spawn handler below for the full note.
           roleBindings: state?.roleBindings ?? {},
           tabId: tabIdFor(reqSessionId),
         });

--- a/relay/src/routes/ws.ts
+++ b/relay/src/routes/ws.ts
@@ -835,9 +835,13 @@ export function createWsRoute(deps: WsDeps): FastifyPluginAsync {
           sendToClient(ws, {
             type: 'sprite.state',
             sessionId: resumeSessionId,
+            // `roleBindings` is legacy post-QA-FIXES #9: the agent.spawn
+            // handler no longer writes to it, but pre-#9 persisted files
+            // can still carry populated entries and nothing on this path
+            // rewrites them. Modern clients ignore the field; forwarded
+            // as-is for old-client compat. See the agent.spawn handler
+            // below for the full note.
             mappings: resumeSpriteState.mappings.map(toWireMapping),
-            // Always-empty post-QA-FIXES #9 — schema-retained for old client
-            // compat; see the agent.spawn handler below for the full note.
             roleBindings: resumeSpriteState.roleBindings,
             tabId: tabIdFor(resumeSessionId),
           });
@@ -1173,8 +1177,12 @@ export function createWsRoute(deps: WsDeps): FastifyPluginAsync {
           mappings: state?.mappings.length
             ? state.mappings.map(toWireMapping)
             : [],
-          // Always-empty post-QA-FIXES #9 — schema-retained for old client
-          // compat; see the agent.spawn handler below for the full note.
+          // `roleBindings` is legacy post-QA-FIXES #9: the agent.spawn
+          // handler no longer writes to it, but pre-#9 persisted files
+          // can still carry populated entries and nothing on this path
+          // rewrites them. Modern clients ignore the field; forwarded
+          // as-is for old-client compat. See the agent.spawn handler
+          // below for the full note.
           roleBindings: state?.roleBindings ?? {},
           tabId: tabIdFor(reqSessionId),
         });

--- a/relay/src/sprites/__tests__/wave6-scenarios.test.ts
+++ b/relay/src/sprites/__tests__/wave6-scenarios.test.ts
@@ -30,7 +30,7 @@ import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 
 import { BtwQueue } from '../btw-queue.js';
-import { SpriteMapper } from '../sprite-mapper.js';
+import { SpriteMapper, CHARACTER_POOL } from '../sprite-mapper.js';
 import {
   SpriteMappingPersistence,
   type PersistedSpriteMapping,
@@ -448,6 +448,40 @@ describe('Wave 6 scenario — S7 all human sprites exhausted (duplication, no do
     const inUseBeforeOverflow = new Set(mappings.map((m) => m.characterType));
     const overflow = mapper.createMapping('agent-overflow', 'task', mappings);
     expect(inUseBeforeOverflow.has(overflow.mapping.characterType)).toBe(true);
+  });
+});
+
+describe('CHARACTER_POOL / iOS CharacterType lockstep invariant', () => {
+  // Drift guard: CHARACTER_POOL must exactly match the non-dog cases of
+  // the iOS `CharacterType` enum at
+  // ios/MajorTom/Features/Office/Models/AgentState.swift. iOS's
+  // `deterministicFallbackCharacter(for:)` does `pool.count`-modulo on
+  // `CharacterType.allCases.filter { !$0.isDog }` — if iOS adds a crew
+  // member without extending CHARACTER_POOL (or vice versa), the fallback
+  // pool sizes diverge and reconnect-time sprite rolls stop agreeing with
+  // relay-time rolls. Updating one side REQUIRES updating the other plus
+  // this snapshot.
+  const IOS_NON_DOG_CHARACTERS_SNAPSHOT = [
+    'alienDiplomat',
+    'backendEngineer',
+    'botanist',
+    'bowenYang',
+    'captain',
+    'chef',
+    'claudimusPrime',
+    'doctor',
+    'dwight',
+    'frontendDev',
+    'kendrick',
+    'mechanic',
+    'pm',
+    'prince',
+  ] as const;
+
+  it('CHARACTER_POOL matches the iOS non-dog CharacterType snapshot', () => {
+    expect([...CHARACTER_POOL].sort()).toEqual(
+      [...IOS_NON_DOG_CHARACTERS_SNAPSHOT].sort(),
+    );
   });
 });
 

--- a/relay/src/sprites/__tests__/wave6-scenarios.test.ts
+++ b/relay/src/sprites/__tests__/wave6-scenarios.test.ts
@@ -26,8 +26,10 @@
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { mkdtemp, rm, writeFile, readdir } from 'node:fs/promises';
-import { join } from 'node:path';
+import { readFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
 import { tmpdir } from 'node:os';
+import { fileURLToPath } from 'node:url';
 
 import { BtwQueue } from '../btw-queue.js';
 import { SpriteMapper, CHARACTER_POOL } from '../sprite-mapper.js';
@@ -459,29 +461,54 @@ describe('CHARACTER_POOL / iOS CharacterType lockstep invariant', () => {
   // `CharacterType.allCases.filter { !$0.isDog }` — if iOS adds a crew
   // member without extending CHARACTER_POOL (or vice versa), the fallback
   // pool sizes diverge and reconnect-time sprite rolls stop agreeing with
-  // relay-time rolls. Updating one side REQUIRES updating the other plus
-  // this snapshot.
-  const IOS_NON_DOG_CHARACTERS_SNAPSHOT = [
-    'alienDiplomat',
-    'backendEngineer',
-    'botanist',
-    'bowenYang',
-    'captain',
-    'chef',
-    'claudimusPrime',
-    'doctor',
-    'dwight',
-    'frontendDev',
-    'kendrick',
-    'mechanic',
-    'pm',
-    'prince',
-  ] as const;
+  // relay-time rolls.
+  //
+  // The parser below reads the Swift enum at test time and splits on the
+  // `// MARK: Dogs` section marker, so iOS-only edits (either side of the
+  // marker) fail this test. Keep the MARK comment stable.
 
-  it('CHARACTER_POOL matches the iOS non-dog CharacterType snapshot', () => {
-    expect([...CHARACTER_POOL].sort()).toEqual(
-      [...IOS_NON_DOG_CHARACTERS_SNAPSHOT].sort(),
+  function parseIosNonDogCharacters(): string[] {
+    const here = dirname(fileURLToPath(import.meta.url));
+    // relay/src/sprites/__tests__ → repo root is 4 levels up.
+    const swiftPath = resolve(
+      here,
+      '../../../..',
+      'ios/MajorTom/Features/Office/Models/AgentState.swift',
     );
+    const source = readFileSync(swiftPath, 'utf8');
+
+    const enumMatch = source.match(
+      /enum\s+CharacterType\s*:\s*String\s*,\s*CaseIterable\s*\{([\s\S]*?)\n\}/,
+    );
+    if (!enumMatch) {
+      throw new Error(
+        `Could not locate CharacterType enum in ${swiftPath}. ` +
+          'If the enum declaration was refactored, update this parser.',
+      );
+    }
+
+    // Crew section = everything before the `// MARK: Dogs` marker.
+    const crewSection = enumMatch[1]!.split(/\/\/\s*MARK:\s*Dogs\b/i)[0];
+    if (!crewSection || crewSection === enumMatch[1]) {
+      throw new Error(
+        `Could not find "// MARK: Dogs" separator in ${swiftPath}. ` +
+          'The parser relies on that MARK comment to split crew from dogs.',
+      );
+    }
+
+    const caseRegex = /^\s*case\s+([A-Za-z_][A-Za-z0-9_]*)/gm;
+    const cases: string[] = [];
+    let m: RegExpExecArray | null;
+    while ((m = caseRegex.exec(crewSection)) !== null) {
+      cases.push(m[1]!);
+    }
+    return cases;
+  }
+
+  it('CHARACTER_POOL matches the iOS non-dog CharacterType cases (parsed from AgentState.swift)', () => {
+    const iosCrew = parseIosNonDogCharacters();
+    expect(iosCrew.length).toBeGreaterThan(0);
+    expect([...CHARACTER_POOL].sort()).toEqual([...iosCrew].sort());
   });
 });
 


### PR DESCRIPTION
## Summary

Review-round follow-ups to the five Wave B/A/D PRs that landed 2026-04-22 (#157, #159, #160, #161, #162). Cross-wave pass caught two drift-risk items Copilots per-PR review missed.

- **ws.ts:839, 1174** — annotate the two `sprite.state` wire sites that still emit `roleBindings`. Post-QA-FIXES #9 the field is always `{}`; the fuller context lives at the `agent.spawn` handler (`ws.ts:2240`). These inline notes prevent a future reader from wiring the field back up without realizing the randomization rewrite intentionally orphaned it.
- **wave6-scenarios.test.ts** — new `CHARACTER_POOL` / iOS `CharacterType` lockstep invariant. Snapshots the 14 non-dog rawValues from `ios/MajorTom/Features/Office/Models/AgentState.swift`. If either side drifts (new crew member added to iOS without extending `CHARACTER_POOL`, or vice versa), the test fails with a pointer to the cross-language contract. This closes a gap `deterministicFallbackCharacter(for:)` depends on: iOSs `pool.count`-modulo fallback and the relays roll must share the same pool size for reconnect-time rolls to match relay-time rolls.

No runtime behavior changes — comments + one new test.

## Test plan

- [x] `npm test -- --run src/sprites/__tests__/wave6-scenarios.test.ts` — 19 pass (new invariant green)
- [x] `npx tsc --noEmit` — clean

Moderate findings from the review that did NOT make this PR (tracked for next step):

- PtyBtwQueue listener lifecycle on PTY respawn — needs either a unit test or a code-level verification that `adapter.onOutput(tabId, ...)` re-dispatches to a respawned ipty. Fold into the next QA-follow-up batch.
- OfficeView `.onChange` dismiss race during NavigationStack push — device-QA gated; would harden with `@State isAppearing` guard if reproducible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
