### PR TITLE
fix(ios): auto-pick relay URL on pairing screen (QA-FIXES #21)

### DIFF
--- a/docs/QA-FIXES.md
+++ b/docs/QA-FIXES.md
@@ -426,23 +426,25 @@ Review: 3/3 specialists `ship`, 0 blocking, 0 advisory. CI green. Single-file ch
 
 ---
 
-### 21. Connect screen shows too many URLs — auto-pick one based on phone network state (device QA 2026-05-03)
+### 21. Connect screen shows too many URLs — auto-pick one based on phone network state (FIXED — PR pending, 2026-05-04)
 
-**Symptom (device QA, 2026-05-03):** Sean's iPhone Connect screen displays Tailscale URL + LAN URL + PIN + maybe more, plus the Mac's LAN IP drifts (`192.168.1.210` → `192.168.1.254` between sessions), so the cached LAN URL goes stale and reconnect fails silently. User just wants "local OR tunnel" — one path at a time.
+**Symptom (device QA, 2026-05-03):** Sean's iPhone pairing screen displays Tailscale URL + LAN URL + Cloudflare tunnel + localhost as four selectable chips, plus the Mac's LAN IP drifts (`192.168.1.210` → `192.168.1.254` between sessions), so the cached LAN URL goes stale and reconnect fails silently. User just wants "local OR tunnel" — one path at a time.
 
-**Quick fix (RECOMMENDED, ~2-4 hr work):** detect phone's network state with `NWPathMonitor`, show **only one URL**:
-- Tailscale interface up → Tailscale URL
-- Otherwise → LAN URL (numeric, will drift if Mac's DHCP lease changes)
-- Both up → prefer Tailscale (stable across networks, immune to LAN IP drift)
+**Quick fix shipped (2026-05-04):** new `NetworkPathMonitor` (`ios/MajorTom/Core/Services/NetworkPathMonitor.swift`) wraps `NWPathMonitor` and exposes a `Reachability` enum (`tailscale | lan | cellular | offline`) inferred from interface types — Tailscale on iOS presents as a `NetworkExtension` (`.other` interface). `PairingView`'s 4-chip horizontal scroll is replaced by a single auto-recommended chip; `PairingViewModel.recommendedPreset` maps reachability → `ServerPreset` (Tailscale > LAN > Cloudflare tunnel; nil when offline). On view appear, an empty `serverAddress` is seeded with the recommendation; user-typed values are never overwritten by reachability flips. Tapping the chip applies the recommendation on demand and refetches `/auth/methods`.
 
-**Long-term winner:** mDNS/Bonjour discovery. Relay advertises `major-tom._http._tcp.local`, iOS uses `NWBrowser` to discover it on LAN; Tailscale fallback uses MagicDNS hostname (`seans-macbook-pro.tail-scale.ts.net`) so the URL is never a numeric IP. Set-and-forget — but bigger lift (relay-side advertise + iOS discovery flow + naming).
+**Note on the file path in the original spec:** the "ConnectionView.swift" reference was wrong — the actual multi-URL display lived in `Features/Pairing/Views/PairingView.swift` (the chip alongside the PIN keypad Sean called out). `ConnectionView.swift` is the post-pair Connect tab and only has a single text field; left untouched.
 
-**Files:**
-- `ios/MajorTom/Features/Connection/Views/ConnectionView.swift` — drop the multi-URL display, gate on NWPathMonitor
-- `ios/MajorTom/Core/Services/NetworkPathMonitor.swift` (likely new)
-- For mDNS path (if pursued): `relay/src/server.ts` (advertise via `dns-sd` or `bonjour-service` npm pkg) + `ios/MajorTom/Core/Services/RelayDiscovery.swift` (NWBrowser)
+**Long-term winner (still on the table):** mDNS/Bonjour discovery. Relay advertises `major-tom._http._tcp.local`, iOS uses `NWBrowser` to discover it on LAN; Tailscale fallback uses MagicDNS hostname (`seans-macbook-pro.tail-scale.ts.net`) so the URL is never a numeric IP. Set-and-forget — bigger lift, only worth it if/when we distribute.
 
-**Priority:** P2 — daily friction. Quick fix is the right move; mDNS only if we end up distributing.
+**Files (shipped):**
+- `ios/MajorTom/Core/Services/NetworkPathMonitor.swift` — new, wraps `NWPathMonitor`.
+- `ios/MajorTom/Features/Pairing/ViewModels/PairingViewModel.swift` — owns the monitor, exposes `recommendedPreset` + `useRecommended()` + `applyInitialRecommendationIfNeeded()`.
+- `ios/MajorTom/Features/Pairing/Views/PairingView.swift` — `ServerPreset.init?(reachability:)`, single `recommendationChip` replaces the 4-chip scroll.
+- `ios/MajorTom.xcodeproj/project.pbxproj` — file refs.
+
+**Future files (mDNS, if pursued):** `relay/src/server.ts` (advertise via `dns-sd` or `bonjour-service` npm pkg) + `ios/MajorTom/Core/Services/RelayDiscovery.swift` (NWBrowser).
+
+**Priority:** was P2. Quick fix done; mDNS deferred until distribution-time.
 
 ---
 

--- a/ios/MajorTom.xcodeproj/project.pbxproj
+++ b/ios/MajorTom.xcodeproj/project.pbxproj
@@ -54,6 +54,7 @@
 		38E33EB668F17E0408DEBF7C /* DelayCountdownView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 735C53A97B86E2331E03A4F0 /* DelayCountdownView.swift */; };
 		3C07EFEF4D80196CACF66B4F /* RelayService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EF58FBAC8341407F9E3E7A0 /* RelayService.swift */; };
 		9A1B2C3D4E5F60718293ABCD /* TabTitleStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A1B2C3D4E5F60718293BCDE /* TabTitleStore.swift */; };
+		BB21AA01CD8C672445BE8C70 /* NetworkPathMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB21AA00CD8C672445BE8C71 /* NetworkPathMonitor.swift */; };
 		3DC3F97C0E915D4328BA3D23 /* xterm-addon-fit.min.js in Resources */ = {isa = PBXBuildFile; fileRef = 70D288C1139CE55F81CA6B84 /* xterm-addon-fit.min.js */; };
 		3EBF323994DDFA263A66D119 /* FleetViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C243979CB87B28424C0EC73 /* FleetViewModel.swift */; };
 		3F2C8C3720ABDE4346DD4010 /* PhoneWatchConnectivityService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28F93EA76007AD19338D6B61 /* PhoneWatchConnectivityService.swift */; };
@@ -320,6 +321,7 @@
 		6ED47D05EBAEFF05755F1CF6 /* SessionListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionListViewModel.swift; sourceTree = "<group>"; };
 		6EF58FBAC8341407F9E3E7A0 /* RelayService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RelayService.swift; sourceTree = "<group>"; };
 		9A1B2C3D4E5F60718293BCDE /* TabTitleStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabTitleStore.swift; sourceTree = "<group>"; };
+		BB21AA00CD8C672445BE8C71 /* NetworkPathMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkPathMonitor.swift; sourceTree = "<group>"; };
 		70D288C1139CE55F81CA6B84 /* xterm-addon-fit.min.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = "xterm-addon-fit.min.js"; sourceTree = "<group>"; };
 		72D88CD4F990BB00B9695888 /* ActivitySelectionEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivitySelectionEngine.swift; sourceTree = "<group>"; };
 		735C53A97B86E2331E03A4F0 /* DelayCountdownView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DelayCountdownView.swift; sourceTree = "<group>"; };
@@ -859,6 +861,7 @@
 				72E9104D85D94935AD94E196 /* FeatureFlags.swift */,
 				7794C5813F5964F288D432AD /* HapticService.swift */,
 				A9BD8A95DFAD6160FF41E83F /* KeychainService.swift */,
+				BB21AA00CD8C672445BE8C71 /* NetworkPathMonitor.swift */,
 				1972DF8FED85D9290EA3F331 /* PerfHUDPreferences.swift */,
 				28F93EA76007AD19338D6B61 /* PhoneWatchConnectivityService.swift */,
 				6EF58FBAC8341407F9E3E7A0 /* RelayService.swift */,
@@ -1758,6 +1761,7 @@
 				35BC4313A2E9AFEBD7B113B0 /* PromptTemplate.swift in Sources */,
 				95294489029F6CCA66271C3B /* RateLimitSettingsView.swift in Sources */,
 				3C07EFEF4D80196CACF66B4F /* RelayService.swift in Sources */,
+				BB21AA01CD8C672445BE8C70 /* NetworkPathMonitor.swift in Sources */,
 				9A1B2C3D4E5F60718293ABCD /* TabTitleStore.swift in Sources */,
 				ECD4CC99C031E1B803D88C76 /* Session.swift in Sources */,
 				7800B5EFB116E5708F3A6300 /* SessionCostRankingView.swift in Sources */,

--- a/ios/MajorTom/Core/Services/NetworkPathMonitor.swift
+++ b/ios/MajorTom/Core/Services/NetworkPathMonitor.swift
@@ -1,0 +1,55 @@
+import Foundation
+import Network
+
+/// Observes the device's current network reachability so the pairing UI
+/// can recommend a single relay endpoint instead of asking the user to
+/// pick from a list of every possible URL.
+///
+/// QA-FIXES #21: prefer Tailscale (stable hostname, immune to LAN-IP
+/// drift) when an `.other`-typed interface is present (Tailscale on iOS
+/// is implemented as a `NetworkExtension` which presents that way).
+/// Otherwise fall back to LAN on wifi/wired, or the public Cloudflare
+/// tunnel when only cellular is available.
+@Observable
+@MainActor
+final class NetworkPathMonitor {
+    enum Reachability: String, Sendable {
+        case tailscale
+        case lan
+        case cellular
+        case offline
+    }
+
+    private(set) var reachability: Reachability = .offline
+
+    private let monitor = NWPathMonitor()
+    private let queue = DispatchQueue(label: "com.majortom.NetworkPathMonitor")
+
+    init() {
+        monitor.pathUpdateHandler = { [weak self] path in
+            let next = Self.classify(path: path)
+            Task { @MainActor [weak self] in
+                self?.reachability = next
+            }
+        }
+        monitor.start(queue: queue)
+    }
+
+    deinit {
+        monitor.cancel()
+    }
+
+    nonisolated private static func classify(path: NWPath) -> Reachability {
+        guard path.status == .satisfied else { return .offline }
+        if path.usesInterfaceType(.other) {
+            return .tailscale
+        }
+        if path.usesInterfaceType(.wifi) || path.usesInterfaceType(.wiredEthernet) {
+            return .lan
+        }
+        if path.usesInterfaceType(.cellular) {
+            return .cellular
+        }
+        return .offline
+    }
+}

--- a/ios/MajorTom/Features/Pairing/ViewModels/PairingViewModel.swift
+++ b/ios/MajorTom/Features/Pairing/ViewModels/PairingViewModel.swift
@@ -7,11 +7,13 @@ final class PairingViewModel {
     var serverAddress: String = ""
     var authMethods: AuthMethods?
     var isFetchingMethods = false
+    let network: NetworkPathMonitor
 
     private let auth: AuthService
 
-    init(auth: AuthService) {
+    init(auth: AuthService, network: NetworkPathMonitor? = nil) {
         self.auth = auth
+        self.network = network ?? NetworkPathMonitor()
         self.serverAddress = auth.serverURL
     }
 
@@ -37,6 +39,29 @@ final class PairingViewModel {
     var hasAnyAuthMethod: Bool {
         guard let methods = authMethods else { return true }
         return methods.pin || methods.google
+    }
+
+    /// Single preset matched to the phone's current reachability — `nil`
+    /// when offline or before the path monitor has fired its first update.
+    var recommendedPreset: ServerPreset? {
+        ServerPreset(reachability: network.reachability)
+    }
+
+    /// Apply the auto-picked URL and refetch auth methods.
+    func useRecommended() async {
+        guard let preset = recommendedPreset else { return }
+        serverAddress = preset.address
+        await fetchAuthMethods()
+    }
+
+    /// On first appear, if the user has no saved server URL, seed the field
+    /// with whatever the path monitor is currently recommending. Subsequent
+    /// reachability changes do NOT auto-overwrite — the user can tap the
+    /// recommendation chip to refresh on demand.
+    func applyInitialRecommendationIfNeeded() {
+        guard serverAddress.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
+        guard let preset = recommendedPreset else { return }
+        serverAddress = preset.address
     }
 
     /// Fetch auth methods from the relay to adapt the login UI.

--- a/ios/MajorTom/Features/Pairing/Views/PairingView.swift
+++ b/ios/MajorTom/Features/Pairing/Views/PairingView.swift
@@ -2,13 +2,12 @@ import SwiftUI
 
 // MARK: - Server Presets
 
-enum ServerPreset: String, CaseIterable, Identifiable {
+enum ServerPreset: String {
     case cloudflare = "majortom.seantokuzodevtunnel.space"
     case tailscale  = "100.69.151.117:9090"
     case lan        = "192.168.1.210:9090"
     case localhost   = "localhost:9090"
 
-    var id: String { rawValue }
     var address: String { rawValue }
 
     var label: String {

--- a/ios/MajorTom/Features/Pairing/Views/PairingView.swift
+++ b/ios/MajorTom/Features/Pairing/Views/PairingView.swift
@@ -19,6 +19,18 @@ enum ServerPreset: String, CaseIterable, Identifiable {
         case .localhost:   return "💻 Local"
         }
     }
+
+    /// Single preset for the device's current reachability. Tailscale
+    /// (or any VPN presenting as `.other`) wins over LAN; cellular-only
+    /// falls back to the public Cloudflare tunnel; offline returns nil.
+    init?(reachability: NetworkPathMonitor.Reachability) {
+        switch reachability {
+        case .tailscale: self = .tailscale
+        case .lan:       self = .lan
+        case .cellular:  self = .cloudflare
+        case .offline:   return nil
+        }
+    }
 }
 
 struct PairingView: View {
@@ -74,34 +86,12 @@ struct PairingView: View {
                         Task { await viewModel.fetchAuthMethods() }
                     }
 
-                // Preset server picker
-                ScrollView(.horizontal, showsIndicators: false) {
-                    HStack(spacing: MajorTomTheme.Spacing.sm) {
-                        ForEach(ServerPreset.allCases) { preset in
-                            Button {
-                                HapticService.impact(.light)
-                                viewModel.serverAddress = preset.address
-                                Task { await viewModel.fetchAuthMethods() }
-                            } label: {
-                                Text(preset.label)
-                                    .font(.system(.caption2, design: .monospaced))
-                                    .foregroundStyle(
-                                        viewModel.serverAddress == preset.address
-                                            ? MajorTomTheme.Colors.background
-                                            : MajorTomTheme.Colors.textSecondary
-                                    )
-                                    .padding(.horizontal, MajorTomTheme.Spacing.sm)
-                                    .padding(.vertical, 4)
-                                    .background(
-                                        viewModel.serverAddress == preset.address
-                                            ? MajorTomTheme.Colors.accent
-                                            : MajorTomTheme.Colors.surfaceElevated
-                                    )
-                                    .clipShape(Capsule())
-                            }
-                        }
-                    }
-                }
+                // QA-FIXES #21: auto-pick a single relay URL based on
+                // the phone's network state. Tailscale wins over LAN
+                // (stable hostname, immune to LAN-IP drift); cellular-
+                // only falls back to the public Cloudflare tunnel.
+                recommendationChip
+                    .frame(maxWidth: .infinity, alignment: .center)
             }
             .padding(.horizontal, MajorTomTheme.Spacing.xxl)
 
@@ -160,7 +150,46 @@ struct PairingView: View {
         .background(MajorTomTheme.Colors.background)
         .animation(.easeInOut(duration: 0.2), value: viewModel.authState)
         .task {
+            // Seed an empty server field with whatever the path monitor
+            // recommends, then fetch auth methods. The seeding is one-shot
+            // so reachability flips don't fight a user-typed override.
+            viewModel.applyInitialRecommendationIfNeeded()
             await viewModel.fetchAuthMethods()
+        }
+    }
+
+    @ViewBuilder
+    private var recommendationChip: some View {
+        if let preset = viewModel.recommendedPreset {
+            Button {
+                HapticService.impact(.light)
+                Task { await viewModel.useRecommended() }
+            } label: {
+                HStack(spacing: 4) {
+                    Text("Auto:")
+                        .font(.system(.caption2, design: .monospaced))
+                        .foregroundStyle(MajorTomTheme.Colors.textTertiary)
+                    Text(preset.label)
+                        .font(.system(.caption2, design: .monospaced))
+                        .foregroundStyle(
+                            viewModel.serverAddress == preset.address
+                                ? MajorTomTheme.Colors.background
+                                : MajorTomTheme.Colors.textSecondary
+                        )
+                }
+                .padding(.horizontal, MajorTomTheme.Spacing.sm)
+                .padding(.vertical, 4)
+                .background(
+                    viewModel.serverAddress == preset.address
+                        ? MajorTomTheme.Colors.accent
+                        : MajorTomTheme.Colors.surfaceElevated
+                )
+                .clipShape(Capsule())
+            }
+        } else {
+            Text("Offline — enter a relay URL above")
+                .font(.system(.caption2, design: .monospaced))
+                .foregroundStyle(MajorTomTheme.Colors.textTertiary)
         }
     }
 


### PR DESCRIPTION
## Summary
- **QA-FIXES #21** quick fix: replace the pairing screen's 4-URL chip scroll with a single auto-picked recommendation backed by `NWPathMonitor`.
- New `NetworkPathMonitor` service classifies reachability as `tailscale | lan | cellular | offline` from `NWPath` interface types — Tailscale on iOS presents as `NetworkExtension` (`.other`), so VPN-up wins over plain LAN.
- `PairingViewModel.recommendedPreset` maps reachability → `ServerPreset`; empty `serverAddress` is seeded once on first appear, user-typed overrides are never clobbered by later reachability flips. Tap the chip to refresh on demand.
- Spec said `Features/Connection/Views/ConnectionView.swift` but the actual multi-URL display lives in `Features/Pairing/Views/PairingView.swift` (the chip alongside the PIN keypad). Confirmed by Sean's QA note that "PIN" was on the same screen. `ConnectionView.swift` only has a single text field and is left untouched.
- Long-term mDNS/Bonjour path stays deferred (only worth it if/when we distribute).

## Test plan
- [x] `xcodebuild build` for iOS Simulator (`iPhone 17`, iOS 26.3) — green
- [ ] Device QA: open the pairing screen on the phone with Tailscale **on** → chip shows `Auto: 🔒 Tailscale`, server field defaults to that URL.
- [ ] Device QA: turn Tailscale **off** on the phone, kill+relaunch → chip shows `Auto: 📡 LAN`.
- [ ] Device QA: airplane mode → chip shows `Offline — enter a relay URL above`.
- [ ] Device QA: type a custom URL, then flip Tailscale on/off — typed value should NOT be overwritten.
- [ ] Device QA: pair successfully via PIN with Tailscale URL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
