### PR TITLE
feat(ci): Claude multi-tier PR review workflows

### DIFF
--- a/.github/instructions/github.instructions.md
+++ b/.github/instructions/github.instructions.md
@@ -69,8 +69,8 @@ When creating a PR:
 1. **Create PR** (not draft)
 2. **Assign `@seantokuzo`**
 3. **Apply labels**: component + type + `Needs Review`
-4. **Request Copilot review**
-5. **STOP** — wait for user response
+4. **Claude auto-reviews** via `.github/workflows/claude-code-review.yml` (Tier 2: 3 specialists + verdict synthesizer)
+5. **Follow autonomous loop** in `~/.claude/CLAUDE.md` "PR Review Workflow (canonical)" + project extensions in `.github/instructions/pr-review.instructions.md`
 
 ## PR Labels
 
@@ -96,6 +96,8 @@ When creating a PR:
 | ----- | ------------- |
 | **Needs Review** | PR ready for review (agent applies) |
 | **Accepted** | Human approved, ready to merge |
+| **claude-deep-review** | Trigger Tier 3 deep review (manual or auto-applied by Tier 2 verdict synthesizer on escalation criteria) |
+| **expected-ci-fail** | CI failure is anticipated and tracked — bypasses the green-CI merge gate (early-phase work only) |
 
 ### CI Labels (auto-applied by GitHub Actions)
 

--- a/.github/instructions/pr-review.instructions.md
+++ b/.github/instructions/pr-review.instructions.md
@@ -2,129 +2,95 @@
 applyTo: "**/*"
 ---
 
-# PR Review — Addressing Copilot Comments
+# PR Review — Addressing Claude Auto-Review
 
-> Canonical polling/threshold rules live in `~/.claude/CLAUDE.md` (PR Review Workflow section) and `CLAUDE.md` (project). This file covers the triage posture for individual comments.
+**Canonical workflow lives in `~/.claude/CLAUDE.md` "PR Review Workflow (canonical)".** This file is project-specific extension only.
 
-## Polling & Threshold (summary)
+## Tier configuration (this project)
 
-- **First poll:** 2 minutes minimum after PR creation or pushing fixes
-- **Subsequent polls:** 1 minute intervals
-- **Completion:** count reviews with body containing `"Pull request overview"` — round N is done when N such reviews exist
-- **Threshold:** `<5` comments in the round → merge. `≥5` → request another round.
+See `CLAUDE.md` "Reviewing with @claude" for the full tier table. TL;DR:
+- **Tier 1**: `@claude` mention → Opus 4.6 max effort, single Q&A response (`.github/workflows/claude.yml`)
+- **Tier 2**: every non-draft PR → 3 parallel specialists (Security / Architecture / Correctness) at Opus 4.7 xhigh + verdict synthesizer (`.github/workflows/claude-code-review.yml`)
+- **Tier 3**: label `claude-deep-review` (manual or auto-escalated) → Opus 4.7 max effort + 4 specialists (adds Threat Model) (`.github/workflows/claude-deep-review.yml`)
 
-Full bash flow: `.agents/skills/pr-review-pipeline/SKILL.md`
+All tiers READ-ONLY (`Edit`, `Write`, `NotebookEdit` disallowed at the workflow level).
 
-## Comment Categorization
+## Sentinels and stickies
 
-When Copilot reviews a PR, categorize each comment:
+Each specialist embeds a JSON sentinel in its top-level summary comment for the synthesizer to parse:
 
-| Category | Action | When to Use |
-| -------- | ------ | ----------- |
-| **fix-now** | Fix in current PR | Real bugs, type errors, security issues |
-| **respond** | Reply explaining why no change | Intentional design, false positives, not applicable |
-| **defer** | Acknowledge, note for later | Valid but out of scope for this PR |
-
-## Skeptical Review (CRITICAL)
-
-**You have MORE context than Copilot.** Before accepting a suggestion, ask:
-
-1. **Does this apply to our setup?** (e.g., SSR concerns in a SwiftUI app)
-2. **Is this already handled elsewhere?** (e.g., guards upstream)
-3. **Is this a real problem or theoretical?** (e.g., edge cases that can't happen)
-4. **Does the fix add complexity for marginal benefit?**
-5. **Would a human reviewer make this same comment with full project context?**
-
-### Default Posture
-
-| Suggestion Type | Default | Reasoning |
-| --------------- | ------- | --------- |
-| Actual bugs | **Fix** | Real runtime errors |
-| Security vulnerabilities | **Fix** | XSS, injection, auth bypass |
-| Type errors | **Fix** | Will break CI |
-| Memory leaks | **Fix** | Will degrade performance |
-| Platform-specific concerns | **Evaluate** | May or may not apply |
-| Over-engineering suggestions | **Respond** | Adds complexity without value |
-| Future feature requests | **Respond** | Out of scope |
-| Architecture opinions | **Respond** | Design decisions already made |
-| Valid but out of scope | **Defer** | Note for future work |
-| Defensive code for impossible scenarios | **Respond** | Cite framework guarantee |
-
-## Workflow
-
-### 1. Fetch Comments
-
-```bash
-gh api repos/seantokuzo/major-tom/pulls/{number}/comments \
-  --jq '.[] | select(.in_reply_to_id == null) | {id, path, line: (.line // .original_line), body: (.body | split("\n")[0])}'
+```html
+<!-- MT-REVIEW-JSON-{SECURITY|ARCHITECTURE|CORRECTNESS|THREATMODEL}
+{"verdict":"...","blocking_count":N,"advisory_count":N,"sensitive_paths_touched":bool,"top_issues":[...],"rationale":"..."}
+-->
 ```
 
-Ignore replies from previous rounds — focus on top-level comments only.
+The verdict synthesizer posts/updates the round sticky:
+- Tier 2: `<!-- MT-VERDICT-STICKY -->` + `<!-- VERDICT_ROUND: N -->`
+- Tier 3: `<!-- MT-DEEP-VERDICT-STICKY -->` + `<!-- DEEP_VERDICT_ROUND: N -->`
 
-### 2. Categorize
+The sticky is the round-completion signal. Its body is the canonical verdict for the round.
 
-Sort every comment into fix-now / respond / defer.
+## Comment categorization (skepticism applies)
 
-### 3. Fix
+For every comment Claude posts, decide:
 
-Address all fix-now items. Verify build after fixes. Commit with descriptive message.
+| Category | Action | When to use |
+|----------|--------|-------------|
+| **fix-now** | Fix in current PR | Real bugs, type errors, security issues, force unwraps, missing protocol `type`, cross-component imports |
+| **respond** | Reply explaining why no change | Intentional design, false positive, framework guarantee makes it impossible |
+| **defer** | File a follow-up issue, link it in reply | Valid but out-of-scope for the PR's stated goal |
 
-### 4. Reply Inline to EVERY Comment
+**You have MORE context than the reviewer.** Push back inline when:
 
-Reply individually to each comment in its thread — **never** as an unlinked PR-level comment.
+1. The comment suggests defensive code for impossible cases (type system / framework guarantees)
+2. It recommends architecture changes already locked in `docs/PLANNING.md` or shipped `docs/PHASE-*.md`
+3. It asks for tests in a component without a test harness wired (PWA / iOS — only relay has vitest)
+4. It conflicts with conventions documented in `CLAUDE.md` (especially "What NOT To Do")
+5. It proposes premature abstraction (three similar lines is fine)
+
+## Reply protocol
 
 ```bash
-# Fixed
-gh api repos/seantokuzo/major-tom/pulls/{number}/comments/{id}/replies \
-  -f body="Fixed in commit abc1234 — brief description of the change."
+# Read PR comments — use per_page=100 to avoid silent truncation
+gh api "repos/seantokuzo/major-tom/pulls/{number}/comments?per_page=100"
 
-# Not applicable
-gh api repos/seantokuzo/major-tom/pulls/{number}/comments/{id}/replies \
-  -f body="Not applicable — this is a native iOS app using URLSessionWebSocketTask, not a browser WebSocket."
-
-# Deferred
-gh api repos/seantokuzo/major-tom/pulls/{number}/comments/{id}/replies \
-  -f body="Valid point. Tracked as issue #N — tech-debt."
-
-# Pushback (comment is wrong or marginal)
-gh api repos/seantokuzo/major-tom/pulls/{number}/comments/{id}/replies \
-  -f body="Pushing back — {reasoning}. {Framework/type guarantee that makes the comment wrong}."
+# Reply to each comment in its thread (never batch into one PR comment)
+gh api repos/seantokuzo/major-tom/pulls/{number}/comments/{comment_id}/replies \
+  -f body="Fixed in {sha} — {what changed}"
 ```
 
-### 5. Apply Threshold & Merge or Re-round
-
-Count top-level comments in the round you just handled.
-
-- **`<5` → merge immediately.** `gh pr merge {number} --merge --delete-branch`
-- **`≥5` → request another round.** Poll again with 2m→1m cadence.
-
-Do NOT leave a summary PR-level comment — inline replies are the audit trail.
-
-## Response Templates
+**Templates:**
 
 ```markdown
 # Fixed
-Fixed in commit abc1234 — {what changed}.
+Fixed in {sha} — {what changed}.
 
-# Not applicable
-Not applicable — {specific reason why this doesn't apply to our architecture}.
+# Intentional / framework guarantee
+Intentional — `{type}` in `{path}` makes this case unreachable: the {layer}
+narrows to `{X}` before {Y} is called. See `{path}:{line}`.
 
-# Intentional
-Intentional design decision — {reason}. See PLANNING.md {section}.
+# Out of scope (deferred)
+Valid concern. Tracked as #{issue} for a follow-up PR — out of scope for
+this {scope-description} PR.
 
-# Deferred
-Valid improvement. Tracked as issue #N (tech-debt).
-
-# Pushback
-Pushing back — {reasoning}. {Framework/type/convention guarantee}.
-Happy to revisit if this ever fires in the wild.
+# Pushback (incorrect comment)
+This recommendation conflicts with `CLAUDE.md` "What NOT To Do": no Combine /
+no UIKit / no `@ObservableObject` / no premature abstraction. {Specific
+reason this fires here.}
 ```
 
-## Key Principles
+## When to trigger Tier 1 / Tier 3 manually
 
-- **Don't blindly fix everything** — Copilot lacks project context
-- **Reply inline to every comment** — close the loop on each thread individually
-- **Include commit SHA** — when fixing, reference the specific commit
-- **Batch fixes, not replies** — fix all issues in one push, then reply inline to each
-- **Be specific** — "Not applicable because X" not just "Not applicable"
-- **No summary comment** — inline replies are the audit trail; PR-level summaries are noise
+- **`@claude check why CI is failing`** — Tier 1, Opus 4.6 inspects logs via `mcp__github_ci__*` tools
+- **`@claude review the relay session manager for hijacking risk`** — Tier 1, targeted security read
+- **Label `claude-deep-review`** — when you suspect the auto-review missed something or the PR is large/sensitive
+- **`gh workflow run claude-deep-review.yml -f pr_number=N`** — same, via CLI
+
+## What NOT to do
+
+- **Don't fix silently** — every comment gets an inline reply (fix or pushback)
+- **Don't batch replies** in one top-level PR comment
+- **Don't manually request the Claude bot** as a reviewer — it auto-runs from the workflow
+- **Don't paste sentinel JSON** into your replies — the synthesizer regenerates them
+- **Don't use `--squash` merge** unless project conventions say otherwise

--- a/.github/instructions/workflow.instructions.md
+++ b/.github/instructions/workflow.instructions.md
@@ -64,17 +64,17 @@ Before ANY push:
 4. Fix issues, commit fixes
 5. Run CI locally
 
-### 5. PR + Copilot Review
+### 5. PR + Claude Auto-Review
 
 1. Push branch
 2. Create PR (not draft) with template
 3. Apply labels, assign @seantokuzo
-4. Request Copilot review
-5. **STOP — wait for user**
+4. **Claude auto-reviews** via `.github/workflows/claude-code-review.yml` — Tier 2 (3 specialists + verdict synthesizer) fires on PR open/sync. The verdict sticky (`<!-- MT-VERDICT-STICKY -->`) is the round-completion signal.
+5. Follow the autonomous loop in `~/.claude/CLAUDE.md` "PR Review Workflow (canonical)" — poll, address, judge, merge.
 
 ### 6. Address Comments
 
-See `.github/instructions/pr-review.instructions.md` for the full comment-handling workflow.
+See `.github/instructions/pr-review.instructions.md` for project-specific extensions and `~/.claude/CLAUDE.md` "PR Review Workflow (canonical)" for the canonical autonomous loop + judge sub-agent step.
 
 ---
 

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,0 +1,454 @@
+name: Claude Auto Review
+
+# Tier 2: multi-specialist auto-review on every PR.
+# Three concurrent specialists (Security / Architecture / Correctness) each
+# Opus 4.7 + --effort xhigh, then a synthesizer job (also Opus 4.7) reads
+# their JSON sentinels, posts a verdict sticky, and auto-applies the
+# `claude-deep-review` label when escalation criteria are met.
+#
+# Tools: READ-ONLY. Write tools (Edit/Write/NotebookEdit) disallowed.
+# The verdict job is the only one allowed to apply the deep-review label.
+
+on:
+  pull_request:
+    types: [opened, synchronize, ready_for_review]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: PR number to review
+        required: true
+        type: number
+
+permissions: {}
+
+concurrency:
+  group: claude-auto-review-${{ github.event.pull_request.number || inputs.pr_number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  preflight:
+    name: Preflight (skip drafts/forks)
+    runs-on: ubuntu-latest
+    if: |
+      github.repository == 'seantokuzo/major-tom' &&
+      (github.event_name == 'workflow_dispatch' ||
+       github.event.pull_request.draft != true)
+    outputs:
+      pr_number: ${{ steps.set.outputs.pr_number }}
+      head_sha: ${{ steps.set.outputs.head_sha }}
+    steps:
+      - id: set
+        run: |
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            echo "pr_number=${{ inputs.pr_number }}" >> "$GITHUB_OUTPUT"
+            echo "head_sha=" >> "$GITHUB_OUTPUT"
+          else
+            echo "pr_number=${{ github.event.pull_request.number }}" >> "$GITHUB_OUTPUT"
+            echo "head_sha=${{ github.event.pull_request.head.sha }}" >> "$GITHUB_OUTPUT"
+          fi
+
+  security-review:
+    needs: preflight
+    name: 🔒 Security specialist
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          additional_permissions: |
+            actions: read
+          prompt: |
+            You are the SECURITY SPECIALIST for the Major Tom auto-review pipeline.
+
+            PR: #${{ needs.preflight.outputs.pr_number }} in ${{ github.repository }}
+
+            FIRST: read CLAUDE.md (especially "Reviewing with @claude"), docs/STATE.md, and
+            docs/PLANNING.md. If the diff touches relay auth/oauth/sessions/adapters or
+            iOS Keychain/Auth code, read the relevant docs/PHASE-*.md files for context.
+
+            YOUR LANE (only flag these):
+            - Auth / token handling: Google OAuth flow correctness, Keychain usage on iOS,
+              session token storage in relay, refresh-flow race conditions, accidental
+              token leakage to logs / error messages / structured-log fields, PAT scope
+              minimization for any GitHub integration code
+            - WebSocket boundary: input validation on every inbound message in
+              relay/src/server.ts and the protocol handlers; no eval / Function() / unsafe
+              JSON parsing of untrusted input; no broadcast leakage between sessions
+            - PTY / Claude Code spawn safety: command injection in node-pty spawn args,
+              env var injection, working-directory escape, stdin echo of secrets
+            - Path traversal: any fs operation that takes a path from a network message
+              (file read, log read, asset serving) — must be path-resolved and confined
+            - PWA security: XSS via markdown / terminal output rendering, CSP correctness,
+              localStorage / sessionStorage token handling, postMessage origins
+            - Cloudflare Tunnel exposure: anything that broadens the public surface,
+              missing auth on a route reachable through the tunnel
+            - Prompt injection: tool output / message content from Claude SDK that flows
+              back into a UI surface that an LLM might re-execute (mostly the chat /
+              terminal layer)
+            - GitHub Actions safety: pull_request_target misuse, fork-trigger guards,
+              permissions: write surface, third-party action SHA pinning
+
+            NOT YOUR LANE (let other specialists handle):
+            - SwiftUI / MVVM violations → Architecture specialist
+            - Type errors / async hygiene / `any` usage → Correctness specialist
+            - Naming / formatting → ignore (Prettier / SwiftFormat handle it)
+
+            SKEPTICISM RULES (per CLAUDE.md):
+            - Do NOT flag defensive code for cases the type system / framework rules out
+            - Do NOT re-litigate decisions already locked in docs/PLANNING.md or shipped
+              phase docs
+            - Do NOT suggest tests for components without a test harness wired in CI yet
+            - Do NOT suggest scope creep beyond the PR's stated goal
+
+            STEPS:
+            1. gh pr diff ${{ needs.preflight.outputs.pr_number }} (read full diff)
+            2. gh pr view ${{ needs.preflight.outputs.pr_number }} --json title,body,additions,deletions,files
+            3. For each finding, post an inline comment via mcp__github_inline_comment__create_inline_comment
+            4. Post ONE top-level summary comment via gh pr comment with this exact structure:
+
+            <!-- MT-REVIEW-JSON-SECURITY
+            {"verdict":"ship|fix-then-ship|rethink","blocking_count":N,"advisory_count":N,"sensitive_paths_touched":true|false,"top_issues":[{"file":"path","line":N,"severity":"blocking|advisory","summary":"..."}],"rationale":"..."}
+            -->
+
+            ## 🔒 Security Review
+
+            **Verdict**: <verdict>
+            **Blocking**: <N> | **Advisory**: <M>
+
+            <human-readable findings, grouped by severity, with file:line refs>
+
+            ---
+
+            sensitive_paths_touched should be `true` if the diff includes any of:
+            relay/src/server.ts, relay/src/auth/, relay/src/oauth/, relay/src/sessions/,
+            relay/src/adapters/, relay/src/tunnel/, web/src/lib/auth/, web/src/lib/ws/,
+            ios/MajorTom/Services/Keychain*, ios/MajorTom/Features/Auth/,
+            .github/workflows/, tunnel/, vscode-extension/src/auth*
+          claude_args: |
+            --model claude-opus-4-7
+            --effort xhigh
+            --max-turns 12
+            --disallowedTools "Edit,Write,NotebookEdit"
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,mcp__github_ci__get_ci_status,mcp__github_ci__get_workflow_run_details,mcp__github_ci__download_job_log,Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr comment:*),Bash(gh pr checks:*),Bash(gh api repos/seantokuzo/major-tom/pulls/*),Bash(gh api repos/seantokuzo/major-tom/contents/*),Bash(gh api repos/seantokuzo/major-tom/commits/*),Bash(gh run list:*),Bash(gh run view:*),Bash(cd relay && npm run typecheck),Bash(cd relay && npm run lint),Bash(cd relay && npm run build),Bash(cd relay && npm test),Bash(cd web && npm run build),Bash(cd web && npm run check),Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(git blame:*)"
+
+  architecture-review:
+    needs: preflight
+    name: 🏗️ Architecture specialist
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          additional_permissions: |
+            actions: read
+          prompt: |
+            You are the ARCHITECTURE SPECIALIST for the Major Tom auto-review pipeline.
+
+            PR: #${{ needs.preflight.outputs.pr_number }} in ${{ github.repository }}
+
+            FIRST: read CLAUDE.md (Tech Stack & Conventions + What NOT To Do + the
+            "Reviewing with @claude" section) and docs/PLANNING.md for the architecture
+            spec. For UI / sprite / scene work, also skim the relevant docs/PHASE-*.md.
+
+            YOUR LANE (only flag these):
+            - Component boundaries: relay / iOS / web / vscode-extension are independent —
+              flag any cross-component import, leaked type, or shared mutable file
+            - Relay adapter pattern: each Claude target implements `IAdapter`. Flag direct
+              CLI spawn outside an adapter, or adapter logic bleeding into server.ts /
+              session manager
+            - Protocol compliance: WebSocket messages MUST include a `type` field; new
+              message types MUST be added to the canonical protocol types in the relay's
+              shared protocol module AND mirrored on the iOS / PWA side; UUIDs v4 for
+              session/request/agent ids; ISO 8601 strings on the wire
+            - iOS conventions (CLAUDE.md "What NOT To Do" is hard rules):
+              * SwiftUI only — no UIKit unless explicitly justified
+              * `@Observable` (iOS 17+) — NO `@ObservableObject` / `@StateObject`
+              * Swift Concurrency — NO Combine
+              * MVVM — Views observe ViewModels, ViewModels call Services, no Service
+                calls from Views
+              * Feature folder layout: `Features/{Name}/Views/`, `ViewModels/`, `Components/`
+              * Keychain for secrets, SwiftData for persistence
+            - Relay conventions:
+              * TypeScript strict mode
+              * Typed errors; no silent catches
+              * Structured pino logging (no bare console.log paths in shipped code)
+            - File organization: types live with the feature, not in a flat shared
+              `types.ts`; tool/handler groups split by concern; no god files
+            - Anti-patterns (per CLAUDE.md): god files, premature abstraction (DI
+              frameworks, hot reload, plugin versioning), inline handlers in server.ts,
+              singletons-as-state, scope creep beyond the PR's stated goal
+
+            NOT YOUR LANE:
+            - Security findings → Security specialist
+            - Type errors / async hygiene / Swift force-unwraps → Correctness specialist
+            - Formatting / naming → ignore
+
+            SKEPTICISM RULES (per CLAUDE.md):
+            - Do NOT re-litigate locked architecture decisions in docs/PLANNING.md
+            - Do NOT suggest abstractions for hypothetical future requirements
+            - Do NOT flag "could be more DRY" if the alternative is a premature abstraction
+            - Three similar lines is BETTER than a premature abstraction
+
+            STEPS:
+            1. gh pr diff ${{ needs.preflight.outputs.pr_number }}
+            2. gh pr view ${{ needs.preflight.outputs.pr_number }} --json files
+            3. For each finding, inline comment via mcp__github_inline_comment__create_inline_comment
+            4. Post ONE top-level summary comment with this exact structure:
+
+            <!-- MT-REVIEW-JSON-ARCHITECTURE
+            {"verdict":"ship|fix-then-ship|rethink","blocking_count":N,"advisory_count":N,"sensitive_paths_touched":true|false,"top_issues":[{"file":"path","line":N,"severity":"blocking|advisory","summary":"..."}],"rationale":"..."}
+            -->
+
+            ## 🏗️ Architecture Review
+
+            **Verdict**: <verdict>
+            **Blocking**: <N> | **Advisory**: <M>
+
+            <human-readable findings>
+
+            ---
+
+            sensitive_paths_touched should be `true` if the diff includes any of:
+            relay/src/server.ts, relay/src/adapters/, relay/src/sessions/,
+            relay/src/protocol*, web/src/lib/protocol*, web/src/lib/ws/,
+            ios/MajorTom/Services/, ios/MajorTom/Models/, docs/PLANNING.md,
+            docs/TERMINAL-PROTOCOL-SPEC.md
+          claude_args: |
+            --model claude-opus-4-7
+            --effort xhigh
+            --max-turns 12
+            --disallowedTools "Edit,Write,NotebookEdit"
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,mcp__github_ci__get_ci_status,mcp__github_ci__get_workflow_run_details,mcp__github_ci__download_job_log,Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr comment:*),Bash(gh pr checks:*),Bash(gh api repos/seantokuzo/major-tom/pulls/*),Bash(gh api repos/seantokuzo/major-tom/contents/*),Bash(gh api repos/seantokuzo/major-tom/commits/*),Bash(gh run list:*),Bash(gh run view:*),Bash(cd relay && npm run typecheck),Bash(cd relay && npm run lint),Bash(cd relay && npm run build),Bash(cd relay && npm test),Bash(cd web && npm run build),Bash(cd web && npm run check),Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(git blame:*)"
+
+  correctness-review:
+    needs: preflight
+    name: ✅ Correctness specialist
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          additional_permissions: |
+            actions: read
+          prompt: |
+            You are the CORRECTNESS SPECIALIST for the Major Tom auto-review pipeline.
+
+            PR: #${{ needs.preflight.outputs.pr_number }} in ${{ github.repository }}
+
+            FIRST: read CLAUDE.md (Code Conventions + What NOT To Do + the "Reviewing
+            with @claude" section) and the existing patterns in any file you find
+            suspect. .github/instructions/ci.instructions.md lists the local CI gates.
+
+            YOUR LANE (only flag these):
+
+            TypeScript (relay/, web/, vscode-extension/):
+            - NO `any` (must be `unknown` + narrowed); type-only imports
+              (`import type { Foo }` when only used as a type)
+            - ESM imports: every relative import path must end in `.js` (even for `.ts`
+              files) — required by node ESM resolver
+            - async/await hygiene: handlers without `await` must NOT be `async`; missing
+              `await` on Promise-returning calls; unhandled promise rejections; floating
+              promises
+            - Null/undefined: `??` not `||` for nullish coalescing; missing optional
+              chaining; non-null assertions (`!`) without justification
+            - Error handling: typed errors, no silent catches that swallow errors;
+              actionable messages on the wire
+            - Race conditions / shared mutable state in session lifecycle, adapter
+              spawn, async event handlers, WebSocket message ordering
+
+            Swift (ios/):
+            - NO force unwraps (`!`) — use `guard let` / `if let`
+            - NO `@ObservableObject` / `@StateObject` — use `@Observable` (iOS 17+)
+            - NO Combine — Swift Concurrency (async/await, actors) only
+            - NO UIKit (unless explicitly justified)
+            - Actor isolation correctness on `@MainActor` boundaries; no data races
+              across actors; @Sendable conformance where required
+            - Optional handling consistent with the rest of the file
+
+            Cross-cutting:
+            - Run `cd relay && npm run typecheck && npm run lint` and
+              `cd web && npm run check` if needed to verify findings
+            - CI failures: if relay typecheck/lint/build/test failed in CI, inspect the
+              workflow logs via mcp__github_ci__* tools and surface the root cause
+
+            NOT YOUR LANE:
+            - Security findings → Security specialist
+            - Component / MVVM / protocol layout → Architecture specialist
+            - Formatting → Prettier / SwiftFormat handles it; ignore
+
+            SKEPTICISM RULES (per CLAUDE.md):
+            - Do NOT flag defensive code for cases the type system rules out
+            - Do NOT suggest comments that explain WHAT — only WHY-when-non-obvious
+            - Do NOT add error handling for scenarios that can't happen
+            - Do NOT suggest validation at internal call boundaries — only system
+              boundaries (user input, external APIs, WebSocket inbound)
+
+            STEPS:
+            1. gh pr diff ${{ needs.preflight.outputs.pr_number }}
+            2. If CI is red, fetch the failing job logs via mcp__github_ci__download_job_log
+            3. Inline comment each finding
+            4. Post ONE top-level summary with:
+
+            <!-- MT-REVIEW-JSON-CORRECTNESS
+            {"verdict":"ship|fix-then-ship|rethink","blocking_count":N,"advisory_count":N,"sensitive_paths_touched":false,"ci_failing":true|false,"top_issues":[{"file":"path","line":N,"severity":"blocking|advisory","summary":"..."}],"rationale":"..."}
+            -->
+
+            ## ✅ Correctness Review
+
+            **Verdict**: <verdict>
+            **Blocking**: <N> | **Advisory**: <M>
+            **CI status**: <green|red — root cause if red>
+
+            <human-readable findings>
+          claude_args: |
+            --model claude-opus-4-7
+            --effort xhigh
+            --max-turns 12
+            --disallowedTools "Edit,Write,NotebookEdit"
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,mcp__github_ci__get_ci_status,mcp__github_ci__get_workflow_run_details,mcp__github_ci__download_job_log,Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr comment:*),Bash(gh pr checks:*),Bash(gh api repos/seantokuzo/major-tom/pulls/*),Bash(gh api repos/seantokuzo/major-tom/contents/*),Bash(gh api repos/seantokuzo/major-tom/commits/*),Bash(gh run list:*),Bash(gh run view:*),Bash(gh run view --log:*),Bash(cd relay && npm ci),Bash(cd relay && npm run typecheck),Bash(cd relay && npm run lint),Bash(cd relay && npm run build),Bash(cd relay && npm test),Bash(cd web && npm ci),Bash(cd web && npm run build),Bash(cd web && npm run check),Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(git blame:*)"
+
+  verdict:
+    needs: [preflight, security-review, architecture-review, correctness-review]
+    name: 📋 Verdict synthesizer
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    if: always() && needs.preflight.result == 'success'
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          prompt: |
+            You are the VERDICT SYNTHESIZER for the Major Tom auto-review pipeline.
+
+            PR: #${{ needs.preflight.outputs.pr_number }} in ${{ github.repository }}
+
+            Specialist job results (some may have failed — handle gracefully):
+            - Security: ${{ needs.security-review.result }}
+            - Architecture: ${{ needs.architecture-review.result }}
+            - Correctness: ${{ needs.correctness-review.result }}
+
+            STEPS:
+
+            1. Fetch PR comments:
+               gh api "repos/${{ github.repository }}/issues/${{ needs.preflight.outputs.pr_number }}/comments?per_page=100"
+
+            2. Extract every JSON sentinel:
+               - <!-- MT-REVIEW-JSON-SECURITY ... -->
+               - <!-- MT-REVIEW-JSON-ARCHITECTURE ... -->
+               - <!-- MT-REVIEW-JSON-CORRECTNESS ... -->
+               (Take the MOST RECENT instance of each — earlier rounds are stale.)
+
+            3. Compute aggregate verdict:
+               - "rethink" if any specialist verdict is "rethink"
+               - "fix-then-ship" if any blocking_count > 0
+               - "ship" otherwise
+               - total_blocking = sum of blocking_count across specialists
+               - total_advisory = sum of advisory_count across specialists
+               - sensitive_paths_touched = OR of all specialists' flags
+               - ci_failing = correctness specialist's ci_failing (or unknown)
+
+            4. Compute round number:
+               - Find existing <!-- MT-VERDICT-STICKY --> comment via gh api
+               - If exists, parse `VERDICT_ROUND: N` from its body and increment to N+1
+               - If not, round = 1
+               - HARD CAP: if round would exceed 4, set verdict to "rethink" and add a
+                 "🚨 4-round cap reached — escalating to human" line in the action plan.
+
+            5. Compute escalation (auto-apply `claude-deep-review` label if true):
+               escalate = (verdict == "rethink") OR
+                          (sensitive_paths_touched AND total_blocking > 0) OR
+                          (total_blocking > 5) OR
+                          (PR additions+deletions > 500 — get via gh pr view --json additions,deletions)
+               If `claude-deep-review` label already present, do not re-apply.
+
+            6. Find existing verdict sticky:
+               gh api "repos/${{ github.repository }}/issues/${{ needs.preflight.outputs.pr_number }}/comments?per_page=100" | jq '.[] | select(.body | contains("<!-- MT-VERDICT-STICKY -->"))'
+
+            7. Post or update sticky body. If existing, PATCH:
+               gh api -X PATCH "repos/${{ github.repository }}/issues/comments/<comment_id>" -f body='<NEW_BODY>'
+               If new, post:
+               gh pr comment ${{ needs.preflight.outputs.pr_number }} --body '<BODY>'
+
+            8. If escalating and label not present:
+               gh pr edit ${{ needs.preflight.outputs.pr_number }} --add-label claude-deep-review
+               (Create the label first if it doesn't exist:
+                gh label create claude-deep-review --color B60205 --description "Trigger deep multi-specialist review" || true)
+
+            STICKY BODY FORMAT (use this exactly — round number, verdict, counts substituted):
+
+            <!-- MT-VERDICT-STICKY -->
+            <!-- VERDICT_ROUND: N -->
+
+            ## 📋 Auto-Review Verdict — Round N
+
+            **Verdict**: <ship | fix-then-ship | rethink>
+            **Blocking**: <N> | **Advisory**: <M>
+            **CI**: <green | red — root cause>
+
+            ### Specialists
+            - 🔒 Security: <verdict> (B blocking, A advisory)
+            - 🏗️ Architecture: <verdict> (B blocking, A advisory)
+            - ✅ Correctness: <verdict> (B blocking, A advisory)
+
+            ### Top action items
+            - [ ] item 1 — `file:line`
+            - [ ] item 2 — `file:line`
+            - ... up to 5
+
+            ---
+
+            <IF ESCALATED>
+            > 🚨 Auto-escalated to deep review — label `claude-deep-review` applied.
+            > Trigger reason: <reason: rethink-verdict | sensitive-paths-with-blocking | >5-blocking | large-diff>
+            </IF>
+
+            <IF ROUND >= 4>
+            > 🚨 4-round cap reached. Human decision required to merge or close.
+            </IF>
+
+            🤖 _Synthesized by Claude Opus 4.7 from Security + Architecture + Correctness specialists._
+          claude_args: |
+            --model claude-opus-4-7
+            --effort high
+            --max-turns 8
+            --disallowedTools "Edit,Write,NotebookEdit"
+            --allowedTools "Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr comment:*),Bash(gh pr edit:*),Bash(gh api repos/seantokuzo/major-tom/issues/*),Bash(gh api repos/seantokuzo/major-tom/pulls/*),Bash(gh api -X PATCH repos/seantokuzo/major-tom/issues/comments/*),Bash(gh label create:*),Bash(gh label list:*),Bash(jq:*)"

--- a/.github/workflows/claude-deep-review.yml
+++ b/.github/workflows/claude-deep-review.yml
@@ -1,0 +1,450 @@
+name: Claude Deep Review
+
+# Tier 3: opt-in heavy review for security-sensitive or large PRs.
+# Same 3 specialists as Tier 2 BUT at --effort max + --max-turns 30,
+# PLUS a 4th THREAT-MODEL specialist that does STRIDE-style deep analysis.
+# Auto-fires when the Tier 2 verdict applies the `claude-deep-review` label.
+# Manually fires via label add or workflow_dispatch.
+#
+# Tools: still READ-ONLY. The depth comes from effort + turns + an extra
+# specialist, not from write access.
+
+on:
+  pull_request:
+    types: [labeled]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: PR number to deep-review
+        required: true
+        type: number
+
+permissions: {}
+
+concurrency:
+  group: claude-deep-review-${{ github.event.pull_request.number || inputs.pr_number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  preflight:
+    name: Preflight
+    runs-on: ubuntu-latest
+    if: |
+      github.repository == 'seantokuzo/major-tom' &&
+      (github.event_name == 'workflow_dispatch' ||
+       (github.event_name == 'pull_request' &&
+        github.event.label.name == 'claude-deep-review' &&
+        github.event.pull_request.draft != true))
+    outputs:
+      pr_number: ${{ steps.set.outputs.pr_number }}
+    steps:
+      - id: set
+        run: |
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            echo "pr_number=${{ inputs.pr_number }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "pr_number=${{ github.event.pull_request.number }}" >> "$GITHUB_OUTPUT"
+          fi
+
+  security-deep:
+    needs: preflight
+    name: 🔒 Security (deep)
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          additional_permissions: |
+            actions: read
+          prompt: |
+            You are the SECURITY SPECIALIST in DEEP REVIEW mode for Major Tom.
+
+            PR: #${{ needs.preflight.outputs.pr_number }} in ${{ github.repository }}
+
+            Deep review means: take your time, read the full transitive surface, run
+            the build/typecheck/test if it helps, fetch CI logs, follow imports across
+            packages, and produce a thorough security review.
+
+            FIRST: read CLAUDE.md, docs/STATE.md, docs/PLANNING.md. For any file in the
+            diff under relay/src/auth, relay/src/oauth, relay/src/sessions,
+            relay/src/adapters, ios/MajorTom/Services/Keychain*, or
+            ios/MajorTom/Features/Auth/, also read the relevant docs/PHASE-*.md and
+            docs/GROUND-CONTROL-HARDENING.md if it exists.
+
+            YOUR LANE (depth this round):
+            - Auth surface: full audit of Google OAuth flow, refresh-token race
+              conditions, Keychain item access policies on iOS, session token storage
+              and rotation in relay, accidental persistence in dotfiles / log files,
+              clearing on logout, multi-user / team-server-mode isolation
+            - WebSocket boundary: trace every inbound message handler in
+              relay/src/server.ts and the protocol layer; validate every untrusted
+              field; confirm no broadcast leakage between sessions; confirm no eval-
+              equivalent paths
+            - PTY / Claude Code spawn: full audit of node-pty spawn args, env injection
+              vectors, working-directory escape, stdin echo of secrets, signal handling,
+              child cleanup on session disconnect
+            - Path traversal: every fs.* call that takes a path derived from a network
+              message — confirm path-resolved + confined under an allowed root
+            - PWA: XSS via markdown / xterm output rendering, CSP correctness,
+              localStorage / sessionStorage handling, postMessage origin checks,
+              service worker scope
+            - Cloudflare Tunnel: any new public-reachable route, missing auth, header
+              forwarding correctness, IP pinning if relevant
+            - Prompt injection: trace every untrusted input (PR/issue body when GitHub
+              integration is touched, file contents read by Claude SDK, terminal
+              output) into MCP tool descriptions / inputs / outputs
+            - GitHub Actions safety: pull_request_target audit, write-permission
+              justification, third-party action SHA pinning, workflow_dispatch input
+              validation
+            - VSCode extension (when touched): activation events, secrets storage,
+              workspace trust, untrusted workspace handling
+
+            SKEPTICISM RULES (per CLAUDE.md): same as Tier 2 — no hypothetical defensive
+            code, no decisions-already-locked re-litigation, no "add tests" without a
+            test framework wired.
+
+            STEPS:
+            1. gh pr diff ${{ needs.preflight.outputs.pr_number }}
+            2. Inspect each touched file in full (not just the hunk)
+            3. Use mcp__github_ci__* tools to inspect any failing CI logs
+            4. Inline-comment findings; pushback explicitly if a finding is wrong
+            5. Top-level summary with sentinel:
+
+            <!-- MT-REVIEW-JSON-SECURITY
+            {"verdict":"...","blocking_count":N,"advisory_count":N,"sensitive_paths_touched":bool,"top_issues":[...],"rationale":"...","tier":"deep"}
+            -->
+
+            ## 🔒 Security Review (Deep)
+
+            **Verdict**: <verdict>
+            **Blocking**: <N> | **Advisory**: <M>
+            **Threat surface touched**: <description>
+
+            <findings>
+          claude_args: |
+            --model claude-opus-4-7
+            --effort max
+            --max-turns 30
+            --disallowedTools "Edit,Write,NotebookEdit"
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,mcp__github_ci__get_ci_status,mcp__github_ci__get_workflow_run_details,mcp__github_ci__download_job_log,Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr comment:*),Bash(gh pr checks:*),Bash(gh api repos/seantokuzo/major-tom/pulls/*),Bash(gh api repos/seantokuzo/major-tom/contents/*),Bash(gh api repos/seantokuzo/major-tom/commits/*),Bash(gh run list:*),Bash(gh run view:*),Bash(gh run view --log:*),Bash(cd relay && npm ci),Bash(cd relay && npm run typecheck),Bash(cd relay && npm run lint),Bash(cd relay && npm run build),Bash(cd relay && npm test),Bash(cd web && npm ci),Bash(cd web && npm run build),Bash(cd web && npm run check),Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(git blame:*)"
+
+  architecture-deep:
+    needs: preflight
+    name: 🏗️ Architecture (deep)
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          additional_permissions: |
+            actions: read
+          prompt: |
+            You are the ARCHITECTURE SPECIALIST in DEEP REVIEW mode for Major Tom.
+
+            PR: #${{ needs.preflight.outputs.pr_number }} in ${{ github.repository }}
+
+            Deep mode: read the full component boundary surface, every shared protocol
+            type, every cross-component import site, look for emergent contract drift
+            across relay / iOS / PWA / extension.
+
+            FIRST: CLAUDE.md (Tech Stack & Conventions + What NOT To Do),
+            docs/PLANNING.md, docs/TERMINAL-PROTOCOL-SPEC.md, the protocol module in
+            relay/src/, and the parallel models in ios/MajorTom/ and web/src/lib/.
+
+            YOUR LANE (depth this round):
+            - Component boundaries: full audit of relay / iOS / web / vscode-extension
+              isolation; flag every cross-component import or leaked type
+            - Adapter pattern: every Claude target implements `IAdapter`; trace the
+              factory, the lifecycle, the spawn / teardown paths; flag any direct CLI
+              spawn outside an adapter
+            - Protocol compliance: every WebSocket message has a `type`; new types are
+              mirrored on every client; UUID v4 for ids; ISO 8601 on the wire; backwards
+              compatibility considered for v1/v2 protocol code
+            - iOS conventions (CLAUDE.md "What NOT To Do" — hard rules):
+              * SwiftUI only; flag UIKit usage
+              * `@Observable` — flag every `@ObservableObject` / `@StateObject`
+              * Swift Concurrency — flag every Combine usage
+              * MVVM — Views observe ViewModels, ViewModels call Services
+              * Feature folder layout (Views / ViewModels / Components)
+              * Keychain for secrets, SwiftData for persistence
+              * Actor isolation correctness, @MainActor boundaries, @Sendable conformance
+            - Relay conventions: TypeScript strict, typed errors, no silent catches,
+              structured pino logging, no god files in server.ts
+            - File organization: per-feature types, no flat shared `types.ts`, no
+              singletons-as-state, no god files
+            - Anti-patterns: god files, premature abstraction (DI frameworks, hot
+              reload, plugin versioning), inline handlers, scope creep — call them all
+              out
+
+            SKEPTICISM RULES: same as Tier 2.
+
+            STEPS: same as Tier 2 + read every imported file's exports section.
+            Sentinel:
+
+            <!-- MT-REVIEW-JSON-ARCHITECTURE
+            {"verdict":"...","blocking_count":N,"advisory_count":N,"sensitive_paths_touched":bool,"top_issues":[...],"rationale":"...","tier":"deep"}
+            -->
+
+            ## 🏗️ Architecture Review (Deep)
+
+            <findings>
+          claude_args: |
+            --model claude-opus-4-7
+            --effort max
+            --max-turns 30
+            --disallowedTools "Edit,Write,NotebookEdit"
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,mcp__github_ci__get_ci_status,mcp__github_ci__get_workflow_run_details,mcp__github_ci__download_job_log,Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr comment:*),Bash(gh pr checks:*),Bash(gh api repos/seantokuzo/major-tom/pulls/*),Bash(gh api repos/seantokuzo/major-tom/contents/*),Bash(gh api repos/seantokuzo/major-tom/commits/*),Bash(gh run list:*),Bash(gh run view:*),Bash(gh run view --log:*),Bash(cd relay && npm ci),Bash(cd relay && npm run typecheck),Bash(cd relay && npm run lint),Bash(cd relay && npm run build),Bash(cd relay && npm test),Bash(cd web && npm ci),Bash(cd web && npm run build),Bash(cd web && npm run check),Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(git blame:*)"
+
+  correctness-deep:
+    needs: preflight
+    name: ✅ Correctness (deep)
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          additional_permissions: |
+            actions: read
+          prompt: |
+            You are the CORRECTNESS SPECIALIST in DEEP REVIEW mode for Major Tom.
+
+            PR: #${{ needs.preflight.outputs.pr_number }} in ${{ github.repository }}
+
+            Deep mode: run the build / typecheck / test / lint locally, fetch CI logs,
+            chase down every type assertion, every unhandled Promise, every `any` slip,
+            every Swift force-unwrap.
+
+            FIRST: CLAUDE.md (Code Conventions + What NOT To Do),
+            .github/instructions/ci.instructions.md.
+
+            YOUR LANE (depth this round):
+            - Run `cd relay && npm ci && npm run lint && npm run typecheck && npm test
+              && npm run build` — surface any failure as blocking
+            - Run `cd web && npm ci && npm run check && npm run build` — surface any
+              failure as blocking
+            - TypeScript: full `any` audit (must be `unknown`+narrow), type-only
+              imports, ESM .js suffixes
+            - async/await: trace every async function; flag `async` without `await`,
+              missing `await` on Promise-returning calls, unhandled rejections,
+              floating promises
+            - Null/undefined: every `||` that could mask 0/false/empty; every non-null
+              assertion (`!`) without justification; missing optional chaining
+            - Error handling: typed errors, no silent catches; messages actionable on
+              the wire; iOS errors surfaced through ViewModels not swallowed
+            - Race conditions / shared state in session lifecycle, adapter spawn,
+              async event handlers, WebSocket message ordering
+            - Swift: full force-unwrap audit, `@Observable` conformance, Concurrency
+              correctness (@MainActor, @Sendable, actor isolation), no Combine slips,
+              no UIKit slips
+
+            STEPS: run the full local CI; fetch failing logs via mcp__github_ci__*;
+            audit the diff with typecheck output context.
+
+            <!-- MT-REVIEW-JSON-CORRECTNESS
+            {"verdict":"...","blocking_count":N,"advisory_count":N,"sensitive_paths_touched":false,"ci_failing":bool,"top_issues":[...],"rationale":"...","tier":"deep"}
+            -->
+
+            ## ✅ Correctness Review (Deep)
+
+            <findings>
+          claude_args: |
+            --model claude-opus-4-7
+            --effort max
+            --max-turns 30
+            --disallowedTools "Edit,Write,NotebookEdit"
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,mcp__github_ci__get_ci_status,mcp__github_ci__get_workflow_run_details,mcp__github_ci__download_job_log,Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr comment:*),Bash(gh pr checks:*),Bash(gh api repos/seantokuzo/major-tom/pulls/*),Bash(gh api repos/seantokuzo/major-tom/contents/*),Bash(gh api repos/seantokuzo/major-tom/commits/*),Bash(gh run list:*),Bash(gh run view:*),Bash(gh run view --log:*),Bash(cd relay && npm ci),Bash(cd relay && npm run typecheck),Bash(cd relay && npm run lint),Bash(cd relay && npm run build),Bash(cd relay && npm test),Bash(cd web && npm ci),Bash(cd web && npm run build),Bash(cd web && npm run check),Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(git blame:*)"
+
+  threatmodel-deep:
+    needs: preflight
+    name: 🎯 Threat Model (deep)
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          additional_permissions: |
+            actions: read
+          prompt: |
+            You are the THREAT-MODEL SPECIALIST for Major Tom — only runs in deep review.
+
+            PR: #${{ needs.preflight.outputs.pr_number }} in ${{ github.repository }}
+
+            FIRST: read CLAUDE.md, docs/PLANNING.md, docs/STATE.md, and any
+            docs/GROUND-CONTROL-HARDENING.md / docs/PHASE-*.md relevant to the touched
+            surface. Major Tom's primary trust boundaries are:
+            - User device (iPhone) ↔ Cloudflare Tunnel ↔ Relay (laptop)
+            - Relay ↔ Claude Code CLI (PTY child process)
+            - Relay ↔ Google OAuth (auth refresh)
+            - Multi-user / team-server mode (per-user OS accounts)
+
+            YOUR JOB: STRIDE-style adversarial review of the changes:
+            - Spoofing: identity / auth assumptions broken? token confusion? UA spoofing?
+              session hijacking via WebSocket?
+            - Tampering: integrity guarantees on protocol messages? config / cookie /
+              localStorage tamper resistance? PTY stdin injection?
+            - Repudiation: actions logged / attested? could an attacker cover tracks
+              in the relay logs? could an LLM action be denied by the user later?
+            - Information disclosure: what new data flows are introduced? could any
+              cross trust boundaries unintentionally? terminal output bleed between
+              sessions? token leakage in error paths?
+            - Denial of service: amplification, resource exhaustion, infinite loops
+              triggered by adversarial input? PTY fork-bomb? WebSocket flood? large
+              message OOM?
+            - Elevation of privilege: privilege boundaries respected? new sudo paths?
+              relay running as user with shell access — what new capabilities does the
+              PR grant a network attacker?
+
+            FOR EACH AFFECTED COMPONENT: write out
+            - Threat: <what could go wrong>
+            - Attacker: <who, what capability they need>
+            - Path: <how the attack works step by step>
+            - Severity: <blocking / advisory>
+            - Mitigation: <existing? new? recommended?>
+            - Post-exploitation: <if attack succeeds, what else falls?>
+
+            DO NOT duplicate findings the Security specialist will catch (you read
+            the same file BUT focus on attacker-perspective scenarios, not defect-
+            perspective findings).
+
+            DO NOT enumerate impossible threats — be honest about likelihood.
+
+            <!-- MT-REVIEW-JSON-THREATMODEL
+            {"verdict":"...","blocking_count":N,"advisory_count":N,"sensitive_paths_touched":bool,"threats":[{"category":"S|T|R|I|D|E","severity":"...","summary":"..."}],"rationale":"...","tier":"deep"}
+            -->
+
+            ## 🎯 Threat Model Review (Deep)
+
+            **Verdict**: <verdict>
+            **Top threats**: <count>
+
+            <STRIDE walkthrough by component>
+          claude_args: |
+            --model claude-opus-4-7
+            --effort max
+            --max-turns 30
+            --disallowedTools "Edit,Write,NotebookEdit"
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,mcp__github_ci__get_ci_status,mcp__github_ci__get_workflow_run_details,mcp__github_ci__download_job_log,Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr comment:*),Bash(gh api repos/seantokuzo/major-tom/pulls/*),Bash(gh api repos/seantokuzo/major-tom/contents/*),Bash(gh api repos/seantokuzo/major-tom/commits/*),Bash(gh run list:*),Bash(gh run view:*),Bash(cd relay && npm run typecheck),Bash(cd relay && npm run lint),Bash(cd relay && npm run build),Bash(cd relay && npm test),Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(git blame:*)"
+
+  verdict-deep:
+    needs: [preflight, security-deep, architecture-deep, correctness-deep, threatmodel-deep]
+    name: 📋 Deep verdict synthesizer
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    if: always() && needs.preflight.result == 'success'
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          prompt: |
+            You are the DEEP VERDICT SYNTHESIZER for Major Tom.
+
+            PR: #${{ needs.preflight.outputs.pr_number }} in ${{ github.repository }}
+
+            Specialists this round:
+            - Security: ${{ needs.security-deep.result }}
+            - Architecture: ${{ needs.architecture-deep.result }}
+            - Correctness: ${{ needs.correctness-deep.result }}
+            - Threat Model: ${{ needs.threatmodel-deep.result }}
+
+            STEPS:
+
+            1. Fetch PR comments:
+               gh api "repos/${{ github.repository }}/issues/${{ needs.preflight.outputs.pr_number }}/comments?per_page=100"
+
+            2. Extract MOST RECENT JSON sentinel for each:
+               - <!-- MT-REVIEW-JSON-SECURITY ... -->  (deep tier preferred)
+               - <!-- MT-REVIEW-JSON-ARCHITECTURE ... -->  (deep tier preferred)
+               - <!-- MT-REVIEW-JSON-CORRECTNESS ... -->  (deep tier preferred)
+               - <!-- MT-REVIEW-JSON-THREATMODEL ... -->
+
+            3. Aggregate:
+               - verdict: rethink if any = rethink, else fix-then-ship if blocking>0, else ship
+               - total_blocking, total_advisory
+               - top threats list from threat model
+
+            4. Round number: find <!-- MT-DEEP-VERDICT-STICKY --> and increment.
+               HARD CAP at 4 — if exceeded, set verdict = rethink + escalate to human.
+
+            5. Find existing deep verdict sticky and PATCH, or post new.
+
+            STICKY BODY:
+
+            <!-- MT-DEEP-VERDICT-STICKY -->
+            <!-- DEEP_VERDICT_ROUND: N -->
+
+            ## 📋 Deep Review Verdict — Round N
+
+            **Verdict**: <ship | fix-then-ship | rethink>
+            **Blocking**: <N> | **Advisory**: <M>
+
+            ### Specialists (deep mode)
+            - 🔒 Security: <verdict> (B blocking, A advisory)
+            - 🏗️ Architecture: <verdict> (B blocking, A advisory)
+            - ✅ Correctness: <verdict> (B blocking, A advisory)
+            - 🎯 Threat Model: <verdict> (B blocking, A advisory)
+
+            ### Top action items
+            - [ ] item 1 — `file:line`
+            - ... up to 7
+
+            ### Top threats (from threat model)
+            - <category>: <summary>
+
+            ---
+
+            🤖 _Synthesized by Claude Opus 4.7 (max effort) from 4 deep specialists._
+          claude_args: |
+            --model claude-opus-4-7
+            --effort high
+            --max-turns 8
+            --disallowedTools "Edit,Write,NotebookEdit"
+            --allowedTools "Bash(gh pr view:*),Bash(gh pr comment:*),Bash(gh api repos/seantokuzo/major-tom/issues/*),Bash(gh api repos/seantokuzo/major-tom/pulls/*),Bash(gh api -X PATCH repos/seantokuzo/major-tom/issues/comments/*),Bash(jq:*)"

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,76 @@
+name: Claude Mention Handler
+
+# Tier 1: @claude interactive Q&A handler.
+# Triggers on @claude mentions in issues, PRs, and review comments.
+# Model: Opus 4.6 + --effort max (snappy, capable, no overthinking on Q&A).
+# Tools: read-only. Write tools (Edit/Write/NotebookEdit) disallowed.
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  pull_request_review:
+    types: [submitted]
+  issues:
+    types: [opened, assigned, labeled]
+  workflow_dispatch:
+    inputs:
+      issue_or_pr_number:
+        description: Issue or PR number to act on
+        required: true
+        type: number
+      prompt:
+        description: Instruction for Claude
+        required: true
+        type: string
+
+permissions: {}
+
+concurrency:
+  group: claude-mention-${{ github.event.issue.number || github.event.pull_request.number || github.event.inputs.issue_or_pr_number || github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  claude:
+    name: Claude
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    if: |
+      github.repository == 'seantokuzo/major-tom' &&
+      (
+        github.event_name == 'workflow_dispatch' ||
+        (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+        (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+        (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+        (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || github.event.label.name == 'claude'))
+      )
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+      id-token: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Run Claude
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          additional_permissions: |
+            actions: read
+          # workflow_dispatch path: pass an explicit prompt. For mention events,
+          # let the action consume the comment body as the user message; we
+          # only append standing instructions to the system prompt.
+          prompt: ${{ github.event_name == 'workflow_dispatch' && inputs.prompt || '' }}
+          claude_args: |
+            --model claude-opus-4-6
+            --effort max
+            --max-turns 10
+            --append-system-prompt "You are the Major Tom @claude mention handler. ALWAYS read CLAUDE.md (especially the 'Reviewing with @claude' section) and docs/STATE.md first. Apply the standing review priorities (SECURITY → ARCHITECTURE → CORRECTNESS → CONVENTIONS) and the 'What NOT to flag' rules. You have READ-ONLY access — never attempt to write files, push commits, or merge. If asked to implement changes, explain what would change and recommend the user open a PR or trigger /implement separately."
+            --disallowedTools "Edit,Write,NotebookEdit"
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,mcp__github_ci__get_ci_status,mcp__github_ci__get_workflow_run_details,mcp__github_ci__download_job_log,Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr comment:*),Bash(gh pr checks:*),Bash(gh issue view:*),Bash(gh issue list:*),Bash(gh issue comment:*),Bash(gh api repos/seantokuzo/major-tom/pulls/*),Bash(gh api repos/seantokuzo/major-tom/issues/*),Bash(gh api repos/seantokuzo/major-tom/contents/*),Bash(gh api repos/seantokuzo/major-tom/commits/*),Bash(gh run list:*),Bash(gh run view:*),Bash(cd relay && npm run typecheck),Bash(cd relay && npm run lint),Bash(cd relay && npm run build),Bash(cd relay && npm test),Bash(cd web && npm run build),Bash(cd web && npm run check),Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(git blame:*)"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,16 +99,18 @@ This project uses a **thin orchestrator, fat workers** pattern:
 
 ### PR Review Pipeline
 
-Canonical rules live in `~/.claude/CLAUDE.md` under **"PR Review Workflow"**. Summary:
+Canonical autonomous loop lives in `~/.claude/CLAUDE.md` under **"PR Review Workflow"**. Reviews are powered by the Claude GitHub App via three workflows in `.github/workflows/` — see "Reviewing with @claude" below for the tier table. Summary:
 
-1. **Polling:** 2m first poll, 1m subsequent. Never poll sooner.
-2. **Completion detection:** count reviews with body containing `"Pull request overview"`. Round N is complete when N such reviews exist.
-3. **5-comment threshold:** `<5` comments in the round → merge. `≥5` → request another round.
+1. **Round completion = sticky updated for head SHA.** Each auto-review round posts/updates the verdict sticky `<!-- MT-VERDICT-STICKY -->` (Tier 2) or `<!-- MT-DEEP-VERDICT-STICKY -->` (Tier 3). The sticky is the round-completion signal — NOT inline comment counts.
+2. **Polling:** first poll 5m after PR creation/push (specialists run in parallel, ~3-5 min each + synth). Subsequent polls every 2m until the sticky lands or updates for the new head SHA.
+3. **Triage:** every comment is `fix-now` / `respond` / `defer`. Push back inline when the comment recommends defensive code for impossible cases, scope creep, or anything that conflicts with `CLAUDE.md` / `docs/PLANNING.md`.
 4. **Replies:** inline to each comment thread (never batched), with commit SHA for fixes or cited reasoning for pushback.
-5. **Post-merge:** `git checkout main && git pull`, update `docs/STATE.md`, prep next phase prompt.
-6. **Override:** if the user says "wait for me", stop after PR creation — don't poll/merge.
+5. **Round-N decision:** spawn an impartial judge sub-agent per the global protocol — fresh general-purpose agent, no review history. Decision is `merge | re-review | human-decides`. Hard cap at 4 rounds.
+6. **CI gate:** must be green before merge unless the PR is labeled `expected-ci-fail`.
+7. **Post-merge:** `git checkout main && git pull`, update `docs/STATE.md`, prep next phase prompt.
+8. **Override:** if the user says "wait for me", stop after PR creation — don't poll/merge.
 
-Execution details (bash commands, triage table, reply formats) are in `.agents/skills/pr-review-pipeline/SKILL.md`. That skill MUST align with the canonical rules — if it drifts, fix the skill.
+Execution details (bash commands, reply templates) are in `.agents/skills/pr-review-pipeline/SKILL.md`. That skill MUST align with the canonical rules + this section — if it drifts, fix the skill.
 
 ### Context Management
 
@@ -153,3 +155,91 @@ Before marking any task complete:
 - Don't guess package versions — always check with `npm view`
 - Don't nest subagents (orchestrator → workers, never workers → sub-workers)
 - Don't paste file contents into agent prompts (pass paths instead)
+
+---
+
+## Reviewing with @claude
+
+Three review tiers powered by the Claude GitHub App. **The action loads THIS file at runtime** — everything below is standing instructions for both the human and the reviewer.
+
+### Review tiers
+
+| Tier | Trigger | Model | Effort | Use for |
+|------|---------|-------|--------|---------|
+| **1: `@claude` Q&A** | mention in issue / PR / review comment | Opus 4.6 | `max` | targeted questions, one-off code reads, CI-failure inspection |
+| **2: Auto-review** | every non-draft PR (open / sync / ready) | Opus 4.7 | `xhigh` | canonical multi-specialist review |
+| **3: Deep review** | label `claude-deep-review` (manual or auto-escalated) | Opus 4.7 | `max`, 30 turns | security-sensitive, large, or escalated changes |
+
+Workflows: `.github/workflows/claude.yml` (Tier 1), `claude-code-review.yml` (Tier 2), `claude-deep-review.yml` (Tier 3). Tier 2 runs three specialists in parallel (🔒 Security / 🏗️ Architecture / ✅ Correctness) plus a verdict synthesizer. Tier 3 adds a 🎯 Threat Model specialist.
+
+All tiers are **READ-ONLY** — `Edit`, `Write`, and `NotebookEdit` are explicitly disallowed. No tier can modify code, push commits, or merge.
+
+### Standing review priorities (in order)
+
+1. **SECURITY** — auth / token handling (Google OAuth, Keychain, session tokens), WebSocket boundary input validation, PTY / Claude Code spawn safety (command injection / env injection / cwd escape), path traversal in fs ops driven by network input, PWA XSS (markdown / xterm rendering), Cloudflare Tunnel exposure, prompt-injection paths, GitHub Actions safety
+2. **ARCHITECTURE** — component boundaries (relay / iOS / web / vscode-extension are independent), adapter pattern in relay (`IAdapter`), protocol compliance (`type` field on every WebSocket message, mirrored types across clients), iOS conventions (SwiftUI only, `@Observable` only, Swift Concurrency only, MVVM, feature folder layout, Keychain + SwiftData), file organization (per-feature types, no god files)
+3. **CORRECTNESS** — strict TS (no `any`, use `unknown`+narrow), ESM `.js` import suffixes, async/await hygiene, `??` not `||`, typed errors with no silent catches; Swift no-force-unwraps + actor isolation correctness
+4. **CONVENTIONS** — see "What NOT To Do" above
+
+### Path-aware focus
+
+| Path | Primary specialist focus |
+|------|--------------------------|
+| `relay/src/server.ts`, `relay/src/sessions/` | Security (WS boundary) + Architecture (no god files) |
+| `relay/src/auth/`, `relay/src/oauth/` | Security (token storage / refresh / leakage) |
+| `relay/src/adapters/` | Architecture (`IAdapter` contract) + Security (PTY spawn safety) |
+| `relay/src/tunnel/`, `tunnel/` | Security (public exposure surface) |
+| `relay/src/protocol*`, `web/src/lib/protocol*` | Architecture (protocol mirroring across clients) |
+| `web/src/lib/ws/`, `web/src/lib/auth/` | Security + protocol mirroring |
+| `ios/MajorTom/Services/Keychain*`, `ios/MajorTom/Features/Auth/` | Security (Keychain access policies) |
+| `ios/MajorTom/Features/*/Views/`, `ViewModels/` | Architecture (MVVM, `@Observable`, Concurrency) |
+| `.github/workflows/` | Security (Actions safety, fork guards, action SHA pinning) |
+
+### What NOT to flag
+
+- **Defensive code for impossible cases** — trust framework / type-system guarantees. Validate only at system boundaries (user input, external APIs, WebSocket inbound).
+- **Test coverage gaps** — vitest is wired only for relay; iOS / PWA test harnesses aren't in CI yet. Don't ask for tests outside relay until they land.
+- **Architecture re-litigation** — locked decisions live in `docs/PLANNING.md` and the shipped `docs/PHASE-*.md` docs. Don't propose alternatives.
+- **Premature abstraction** — three similar lines is BETTER than a bad abstraction. Don't suggest DRY without strong evidence.
+- **Scope creep** — review the PR's stated scope, not adjacent work or future features.
+- **Style nits** — Prettier / SwiftFormat handle formatting; ignore.
+- **Comment density** — code without comments is fine if names are clear; only flag missing comments when WHY is non-obvious.
+
+### Mention syntax cheatsheet
+
+```text
+# Targeted question
+@claude does this introduce any prompt-injection vectors via the terminal output path?
+
+# Re-review after fixes
+@claude addressed in <sha> — re-review the security findings only
+
+# Inspect CI
+@claude check why CI is failing on this PR and surface the root cause
+
+# Explain
+@claude walk me through how the relay's session manager handles WebSocket reconnect
+
+# Trigger deep review
+# Add the `claude-deep-review` label, or run claude-deep-review.yml via workflow_dispatch
+```
+
+### Round protocol
+
+Round 1 = the auto-review on PR open / push. Subsequent rounds fire on each new commit (the `synchronize` event re-runs Tier 2). The verdict synthesizer posts a sticky comment (`<!-- MT-VERDICT-STICKY -->`) that is updated in place each round.
+
+- **Hard cap: 4 rounds.** After round 4 the synthesizer escalates to a human decision regardless of remaining issues.
+- **Auto-escalation to Tier 3** when the synthesizer detects: any specialist verdict = `rethink`, OR `sensitive_paths_touched: true` AND blocking>0, OR total blocking > 5, OR PR diff > 500 lines.
+- **CI must be green** before merge unless the PR is explicitly labeled `expected-ci-fail` (early-phase work).
+
+### Reviewer JSON sentinel format
+
+Each specialist embeds a sentinel in its summary comment for the synthesizer to parse:
+
+```html
+<!-- MT-REVIEW-JSON-{SECURITY|ARCHITECTURE|CORRECTNESS|THREATMODEL}
+{"verdict":"ship|fix-then-ship|rethink","blocking_count":N,"advisory_count":N,"sensitive_paths_touched":bool,"top_issues":[...],"rationale":"..."}
+-->
+```
+
+Don't edit these by hand — they're regenerated each round.


### PR DESCRIPTION
## Summary

Replaces the GitHub Copilot review path (Pro+ cancelled) with three Claude GitHub App workflows, mirroring the setup proven out in the sister `seantokuzo-mcp` repo, but with specialist prompts rewritten for major-tom's relay/iOS/PWA architecture.

## What ships

**3 new workflow files in `.github/workflows/`:**

| Tier | File | Trigger | Model | Effort | Purpose |
|------|------|---------|-------|--------|---------|
| 1 | `claude.yml` | `@claude` mention in PR/issue/review | Opus 4.6 | max | Targeted Q&A, CI inspection |
| 2 | `claude-code-review.yml` | every non-draft PR (open/sync/ready) | Opus 4.7 | xhigh | 3 parallel specialists + verdict synth |
| 3 | `claude-deep-review.yml` | `claude-deep-review` label or workflow_dispatch | Opus 4.7 | max, 30 turns | 4 specialists incl. Threat Model + deep verdict synth |

All tiers are **READ-ONLY** (`Edit`/`Write`/`NotebookEdit` disallowed at the workflow level). All Bash allowlists are repo-scoped. Top-level `permissions: {}` (default-deny). Sentinels prefixed `MT-*` to avoid collision with the sister repo's `KUZO-*`.

**Specialist lanes** (rewritten for our surface):
- 🔒 **Security** — WebSocket boundary input validation, PTY/Claude Code spawn safety (command injection / env injection / cwd escape), OAuth + Keychain handling, path traversal in fs ops driven by network input, PWA XSS (markdown / xterm rendering), Cloudflare Tunnel exposure, prompt injection, GitHub Actions safety
- 🏗️ **Architecture** — component isolation (relay / iOS / web / vscode-extension are independent), `IAdapter` contract in relay, protocol mirroring across clients, iOS conventions (SwiftUI only, `@Observable` only, Swift Concurrency only, MVVM, feature folder layout)
- ✅ **Correctness** — TS strict (no `any`, ESM `.js` suffixes, `??` not `||`, async/await hygiene); Swift force-unwrap audit, actor isolation, `@MainActor` / `@Sendable` correctness; runs `cd relay && npm run typecheck/lint/build/test` and `cd web && npm run check/build` to verify
- 🎯 **Threat Model** (Tier 3 only) — STRIDE walkthrough across the iPhone ↔ Cloudflare Tunnel ↔ Relay ↔ Claude CLI trust boundaries

**Auto-escalation to Tier 3:** the Tier 2 verdict synth applies the `claude-deep-review` label when any specialist verdicts `rethink`, OR `sensitive_paths_touched` AND blocking>0, OR total blocking >5, OR PR diff >500 lines. **Hard cap: 4 rounds** then human-decides.

## Doc updates

- **`CLAUDE.md`** — new "Reviewing with @claude" section (tier table, standing priorities, path-aware focus, what-NOT-to-flag, mention syntax, round protocol, sentinel format) + replaced Copilot-flavored "PR Review Pipeline" summary with the sticky-driven autonomous loop
- **`.github/instructions/pr-review.instructions.md`** — rewritten Claude-flavored (sentinels, stickies, reply protocol, pushback templates)
- **`.github/instructions/{github,workflow}.instructions.md`** — replace "Request Copilot review / STOP" with "Claude auto-reviews", add `claude-deep-review` + `expected-ci-fail` labels

## To enable on this repo

- [ ] `CLAUDE_CODE_OAUTH_TOKEN` repo secret set (or `ANTHROPIC_API_KEY` as fallback — action prefers OAuth)
- [ ] Claude Code GitHub App installed on `seantokuzo/major-tom` (provides the `mcp__github_inline_comment__*` and `mcp__github_ci__*` tools the specialists need)
- [ ] Optional: pre-create labels `claude-deep-review` (the synth creates it on first escalation if missing) and `expected-ci-fail`

## Test plan

- [ ] This PR will be the first end-to-end test — Tier 2 fires on `pull_request: opened`. Verify the 3 specialists run, post inline comments where applicable, and the synth posts an `<!-- MT-VERDICT-STICKY -->` comment.
- [ ] If Tier 2 verdicts escalate, confirm `claude-deep-review` label is auto-applied and Tier 3 fires.
- [ ] Manually `@claude what does this PR change?` to validate Tier 1.
- [ ] Verify `actions/checkout@v4` and `anthropics/claude-code-action@v1` resolve and run.
- [ ] Confirm CI (`ci.yml`) still passes — these workflows are additive, no overlap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)