### PR TITLE
fix(ios): defer subagent sprite render until sprite.link arrives (#22)

### DIFF
--- a/ios/MajorTom/Features/Office/Views/OfficeView.swift
+++ b/ios/MajorTom/Features/Office/Views/OfficeView.swift
@@ -40,7 +40,7 @@ struct OfficeView: View {
     /// IDs of agents currently rendered in the SKScene, used to diff adds/
     /// removes on each `agents` change. Subagents whose `sprite.link` hasn't
     /// arrived yet (no `spriteHandle`) are intentionally absent — see
-    /// `syncScene` and QA-FIXES #22
+    /// `syncScene` and QA-FIXES #22.
     @State private var previousAgentIds: Set<String> = []
     @State private var previousStatuses: [String: AgentStatus] = [:]
 

--- a/ios/MajorTom/Features/Office/Views/OfficeView.swift
+++ b/ios/MajorTom/Features/Office/Views/OfficeView.swift
@@ -40,7 +40,7 @@ struct OfficeView: View {
     /// IDs of agents currently rendered in the SKScene, used to diff adds/
     /// removes on each `agents` change. Subagents whose `sprite.link` hasn't
     /// arrived yet (no `spriteHandle`) are intentionally absent — see
-    /// `syncScene` and QA-FIXES #22.
+    /// `syncScene` and QA-FIXES #22
     @State private var previousAgentIds: Set<String> = []
     @State private var previousStatuses: [String: AgentStatus] = [:]
 

--- a/ios/MajorTom/Features/Office/Views/OfficeView.swift
+++ b/ios/MajorTom/Features/Office/Views/OfficeView.swift
@@ -37,7 +37,10 @@ struct OfficeView: View {
     /// Space weather engine for cosmetic atmospheric events.
     @State private var spaceWeather = SpaceWeatherEngine()
 
-    /// Previous agent states for diffing.
+    /// IDs of agents currently rendered in the SKScene, used to diff adds/
+    /// removes on each `agents` change. Subagents whose `sprite.link` hasn't
+    /// arrived yet (no `spriteHandle`) are intentionally absent — see
+    /// `syncScene` and QA-FIXES #22.
     @State private var previousAgentIds: Set<String> = []
     @State private var previousStatuses: [String: AgentStatus] = [:]
 
@@ -668,9 +671,19 @@ struct OfficeView: View {
     // MARK: - Scene Sync
 
     private func syncScene(with agents: [AgentState], viewModel: OfficeViewModel, scene: OfficeScene) {
-        let currentIds = Set(agents.map(\.id))
+        // QA-FIXES #22: defer rendering subagent sprites until `sprite.link`
+        // populates `spriteHandle` (and the relay's authoritative
+        // `characterType`). Otherwise the scene locks the sprite to the
+        // local placeholder picked in `handleAgentSpawn`, while the inspector
+        // reads the post-link AgentState — divergent visuals on the same
+        // agent. Idle pool sprites have no link by design and render
+        // immediately.
+        let renderable = agents.filter { agent in
+            agent.id.hasPrefix("idle-") || agent.spriteHandle != nil
+        }
+        let renderableIds = Set(renderable.map(\.id))
 
-        for agent in agents where !previousAgentIds.contains(agent.id) {
+        for agent in renderable where !previousAgentIds.contains(agent.id) {
             scene.addAgent(id: agent.id, name: agent.name, characterType: agent.characterType)
             if let deskIndex = agent.deskIndex {
                 scene.highlightDesk(deskIndex, occupied: true)
@@ -681,7 +694,7 @@ struct OfficeView: View {
             }
         }
 
-        for id in previousAgentIds where !currentIds.contains(id) {
+        for id in previousAgentIds where !renderableIds.contains(id) {
             viewModel.activityAnimator.stopPhase(for: id, furnitureNodes: scene.furnitureNodes)
             scene.removeAgent(id: id)
         }
@@ -693,7 +706,7 @@ struct OfficeView: View {
             }
         }
 
-        previousAgentIds = currentIds
+        previousAgentIds = renderableIds
         previousStatuses = Dictionary(uniqueKeysWithValues: agents.map { ($0.id, $0.status) })
     }
 


### PR DESCRIPTION
## Summary

Closes QA-FIXES **#22** — sprite identity diverged between Office scene and Inspector panel on the same agent.

**Root cause.** Relay sends `agent.spawn` followed by `sprite.link` for each subagent. iOS handlers run in order:
1. `OfficeViewModel.handleAgentSpawn` appends an `AgentState` with a **local placeholder** `characterType` (random non-dog).
2. SwiftUI re-renders → `OfficeView.syncScene` calls `scene.addAgent(...)` with the placeholder. `AgentSprite.characterType` is `let` — the body texture is locked.
3. `OfficeViewModel.handleSpriteLink` arrives → overwrites `agents[i].characterType` with the relay's authoritative pick.
4. `syncScene` runs again, but the agent ID is already in `previousAgentIds`, so `addAgent` doesn't fire. The scene's sprite stays on the placeholder.
5. User taps the sprite → `viewModel.selectedAgent.characterType` is the post-link value → Inspector renders the relay's character. Scene shows the placeholder. Two surfaces, two characters.

The user's hypothesis (RoleMapper leftover in the inspector) was wrong — `RoleMapper.color(forCanonicalRole:)` is the only thing left after PR #161 and never resolves a character. This was a pure spawn/link race in scene rendering.

**Fix.** `syncScene` now defers `scene.addAgent` for non-idle agents until `spriteHandle` is populated (i.e. `sprite.link` has landed with the relay's authoritative `characterType`). Idle pool sprites still render immediately. `previousAgentIds` now tracks only rendered IDs so deferred agents become visible the moment their link arrives.

Trade-off: visible sprite appears milliseconds later than before (after the second WebSocket frame, not the first). Both events come from the same relay handler, so the gap is sub-perceptible. In return, scene and inspector are guaranteed to consume the same `characterType` for the lifetime of every sprite.

## Test plan

- [ ] Build & install on physical device
- [ ] Spawn a few subagents in a PTY tab (e.g. via Explore subagents in claude)
- [ ] Tap each sprite; confirm inspector character + label match the scene's sprite
- [ ] Repeat across multiple spawns to rule out the first-spawn-only case
- [ ] Verify idle pool sprites (humans + dogs) still render unchanged on Office open
- [ ] Verify reconnect / sprite.state rehydrate path still renders all bound sprites (those events ship `spriteHandle`, so should pass through immediately)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
