### PR TITLE
QA-FIXES #17 + #19: TTL-aware cwd cascade + configurable defaultSpawnCwd

### DIFF
--- a/docs/QA-FIXES.md
+++ b/docs/QA-FIXES.md
@@ -488,47 +488,56 @@ Review: 3/3 specialists `ship`, 0 blocking, 0 advisory. CI green. Single-file ch
 
 ---
 
-### 19. Feature request — Ground Control: user-settable default cwd for fresh shells (device QA 2026-05-01)
+### 19. Feature request — Ground Control: user-settable default cwd for fresh shells (FIXED — PR pending, 2026-05-07)
 
 **Ask (Sean, 2026-05-01):** "we need to add a user-set default cwd option in Ground Control so if we distribute, users can set their favorite pwd to start in"
 
 **Context:** today, the cwd a fresh terminal tab spawns into is determined by `pty-adapter.ts` `resolveSpawnCwd` → falls back to `this.cwd` (relay process cwd) when no per-tab override exists. For Sean today that's `~/Documents/code/dev` (apparently — needs verification). For a user who installs Major Tom + Ground Control on a fresh machine, the relay cwd would be wherever Ground Control launched it from — probably random.
 
-**Fix direction:**
-- Add a "Default working directory" field to Ground Control's relay config UI.
-- Persist into the relay's startup config (env var or config.json).
-- `pty-adapter.ts` reads this as the bottom-of-the-cascade fallback in `resolveSpawnCwd`.
+**Fix shipped (B′ approach — folded with #17):**
+- New `relay/src/config/relay-config.ts` — `RelayConfigStore` over `~/.major-tom/relay-config.json`, `defaultSpawnCwd?: string`.
+- New REST endpoint `GET/PATCH /api/relay-config` (auth required) for read/write.
+- `resolveDefaultSpawnCwd` cascade: `MAJORTOM_DEFAULT_CWD` env → persisted file → `$HOME/Documents/code/dev` if it exists → `$HOME`. Drops the prior incidental `process.cwd()` fallback.
+- `PtyAdapter.cwd` accepts a getter so PATCH writes flow into the very next spawn (no relay restart).
+- iOS Settings → Developer → "Default Working Directory" surfaces the value; Ground Control will surface the same field later.
 
-**Priority:** P3 — relevant for distribution, not for current dev usage. Track in Ground Control roadmap.
+**Files (shipped):**
+- `relay/src/config/relay-config.ts` — store + resolver.
+- `relay/src/routes/relay-config.ts` — REST.
+- `relay/src/adapters/pty-adapter.ts` — `cwd` getter form.
+- `relay/src/app.ts` — wires store + getter.
+- `ios/MajorTom/Core/Services/RelayService.swift` — `fetchRelayConfig` / `updateRelayConfig`.
+- `ios/MajorTom/Features/Settings/Views/DefaultWorkingDirView.swift` — editor.
+- `ios/MajorTom/Features/Settings/Views/SettingsView.swift` — Developer row.
+- `ios/MajorTom.xcodeproj/project.pbxproj` — file refs.
 
-**Files (estimated):**
-- `ground-control/` — config UI surface
-- `relay/src/server.ts` — accept new env / config var
-- `relay/src/adapters/pty-adapter.ts` — `this.cwd` honors the configured default
+**Priority:** was P3. Closed alongside #17 since the same plumbing serves both.
 
 ---
 
-### 17. PTY cwd persistence misses plain-shell `cd` updates (device QA 2026-05-01)
+### 17. PTY cwd persistence misses plain-shell `cd` updates (FIXED — PR pending, 2026-05-07)
 
 **Symptom (Wave D #12 device QA, 2026-05-01):** Sean had a tab with cwd=`/Users/seansimpson/Documents/code/dev/FAKE_DIR/FAKE_SUB_DIR` (cd'd to in a plain shell, never ran claude there). Relay restarted. On reconnect/respawn, iOS landed on a DIFFERENT tab (`tab-272fa801`, auto-named "H4LA") whose persisted `workingDir` was an old `_old_projects/H4LA` path captured weeks ago. New PTY correctly spawned at the persisted dir — but from the user's POV, they were "kicked out" to a stale, unrelated directory.
 
 **Root cause:** `relay/src/tabs/tab-registry.ts` `registerSessionStart` is the ONLY producer of `workingDir`. Plain-shell `cd` events never update the persisted record. Combined with persisted tabs surviving across many sessions, this means the cwd a user sees on reconnect is the cwd at the time of the LAST `claude` SessionStart in that tab — possibly weeks ago, possibly in an unrelated dir.
 
-**Spec:** the original QA-FIXES #12 fix correctly preserves cwd across relay restart for tabs with claude sessions. This is a separate gap — cwd should track the live shell, not just SessionStart payloads.
+**Fix shipped (approach B′ — TTL gate + configurable default, both sides of the cascade in one PR):**
+1. `TabRegistry` now stamps `workingDirUpdatedAt` (ISO timestamp) on every SessionStart that carries a cwd. New `getFreshWorkingDir(tabId, ttlMs)` helper returns the path only when its stamp is within the window. Persisted file format gains an optional `workingDirUpdatedAt`; legacy records load with it `undefined` and are treated as stale (no migration needed).
+2. `shell.ts` calls `tabRegistry.getFreshWorkingDir(tabId, 12h)` instead of reading `workingDir` directly. Stale / never-stamped values fall through.
+3. `PtyAdapter.resolveSpawnCwd` falls back to `defaultSpawnCwd` (resolved through the new config cascade in #19). The prior incidental `process.cwd()` fallback is gone.
 
-**Fix directions (pick one):**
-- **A.** Add a heartbeat from PTY → registry that calls `registerCwdUpdate(tabId, cwd)`. Could read from `/proc/PID/cwd` (not available on macOS) OR run a background `pwd` periodically (intrusive). OR have iOS observe shell prompts and POST cwd updates (invasive client coupling).
-- **B.** Use OSC 7 (`\x1b]7;file://host/path\x07`) — many shells emit this on `cd` and PROMPT_COMMAND can be configured to. Relay's PTY adapter could parse OSC 7 from the output stream and update registry without touching shell config. iTerm2 / VSCode terminal use this. Cleanest.
-- **C.** Skip the fix and add a UI affordance: inspector showing "this tab's cwd is X (last set at TIME)" so the user can sanity-check before reconnecting.
+**TTL = 12h.** Long enough to cover a workday's worth of activity in a tab; short enough that a weeks-old SessionStart cannot resurface and pin the spawn to a stale dir. Easy to tune later if reality says otherwise.
 
-**Priority:** P2 — preserves the canonical fix; surfaces a UX foot-gun. Fix only if it bites someone again.
+**Why not pure OSC 7:** OSC 7 was the original cleanest-fix recommendation but it does NOT close #19 (distribution users still need a configurable default), and the H4LA reproducer is solved by either approach. The combined B′ approach is one PR for two issues with no shell-config glue.
 
-**Related:** also a candidate for cleanup — old persisted tab files (`tab-443f5546.json`, `tab-cc323c29.json`) accumulate forever. Worth a TTL or "remove if not seen in 30d" sweep.
+**Files (shipped):**
+- `relay/src/tabs/tab-registry.ts` — `workingDirUpdatedAt`, `DEFAULT_WORKING_DIR_TTL_MS`, `getFreshWorkingDir`.
+- `relay/src/tabs/tab-registry-persistence.ts` — schema field + back-compat.
+- `relay/src/adapters/pty-adapter.ts` — `cwd` accepts a getter; cascade rewrite.
+- `relay/src/routes/shell.ts` — wires the freshness helper.
+- See #19 for the config-side files.
 
-**Files:**
-- `relay/src/adapters/pty-adapter.ts` — OSC 7 parse hook in `onData` if going with B
-- `relay/src/tabs/tab-registry.ts` — `registerCwdUpdate` method + persistence
-- `relay/src/tabs/tab-persistence.ts` — TTL cleanup for stale tabs (separate fix)
+**Open follow-up (worth its own ticket):** `tab-*.json` files accumulate forever in `~/.major-tom/tabs/`. A boot-time sweep (drop entries not seen in 30 days) is independent of this fix and can be filed once the broader QA queue clears.
 
 ---
 

--- a/ios/MajorTom.xcodeproj/project.pbxproj
+++ b/ios/MajorTom.xcodeproj/project.pbxproj
@@ -118,6 +118,7 @@
 		93364D032EFFBC61FEAFD519 /* SessionCountWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1CCA0A46BE9EDE79DF3CB8F /* SessionCountWidget.swift */; };
 		93EFF11D75E2B7730AA50D4E /* ActivityStation.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1C51280EF867529A6909DDD /* ActivityStation.swift */; };
 		95294489029F6CCA66271C3B /* RateLimitSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D06F8E498C8D1F63A30D6A5F /* RateLimitSettingsView.swift */; };
+		662C3BE3B2B3A7F8C42FC4AD /* DefaultWorkingDirView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6809542F2D405907D24C90EB /* DefaultWorkingDirView.swift */; };
 		961131A6B840819BB8224A5A /* WorkspaceTreeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7C81160C4EC85E9F1578864 /* WorkspaceTreeView.swift */; };
 		9643125507370C9DB009F0FF /* GitDiffView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF7AD5FC894586150B89BEAD /* GitDiffView.swift */; };
 		97FD06A7190429C1A1F445B1 /* MajorTomDynamicIsland.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11221A86D528743D2A8857BE /* MajorTomDynamicIsland.swift */; };
@@ -398,6 +399,7 @@
 		CEE5C5DC2463A313FEDD6406 /* TerminalTabBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalTabBar.swift; sourceTree = "<group>"; };
 		CF16084D9274212487A6B7CC /* TokenBreakdownView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenBreakdownView.swift; sourceTree = "<group>"; };
 		D06F8E498C8D1F63A30D6A5F /* RateLimitSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RateLimitSettingsView.swift; sourceTree = "<group>"; };
+		6809542F2D405907D24C90EB /* DefaultWorkingDirView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultWorkingDirView.swift; sourceTree = "<group>"; };
 		D136B4051E73808BE748883D /* MajorTomWidgets.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = MajorTomWidgets.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		D23AB94034A1FEDA8FDC0C0A /* FleetModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FleetModels.swift; sourceTree = "<group>"; };
 		D4E5F6071829A1B2C3A4B5C6 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -1362,6 +1364,7 @@
 			isa = PBXGroup;
 			children = (
 				177E95044756377A532D2A5F /* AuditLogView.swift */,
+				6809542F2D405907D24C90EB /* DefaultWorkingDirView.swift */,
 				5B2D2956D7BBBE520D548CED /* DeviceManagementView.swift */,
 				6C4FC6C7F8AA0ACAD27D5D54 /* DirectoryPermissionsView.swift */,
 				D06F8E498C8D1F63A30D6A5F /* RateLimitSettingsView.swift */,
@@ -1760,6 +1763,7 @@
 				241AFDC78C513CD9E223E14B /* PromptHistoryViewModel.swift in Sources */,
 				35BC4313A2E9AFEBD7B113B0 /* PromptTemplate.swift in Sources */,
 				95294489029F6CCA66271C3B /* RateLimitSettingsView.swift in Sources */,
+				662C3BE3B2B3A7F8C42FC4AD /* DefaultWorkingDirView.swift in Sources */,
 				3C07EFEF4D80196CACF66B4F /* RelayService.swift in Sources */,
 				BB21AA01CD8C672445BE8C70 /* NetworkPathMonitor.swift in Sources */,
 				9A1B2C3D4E5F60718293ABCD /* TabTitleStore.swift in Sources */,

--- a/ios/MajorTom/Core/Services/RelayService.swift
+++ b/ios/MajorTom/Core/Services/RelayService.swift
@@ -220,6 +220,115 @@ final class RelayService {
         }
     }
 
+    // MARK: - Relay Config (`/api/relay-config`)
+
+    /// Mirrors `relay/src/config/relay-config.ts::RelayConfig`. Add new
+    /// fields here and on the relay side together; older relays without
+    /// the field will simply omit it on GET.
+    struct RelayConfigData: Codable, Equatable {
+        var defaultSpawnCwd: String?
+    }
+
+    enum RelayConfigError: LocalizedError {
+        case notAuthenticated
+        case invalidServerURL
+        case http(status: Int, message: String?)
+        case transport(Error)
+
+        var errorDescription: String? {
+            switch self {
+            case .notAuthenticated:
+                return "Not paired with a relay yet."
+            case .invalidServerURL:
+                return "Invalid relay server URL."
+            case .http(let status, let message):
+                if let message, !message.isEmpty {
+                    return message
+                }
+                return "Relay returned HTTP \(status)."
+            case .transport(let err):
+                return err.localizedDescription
+            }
+        }
+    }
+
+    /// Fetch the relay-side config (currently `defaultSpawnCwd`). Returns
+    /// an empty struct when the relay has nothing persisted.
+    func fetchRelayConfig() async throws -> RelayConfigData {
+        let request = try makeRelayConfigRequest(method: "GET", body: nil)
+        do {
+            let (data, response) = try await URLSession.shared.data(for: request)
+            guard let http = response as? HTTPURLResponse else {
+                throw RelayConfigError.http(status: -1, message: nil)
+            }
+            if http.statusCode == 200 {
+                return (try? JSONDecoder().decode(RelayConfigData.self, from: data))
+                    ?? RelayConfigData(defaultSpawnCwd: nil)
+            }
+            throw RelayConfigError.http(
+                status: http.statusCode,
+                message: errorMessage(from: data),
+            )
+        } catch let err as RelayConfigError {
+            throw err
+        } catch {
+            throw RelayConfigError.transport(error)
+        }
+    }
+
+    /// PATCH the relay-side config. Pass `nil` to clear `defaultSpawnCwd`.
+    /// Server validates the path is a real directory; bad values return
+    /// HTTP 400 with a human-readable message.
+    func updateRelayConfig(defaultSpawnCwd: String?) async throws -> RelayConfigData {
+        let payload: [String: Any?] = ["defaultSpawnCwd": defaultSpawnCwd]
+        let body = try JSONSerialization.data(withJSONObject: payload, options: [.fragmentsAllowed])
+        var request = try makeRelayConfigRequest(method: "PATCH", body: body)
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        do {
+            let (data, response) = try await URLSession.shared.data(for: request)
+            guard let http = response as? HTTPURLResponse else {
+                throw RelayConfigError.http(status: -1, message: nil)
+            }
+            if http.statusCode == 200 {
+                return (try? JSONDecoder().decode(RelayConfigData.self, from: data))
+                    ?? RelayConfigData(defaultSpawnCwd: defaultSpawnCwd)
+            }
+            throw RelayConfigError.http(
+                status: http.statusCode,
+                message: errorMessage(from: data),
+            )
+        } catch let err as RelayConfigError {
+            throw err
+        } catch {
+            throw RelayConfigError.transport(error)
+        }
+    }
+
+    private func makeRelayConfigRequest(method: String, body: Data?) throws -> URLRequest {
+        guard let auth = authService else { throw RelayConfigError.notAuthenticated }
+        let baseURL = AuthService.normalizeBaseURL(auth.serverURL)
+        guard let url = URL(string: "\(baseURL)/api/relay-config") else {
+            throw RelayConfigError.invalidServerURL
+        }
+        var request = URLRequest(url: url)
+        request.httpMethod = method
+        request.httpBody = body
+        if let cookie = auth.sessionCookie {
+            request.setValue("mt-session=\(cookie)", forHTTPHeaderField: "Cookie")
+        } else {
+            throw RelayConfigError.notAuthenticated
+        }
+        return request
+    }
+
+    private func errorMessage(from data: Data) -> String? {
+        guard
+            let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+            let msg = obj["error"] as? String
+        else { return nil }
+        return msg
+    }
+
     // MARK: - Session
 
     func startSession(adapter: AdapterType = .cli, workingDir: String? = nil) async throws {

--- a/ios/MajorTom/Features/Settings/Views/DefaultWorkingDirView.swift
+++ b/ios/MajorTom/Features/Settings/Views/DefaultWorkingDirView.swift
@@ -1,0 +1,184 @@
+import SwiftUI
+
+/// Edits the relay-side `defaultSpawnCwd` setting via `/api/relay-config`.
+/// New PTY tabs spawn into this directory when the tab has no fresh
+/// per-tab `workingDir`. QA-FIXES #17 + #19.
+struct DefaultWorkingDirView: View {
+    private let relay: RelayService
+
+    @State private var draft: String = ""
+    @State private var serverValue: String? = nil
+    @State private var isLoading = false
+    @State private var isSaving = false
+    @State private var loadError: String?
+    @State private var saveError: String?
+    @State private var saveConfirmation: String?
+
+    init(relay: RelayService) {
+        self.relay = relay
+    }
+
+    var body: some View {
+        List {
+            currentValueSection
+            editSection
+        }
+        .scrollContentBackground(.hidden)
+        .background(MajorTomTheme.Colors.background)
+        .navigationTitle("Default Directory")
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItem(placement: .topBarTrailing) {
+                Button {
+                    Task { await refresh() }
+                } label: {
+                    Image(systemName: "arrow.clockwise")
+                }
+                .disabled(isLoading || isSaving)
+            }
+        }
+        .task { await refresh() }
+    }
+
+    private var currentValueSection: some View {
+        Section {
+            HStack {
+                Label("Current", systemImage: "folder")
+                Spacer()
+                if isLoading {
+                    ProgressView().tint(MajorTomTheme.Colors.accent)
+                } else {
+                    Text(displayCurrent)
+                        .font(MajorTomTheme.Typography.codeFontSmall)
+                        .foregroundStyle(MajorTomTheme.Colors.textSecondary)
+                        .lineLimit(2)
+                        .truncationMode(.middle)
+                }
+            }
+            .listRowBackground(MajorTomTheme.Colors.surface)
+
+            if let loadError {
+                Text(loadError)
+                    .font(.footnote)
+                    .foregroundStyle(MajorTomTheme.Colors.deny)
+                    .listRowBackground(MajorTomTheme.Colors.surface)
+            }
+        } header: {
+            Text("Configured")
+        } footer: {
+            Text("New terminal tabs spawn here when there is no recently-used directory for the tab. Leave empty to fall back to the relay default ($HOME/Documents/code/dev if it exists, otherwise $HOME).")
+        }
+    }
+
+    private var editSection: some View {
+        Section {
+            TextField(
+                "/Users/you/Documents/code/dev",
+                text: $draft,
+                axis: .vertical,
+            )
+            .font(MajorTomTheme.Typography.codeFont)
+            .textInputAutocapitalization(.never)
+            .autocorrectionDisabled(true)
+            .listRowBackground(MajorTomTheme.Colors.surface)
+
+            HStack {
+                Button {
+                    Task { await save() }
+                } label: {
+                    if isSaving {
+                        ProgressView().tint(MajorTomTheme.Colors.accent)
+                    } else {
+                        Text("Save")
+                    }
+                }
+                .disabled(isSaving || draft == (serverValue ?? ""))
+
+                Spacer()
+
+                Button(role: .destructive) {
+                    Task { await clear() }
+                } label: {
+                    Text("Clear")
+                }
+                .disabled(isSaving || (serverValue ?? "").isEmpty)
+            }
+            .listRowBackground(MajorTomTheme.Colors.surface)
+
+            if let saveError {
+                Text(saveError)
+                    .font(.footnote)
+                    .foregroundStyle(MajorTomTheme.Colors.deny)
+                    .listRowBackground(MajorTomTheme.Colors.surface)
+            }
+            if let saveConfirmation {
+                Text(saveConfirmation)
+                    .font(.footnote)
+                    .foregroundStyle(MajorTomTheme.Colors.allow)
+                    .listRowBackground(MajorTomTheme.Colors.surface)
+            }
+        } header: {
+            Text("Edit")
+        } footer: {
+            Text("The relay validates that the path exists and is a directory. The next new tab picks up the change — existing tabs keep their current cwd.")
+        }
+    }
+
+    private var displayCurrent: String {
+        guard let v = serverValue, !v.isEmpty else {
+            return "Not set"
+        }
+        return v
+    }
+
+    private func refresh() async {
+        isLoading = true
+        loadError = nil
+        defer { isLoading = false }
+        do {
+            let data = try await relay.fetchRelayConfig()
+            let value = data.defaultSpawnCwd ?? ""
+            serverValue = data.defaultSpawnCwd
+            draft = value
+            saveError = nil
+            saveConfirmation = nil
+        } catch {
+            loadError = (error as? LocalizedError)?.errorDescription ?? error.localizedDescription
+        }
+    }
+
+    private func save() async {
+        let trimmed = draft.trimmingCharacters(in: .whitespacesAndNewlines)
+        let next = trimmed.isEmpty ? nil : trimmed
+        await applyUpdate(next)
+    }
+
+    private func clear() async {
+        await applyUpdate(nil)
+    }
+
+    private func applyUpdate(_ value: String?) async {
+        isSaving = true
+        saveError = nil
+        saveConfirmation = nil
+        defer { isSaving = false }
+        do {
+            let data = try await relay.updateRelayConfig(defaultSpawnCwd: value)
+            serverValue = data.defaultSpawnCwd
+            draft = data.defaultSpawnCwd ?? ""
+            saveConfirmation = value == nil
+                ? "Cleared. New tabs will use the relay default."
+                : "Saved. New tabs will spawn here."
+            HapticService.selection()
+        } catch {
+            saveError = (error as? LocalizedError)?.errorDescription ?? error.localizedDescription
+            HapticService.impact(.medium)
+        }
+    }
+}
+
+#Preview {
+    NavigationStack {
+        DefaultWorkingDirView(relay: RelayService())
+    }
+}

--- a/ios/MajorTom/Features/Settings/Views/SettingsView.swift
+++ b/ios/MajorTom/Features/Settings/Views/SettingsView.swift
@@ -243,6 +243,13 @@ struct SettingsView: View {
 
     private var developerSection: some View {
         Section {
+            NavigationLink {
+                DefaultWorkingDirView(relay: relay)
+            } label: {
+                Label("Default Working Directory", systemImage: "folder.badge.gearshape")
+            }
+            .listRowBackground(MajorTomTheme.Colors.surface)
+
             Toggle(isOn: $showsPerfHUD) {
                 Label("SpriteKit Stats", systemImage: "speedometer")
             }
@@ -253,7 +260,7 @@ struct SettingsView: View {
         } header: {
             Text("Developer")
         } footer: {
-            Text("Overlays SpriteKit FPS + node/draw/quad counts on the Office scene. Use during Instruments profiling — see docs/PERF-BASELINE.md. (Not the iOS Metal Performance HUD — that lives in iOS Settings → Developer and can't be toggled from an app.)")
+            Text("Default Working Directory sets where new terminal tabs spawn when the tab has no recently-used directory. SpriteKit Stats overlays FPS + draw counts on the Office scene during Instruments profiling — see docs/PERF-BASELINE.md.")
         }
     }
 

--- a/relay/src/adapters/__tests__/pty-adapter.test.ts
+++ b/relay/src/adapters/__tests__/pty-adapter.test.ts
@@ -623,6 +623,59 @@ describe('PtyAdapter cwd override (QA-FIXES #12)', () => {
     }
   });
 
+  it('resolves the default lazily when cwd is a getter (hot-reloads config changes)', () => {
+    // QA-FIXES #19 — defaultSpawnCwd is wired through a getter so a config
+    // change picked up by the relay between spawns flows through without
+    // a restart. A fixed string would silently snapshot the old value.
+    let active = '/first';
+    const cwds: string[] = [];
+    const fakePty = {
+      pid: 1, cols: 80, rows: 24,
+      onData() {}, onExit() {}, kill: vi.fn(), resize: vi.fn(), write: vi.fn(),
+    };
+    const a = new PtyAdapter({
+      cwd: () => active,
+      env: { SHELL: '/bin/bash' },
+      spawn: ((_file: string, _args: string[], opts: { cwd: string }) => {
+        cwds.push(opts.cwd);
+        return fakePty;
+      }) as never,
+    });
+    try {
+      a.attach('tab-1', makeClient(), ATTACH_DEFAULTS);
+      active = '/second';
+      a.attach('tab-2', makeClient(), ATTACH_DEFAULTS);
+      expect(cwds).toEqual(['/first', '/second']);
+    } finally {
+      a.dispose();
+    }
+  });
+
+  it('falls back to $HOME when the cwd getter returns an empty string', () => {
+    // Defensive: a misconfigured config file could yield "". node-pty
+    // rejects empty cwd, so re-resolve to $HOME instead of letting that
+    // propagate.
+    let capturedCwd: string | undefined;
+    const fakePty = {
+      pid: 1, cols: 80, rows: 24,
+      onData() {}, onExit() {}, kill: vi.fn(), resize: vi.fn(), write: vi.fn(),
+    };
+    const a = new PtyAdapter({
+      cwd: () => '',
+      env: { SHELL: '/bin/bash', HOME: '/home/fallback' },
+      spawn: ((_file: string, _args: string[], opts: { cwd: string }) => {
+        capturedCwd = opts.cwd;
+        return fakePty;
+      }) as never,
+    });
+    try {
+      a.attach('tab-1', makeClient(), ATTACH_DEFAULTS);
+      expect(capturedCwd).toBe('/home/fallback');
+    } finally {
+      a.dispose();
+    }
+  });
+
   it('uses the adapter default when no cwd override is supplied', () => {
     let capturedCwd: string | undefined;
     const fakePty = {

--- a/relay/src/adapters/pty-adapter.ts
+++ b/relay/src/adapters/pty-adapter.ts
@@ -75,7 +75,14 @@ export interface PtyAdapterOptions {
   graceMs?: number;
   bufferBytes?: number;
   inputMaxBytes?: number;
-  cwd?: string;
+  /**
+   * Default cwd used when no per-attach override is supplied OR when the
+   * override directory is missing / not a directory. Accepts either a fixed
+   * path or a getter — the getter form lets the relay hot-reload the
+   * configured `defaultSpawnCwd` between PTY spawns without restarting
+   * (QA-FIXES #19). When omitted, falls back to `$HOME`.
+   */
+  cwd?: string | (() => string);
   /** Override for `process.env`. Defaults to `process.env`. */
   env?: Record<string, string | undefined>;
   /** Explicit shell path. Defaults to `env.SHELL || '/bin/bash'`. */
@@ -151,7 +158,8 @@ export class PtyAdapter {
   private readonly graceMs: number;
   private readonly bufferBytes: number;
   private readonly inputMaxBytes: number;
-  private readonly cwd: string;
+  /** Fallback cwd resolver — called once per spawn so config changes are live. */
+  private readonly resolveDefaultCwd: () => string;
   private readonly env: Record<string, string | undefined>;
   private readonly shell: string;
   private readonly shellArgs: string[];
@@ -163,7 +171,21 @@ export class PtyAdapter {
     this.bufferBytes = opts.bufferBytes ?? DEFAULT_BUFFER_BYTES;
     this.inputMaxBytes = opts.inputMaxBytes ?? DEFAULT_INPUT_MAX_BYTES;
     this.env = opts.env ?? process.env;
-    this.cwd = opts.cwd ?? this.env['HOME'] ?? homedir();
+    const homeFallback = (): string => this.env['HOME'] ?? homedir();
+    if (typeof opts.cwd === 'function') {
+      const getter = opts.cwd;
+      // Wrap so an empty / blank getter return still falls back to $HOME
+      // rather than spawning into "" (node-pty would reject that).
+      this.resolveDefaultCwd = (): string => {
+        const v = getter();
+        return v && v.length > 0 ? v : homeFallback();
+      };
+    } else if (typeof opts.cwd === 'string' && opts.cwd.length > 0) {
+      const fixed = opts.cwd;
+      this.resolveDefaultCwd = (): string => fixed;
+    } else {
+      this.resolveDefaultCwd = homeFallback;
+    }
     this.shell = opts.shell ?? this.env['SHELL'] ?? '/bin/bash';
     this.shellArgs = opts.shellArgs ?? ['-l'];
     this.spawnFn = opts.spawn ?? pty.spawn;
@@ -464,20 +486,21 @@ export class PtyAdapter {
   }
 
   private resolveSpawnCwd(tabId: string, override: string | undefined): string {
-    if (!override) return this.cwd;
+    const fallback = this.resolveDefaultCwd();
+    if (!override) return fallback;
     try {
       if (statSync(override).isDirectory()) return override;
       logger.warn(
-        { tabId, override, fallback: this.cwd },
+        { tabId, override, fallback },
         'Tab cwd override exists but is not a directory — falling back',
       );
     } catch (err) {
       logger.warn(
-        { err, tabId, override, fallback: this.cwd },
+        { err, tabId, override, fallback },
         'Tab cwd override unreadable — falling back to default',
       );
     }
-    return this.cwd;
+    return fallback;
   }
 
   private evict(tabId: string): void {

--- a/relay/src/app.ts
+++ b/relay/src/app.ts
@@ -23,6 +23,11 @@ import { createWsRoute } from './routes/ws.js';
 import { createShellRoute, clearUserIdForTab, getUserIdForTab } from './routes/shell.js';
 import { createApiApprovalsRoutes } from './routes/api-approvals.js';
 import { createPreferencesRoutes } from './routes/preferences.js';
+import { createRelayConfigRoutes } from './routes/relay-config.js';
+import {
+  RelayConfigStore,
+  resolveDefaultSpawnCwd,
+} from './config/relay-config.js';
 import { PtyAdapter } from './adapters/pty-adapter.js';
 
 // Phase 13 Wave 2 — shell-side approval routing
@@ -110,6 +115,14 @@ export async function buildApp(config: AppConfig) {
   // tab↔session mapping that backs the iOS Office metaphor.
   const tabRegistryPersistence = new TabRegistryPersistence();
   const tabRegistry = new TabRegistry(tabRegistryPersistence);
+
+  // Relay-side runtime config (`~/.major-tom/relay-config.json`). Holds
+  // `defaultSpawnCwd` today; future fields layer on without schema
+  // changes. Loaded once at boot; PATCH writes via /api/relay-config
+  // mutate both disk and the in-memory cache so the next PTY spawn picks
+  // up the new value without a restart (QA-FIXES #19).
+  const relayConfigStore = new RelayConfigStore();
+  await relayConfigStore.load();
 
   // Multi-user services — only created when multi-user mode is enabled
   const userRegistry = config.multiUserEnabled ? new UserRegistry() : undefined;
@@ -354,7 +367,13 @@ export async function buildApp(config: AppConfig) {
     graceMs: parseNonNegativeInt(process.env['MAJOR_TOM_PTY_GRACE_MS']),
     bufferBytes: parseNonNegativeInt(process.env['MAJOR_TOM_PTY_BUFFER_BYTES']),
     inputMaxBytes: parseNonNegativeInt(process.env['MAJOR_TOM_PTY_INPUT_MAX']),
-    cwd: config.claudeWorkDir,
+    // QA-FIXES #17 / #19 — resolve the default spawn cwd lazily so
+    // `MAJORTOM_DEFAULT_CWD` env changes (rare) and PATCH /api/relay-config
+    // updates (common via iOS Settings) flow into the next PTY spawn
+    // without requiring a relay restart. The `claudeWorkDir` from server.ts
+    // continues to drive the SDK path; PTY now decouples to the resolver
+    // cascade (env → relay-config.json → ~/Documents/code/dev → ~).
+    cwd: () => resolveDefaultSpawnCwd(relayConfigStore),
     // Tab-Keyed Offices — PTY grace-expire / natural exit is when the
     // tab is truly gone. Clear the shell.ts userId map, drop the
     // TabRegistry entry, and broadcast tab.closed so the iOS Office
@@ -409,6 +428,9 @@ export async function buildApp(config: AppConfig) {
     userRegistry,
     multiUserEnabled: config.multiUserEnabled,
   }));
+
+  // Relay-side runtime config (defaultSpawnCwd today; auth required).
+  await app.register(createRelayConfigRoutes({ configStore: relayConfigStore }));
 
   // Shell WebSocket — registered after `createPreferencesRoutes` so its
   // path doesn't collide with any earlier catch-all. PtyAdapter was

--- a/relay/src/config/__tests__/relay-config.test.ts
+++ b/relay/src/config/__tests__/relay-config.test.ts
@@ -132,6 +132,42 @@ describe('RelayConfigStore', () => {
       const loaded = await fresh.load();
       expect(loaded.defaultSpawnCwd).toBeUndefined();
     });
+
+    it('throws RelayConfigError(kind=io) and rolls back the cache when writeFile fails', async () => {
+      // Path inside a file (not a directory) — `mkdir` succeeds because
+      // `recursive: true` is a no-op when the path exists, but writing a
+      // file at `<existing-file>/relay-config.json` rejects with ENOTDIR.
+      // This forces the IO failure branch.
+      const filePath = join(baseDir, 'sentinel.txt');
+      await writeFile(filePath, 'hi', 'utf-8');
+      const blockedPath = join(filePath, 'relay-config.json');
+      const store = new RelayConfigStore(blockedPath);
+      // Seed memory with a known prior value via a separate, working store.
+      store['cached'] = { defaultSpawnCwd: '/old' };
+
+      await expect(
+        store.save({ defaultSpawnCwd: baseDir }),
+      ).rejects.toMatchObject({
+        name: 'RelayConfigError',
+        kind: 'io',
+      });
+      // Cache must NOT have advanced — otherwise PATCH would silently
+      // claim the value persisted while disk has the old one.
+      expect(store.get().defaultSpawnCwd).toBe('/old');
+    });
+
+    it('rejects validation errors with kind=validation', async () => {
+      const store = new RelayConfigStore(configFile);
+      try {
+        await store.save({ defaultSpawnCwd: '' });
+        expect.unreachable('should have thrown');
+      } catch (err) {
+        expect(err).toMatchObject({
+          name: 'RelayConfigError',
+          kind: 'validation',
+        });
+      }
+    });
   });
 });
 

--- a/relay/src/config/__tests__/relay-config.test.ts
+++ b/relay/src/config/__tests__/relay-config.test.ts
@@ -1,0 +1,209 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mkdtemp, mkdir, rm, readFile, writeFile } from 'node:fs/promises';
+import { tmpdir, homedir } from 'node:os';
+import { join } from 'node:path';
+
+import {
+  RelayConfigStore,
+  RelayConfigError,
+  resolveDefaultSpawnCwd,
+} from '../relay-config.js';
+
+describe('RelayConfigStore', () => {
+  let baseDir: string;
+  let configFile: string;
+
+  beforeEach(async () => {
+    baseDir = await mkdtemp(join(tmpdir(), 'relay-config-'));
+    configFile = join(baseDir, 'relay-config.json');
+  });
+
+  afterEach(async () => {
+    await rm(baseDir, { recursive: true, force: true });
+  });
+
+  describe('load', () => {
+    it('returns empty config when file is missing (fresh install)', async () => {
+      const store = new RelayConfigStore(configFile);
+      const cfg = await store.load();
+      expect(cfg).toEqual({});
+    });
+
+    it('reads a valid config from disk', async () => {
+      await writeFile(
+        configFile,
+        JSON.stringify({ defaultSpawnCwd: '/some/path' }),
+        'utf-8',
+      );
+      const store = new RelayConfigStore(configFile);
+      const cfg = await store.load();
+      expect(cfg.defaultSpawnCwd).toBe('/some/path');
+    });
+
+    it('treats invalid JSON as empty', async () => {
+      await writeFile(configFile, 'not json', 'utf-8');
+      const store = new RelayConfigStore(configFile);
+      const cfg = await store.load();
+      expect(cfg).toEqual({});
+    });
+
+    it('treats invalid schema as empty', async () => {
+      await writeFile(
+        configFile,
+        JSON.stringify({ defaultSpawnCwd: 12345 }),
+        'utf-8',
+      );
+      const store = new RelayConfigStore(configFile);
+      const cfg = await store.load();
+      expect(cfg).toEqual({});
+    });
+
+    it('accepts a config with no defaultSpawnCwd field set', async () => {
+      await writeFile(configFile, JSON.stringify({}), 'utf-8');
+      const store = new RelayConfigStore(configFile);
+      const cfg = await store.load();
+      expect(cfg).toEqual({});
+    });
+  });
+
+  describe('save', () => {
+    it('persists defaultSpawnCwd and reads it back', async () => {
+      const store = new RelayConfigStore(configFile);
+      await store.save({ defaultSpawnCwd: baseDir });
+
+      const fresh = new RelayConfigStore(configFile);
+      const loaded = await fresh.load();
+      expect(loaded.defaultSpawnCwd).toBe(baseDir);
+    });
+
+    it('updates the in-memory cache so resolveDefaultSpawnCwd sees the new value immediately', async () => {
+      const store = new RelayConfigStore(configFile);
+      await store.load();
+      expect(store.get().defaultSpawnCwd).toBeUndefined();
+
+      await store.save({ defaultSpawnCwd: baseDir });
+      expect(store.get().defaultSpawnCwd).toBe(baseDir);
+    });
+
+    it('creates the parent directory if missing', async () => {
+      const nested = join(baseDir, 'a', 'b', 'relay-config.json');
+      const store = new RelayConfigStore(nested);
+      await store.save({ defaultSpawnCwd: baseDir });
+      // If it threw, this line never runs. Re-read to confirm round-trip.
+      const fresh = new RelayConfigStore(nested);
+      const loaded = await fresh.load();
+      expect(loaded.defaultSpawnCwd).toBe(baseDir);
+    });
+
+    it('rejects empty defaultSpawnCwd before writing', async () => {
+      const store = new RelayConfigStore(configFile);
+      await expect(store.save({ defaultSpawnCwd: '' })).rejects.toBeInstanceOf(
+        RelayConfigError,
+      );
+    });
+
+    it('rejects defaultSpawnCwd that does not exist', async () => {
+      const store = new RelayConfigStore(configFile);
+      await expect(
+        store.save({ defaultSpawnCwd: '/nonexistent/major-tom/test' }),
+      ).rejects.toBeInstanceOf(RelayConfigError);
+    });
+
+    it('rejects defaultSpawnCwd that points at a file', async () => {
+      const filePath = join(baseDir, 'not-a-dir.txt');
+      await writeFile(filePath, 'hi', 'utf-8');
+      const store = new RelayConfigStore(configFile);
+      await expect(
+        store.save({ defaultSpawnCwd: filePath }),
+      ).rejects.toBeInstanceOf(RelayConfigError);
+    });
+
+    it('does not persist when validation fails', async () => {
+      const store = new RelayConfigStore(configFile);
+      await store.load();
+      try {
+        await store.save({ defaultSpawnCwd: '/missing' });
+      } catch {
+        // expected
+      }
+      expect(store.get().defaultSpawnCwd).toBeUndefined();
+      // File never written either.
+      const fresh = new RelayConfigStore(configFile);
+      const loaded = await fresh.load();
+      expect(loaded.defaultSpawnCwd).toBeUndefined();
+    });
+  });
+});
+
+describe('resolveDefaultSpawnCwd', () => {
+  let baseDir: string;
+
+  beforeEach(async () => {
+    baseDir = await mkdtemp(join(tmpdir(), 'relay-resolve-'));
+  });
+
+  afterEach(async () => {
+    await rm(baseDir, { recursive: true, force: true });
+  });
+
+  it('returns $MAJORTOM_DEFAULT_CWD when it points to an existing dir', () => {
+    const store = new RelayConfigStore(join(baseDir, 'cfg.json'));
+    const path = resolveDefaultSpawnCwd(store, {
+      MAJORTOM_DEFAULT_CWD: baseDir,
+      HOME: '/should-not-reach',
+    } as NodeJS.ProcessEnv);
+    expect(path).toBe(baseDir);
+  });
+
+  it('falls through env var when the path is missing', async () => {
+    const store = new RelayConfigStore(join(baseDir, 'cfg.json'));
+    await store.save({ defaultSpawnCwd: baseDir });
+    const path = resolveDefaultSpawnCwd(store, {
+      MAJORTOM_DEFAULT_CWD: '/nonexistent/major-tom/test',
+      HOME: '/should-not-reach',
+    } as NodeJS.ProcessEnv);
+    expect(path).toBe(baseDir);
+  });
+
+  it('returns persisted defaultSpawnCwd when the env var is unset', async () => {
+    const store = new RelayConfigStore(join(baseDir, 'cfg.json'));
+    await store.save({ defaultSpawnCwd: baseDir });
+    const path = resolveDefaultSpawnCwd(store, {
+      HOME: '/should-not-reach',
+    } as NodeJS.ProcessEnv);
+    expect(path).toBe(baseDir);
+  });
+
+  it('falls back to $HOME/Documents/code/dev when present', async () => {
+    const fakeHome = join(baseDir, 'home');
+    const devDir = join(fakeHome, 'Documents', 'code', 'dev');
+    await mkdir(devDir, { recursive: true });
+    const store = new RelayConfigStore(join(baseDir, 'cfg.json'));
+    const path = resolveDefaultSpawnCwd(store, {
+      HOME: fakeHome,
+    } as NodeJS.ProcessEnv);
+    expect(path).toBe(devDir);
+  });
+
+  it('falls back to $HOME when nothing else resolves', async () => {
+    const fakeHome = join(baseDir, 'lonely-home');
+    await mkdir(fakeHome, { recursive: true });
+    const store = new RelayConfigStore(join(baseDir, 'cfg.json'));
+    const path = resolveDefaultSpawnCwd(store, {
+      HOME: fakeHome,
+    } as NodeJS.ProcessEnv);
+    expect(path).toBe(fakeHome);
+  });
+
+  it('falls back to homedir() when env.HOME is unset', () => {
+    const store = new RelayConfigStore(join(baseDir, 'cfg.json'));
+    const path = resolveDefaultSpawnCwd(store, {} as NodeJS.ProcessEnv);
+    // We can't assert an exact value without mocking homedir, but we can
+    // assert the resolver returns a non-empty string and doesn't throw.
+    expect(typeof path).toBe('string');
+    expect(path.length).toBeGreaterThan(0);
+    // Should at minimum be the OS homedir or a real path; sanity-check by
+    // matching the actual homedir for the test runner.
+    expect(path === homedir() || path.startsWith(homedir())).toBe(true);
+  });
+});

--- a/relay/src/config/relay-config.ts
+++ b/relay/src/config/relay-config.ts
@@ -38,8 +38,17 @@ export const DEFAULT_RELAY_CONFIG_FILE = join(
   'relay-config.json',
 );
 
+/**
+ * Distinguishes user-input errors (`validation`) from disk-write failures
+ * (`io`) so the REST layer can pick the right HTTP status. Validation
+ * errors = 400; IO errors = 500. Without the kind, a misconfigured path
+ * and an out-of-disk would look the same to the client.
+ */
 export class RelayConfigError extends Error {
-  constructor(message: string) {
+  constructor(
+    message: string,
+    public readonly kind: 'validation' | 'io' = 'validation',
+  ) {
     super(message);
     this.name = 'RelayConfigError';
   }
@@ -100,10 +109,12 @@ export class RelayConfigStore {
   }
 
   /**
-   * Persist a new config. Validates fields before writing — bad values
-   * throw `RelayConfigError` and DO NOT mutate the in-memory cache or
-   * disk. I/O failures on the write itself log at WARN but do not throw
-   * (the cache has already advanced; the next save will retry).
+   * Persist a new config. Validation runs first — bad values throw
+   * `RelayConfigError(kind='validation')` and never touch disk or the
+   * in-memory cache. After a successful write, the cache advances so
+   * memory always matches what is persisted. I/O failures throw
+   * `RelayConfigError(kind='io')` so the REST route can return 500
+   * instead of misleading the client into thinking the value persisted.
    */
   async save(next: RelayConfig): Promise<void> {
     if (next.defaultSpawnCwd !== undefined) {
@@ -126,16 +137,21 @@ export class RelayConfigStore {
         throw new RelayConfigError(`defaultSpawnCwd does not exist: ${v}`);
       }
     }
-    this.cached = { ...next };
     try {
       await mkdir(dirname(this.path), { recursive: true });
-      await writeFile(this.path, JSON.stringify(this.cached, null, 2), 'utf-8');
+      await writeFile(this.path, JSON.stringify(next, null, 2), 'utf-8');
     } catch (err) {
       logger.warn(
         { err, path: this.path },
-        'Relay config save failed — in-memory cache preserved',
+        'Relay config save failed — cache NOT advanced; client receives 500',
+      );
+      throw new RelayConfigError(
+        `Failed to persist relay config: ${(err as Error).message}`,
+        'io',
       );
     }
+    // Disk holds the new value — safe to advance memory.
+    this.cached = { ...next };
   }
 }
 

--- a/relay/src/config/relay-config.ts
+++ b/relay/src/config/relay-config.ts
@@ -1,0 +1,195 @@
+// Relay-side runtime config — persists across restart in
+// `~/.major-tom/relay-config.json`. Today only `defaultSpawnCwd` lives
+// here; future fields (PTY input limit overrides, default permission
+// mode, etc.) can layer on without changing the file shape since
+// missing fields are treated as unset.
+//
+// Mutations come from the REST surface in `routes/relay-config.ts`
+// (driven by iOS Settings → Developer → Default Working Directory and,
+// later, Ground Control's config UI — closes QA-FIXES #19).
+//
+// Failure modes:
+//   - Missing file → silent default (fresh-install, expected).
+//   - Corrupt / bad schema → logged at WARN, ignored (treat as fresh).
+//   - I/O failures on save → logged at WARN, NOT thrown. The in-memory
+//     cache stays advanced; next save attempt will retry.
+
+import { existsSync, statSync } from 'node:fs';
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { homedir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { logger } from '../utils/logger.js';
+
+export interface RelayConfig {
+  /**
+   * Default cwd for new PTY spawns when there is no fresh per-tab
+   * workingDir to honor. iOS Settings → Developer writes this; the env
+   * var `MAJORTOM_DEFAULT_CWD` takes precedence at read time.
+   *
+   * Validated on save: must be a non-empty string, must exist, must be
+   * a directory. Invalid values are rejected with `RelayConfigError`.
+   */
+  defaultSpawnCwd?: string;
+}
+
+export const DEFAULT_RELAY_CONFIG_FILE = join(
+  homedir(),
+  '.major-tom',
+  'relay-config.json',
+);
+
+export class RelayConfigError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'RelayConfigError';
+  }
+}
+
+/**
+ * In-process holder for the persisted relay config. Loads at app boot
+ * and stays in memory; PATCH writes both update the cache and persist
+ * to disk. Constructed once and shared across the resolver + REST route.
+ */
+export class RelayConfigStore {
+  private cached: RelayConfig = {};
+
+  constructor(private readonly path: string = DEFAULT_RELAY_CONFIG_FILE) {}
+
+  /** Path the store reads/writes — exposed for tests + diagnostics. */
+  get filePath(): string {
+    return this.path;
+  }
+
+  /**
+   * Read the config file once at startup. ENOENT is a silent noop —
+   * fresh installs have no file. Corrupt / bad-schema files log at
+   * WARN and reset the in-memory cache to empty.
+   */
+  async load(): Promise<RelayConfig> {
+    let raw: string;
+    try {
+      raw = await readFile(this.path, 'utf-8');
+    } catch (err) {
+      const code = errnoCode(err);
+      if (code !== 'ENOENT') {
+        logger.warn({ err, path: this.path, code }, 'Relay config read failed');
+      }
+      this.cached = {};
+      return this.cached;
+    }
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(raw);
+    } catch (err) {
+      logger.warn({ err, path: this.path }, 'Relay config is invalid JSON — ignoring');
+      this.cached = {};
+      return this.cached;
+    }
+    if (!isRelayConfig(parsed)) {
+      logger.warn({ path: this.path }, 'Relay config has invalid schema — ignoring');
+      this.cached = {};
+      return this.cached;
+    }
+    this.cached = parsed;
+    return this.cached;
+  }
+
+  /** Snapshot of the current in-memory config. */
+  get(): RelayConfig {
+    return { ...this.cached };
+  }
+
+  /**
+   * Persist a new config. Validates fields before writing — bad values
+   * throw `RelayConfigError` and DO NOT mutate the in-memory cache or
+   * disk. I/O failures on the write itself log at WARN but do not throw
+   * (the cache has already advanced; the next save will retry).
+   */
+  async save(next: RelayConfig): Promise<void> {
+    if (next.defaultSpawnCwd !== undefined) {
+      const v = next.defaultSpawnCwd;
+      if (typeof v !== 'string') {
+        throw new RelayConfigError('defaultSpawnCwd must be a string');
+      }
+      if (v.length === 0) {
+        throw new RelayConfigError('defaultSpawnCwd must not be empty');
+      }
+      // Stat upfront so the user gets a clear rejection instead of the
+      // failure showing up later as a silent fall-through inside
+      // resolveDefaultSpawnCwd.
+      try {
+        if (!statSync(v).isDirectory()) {
+          throw new RelayConfigError(`defaultSpawnCwd is not a directory: ${v}`);
+        }
+      } catch (err) {
+        if (err instanceof RelayConfigError) throw err;
+        throw new RelayConfigError(`defaultSpawnCwd does not exist: ${v}`);
+      }
+    }
+    this.cached = { ...next };
+    try {
+      await mkdir(dirname(this.path), { recursive: true });
+      await writeFile(this.path, JSON.stringify(this.cached, null, 2), 'utf-8');
+    } catch (err) {
+      logger.warn(
+        { err, path: this.path },
+        'Relay config save failed — in-memory cache preserved',
+      );
+    }
+  }
+}
+
+/**
+ * Resolve the cwd a fresh PTY should spawn into when no fresh per-tab
+ * workingDir is available. Cascade order:
+ *   1. `$MAJORTOM_DEFAULT_CWD` env var (must point at an existing dir)
+ *   2. Persisted `defaultSpawnCwd` from the relay config file
+ *   3. `$HOME/Documents/code/dev` if it exists
+ *   4. `$HOME`
+ *
+ * Each non-final stop is path-validated; any miss falls through. We never
+ * spawn into an empty / non-existent dir — node-pty would reject that.
+ */
+export function resolveDefaultSpawnCwd(
+  store: RelayConfigStore,
+  env: NodeJS.ProcessEnv = process.env,
+): string {
+  const fromEnv = env['MAJORTOM_DEFAULT_CWD'];
+  if (fromEnv && isExistingDir(fromEnv)) return fromEnv;
+
+  const fromFile = store.get().defaultSpawnCwd;
+  if (fromFile && isExistingDir(fromFile)) return fromFile;
+
+  const home = env['HOME'] ?? homedir();
+  const devGuess = join(home, 'Documents', 'code', 'dev');
+  if (isExistingDir(devGuess)) return devGuess;
+
+  return home;
+}
+
+function isExistingDir(path: string): boolean {
+  if (!path || path.length === 0) return false;
+  try {
+    return existsSync(path) && statSync(path).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+function isRelayConfig(v: unknown): v is RelayConfig {
+  if (typeof v !== 'object' || v === null) return false;
+  const o = v as Record<string, unknown>;
+  if (
+    o['defaultSpawnCwd'] !== undefined &&
+    typeof o['defaultSpawnCwd'] !== 'string'
+  ) return false;
+  return true;
+}
+
+function errnoCode(err: unknown): string | undefined {
+  if (typeof err === 'object' && err !== null && 'code' in err) {
+    const code = (err as { code: unknown }).code;
+    if (typeof code === 'string') return code;
+  }
+  return undefined;
+}

--- a/relay/src/routes/__tests__/relay-config.test.ts
+++ b/relay/src/routes/__tests__/relay-config.test.ts
@@ -160,6 +160,35 @@ describe('PATCH /api/relay-config', () => {
     expect(res.statusCode).toBe(400);
   });
 
+  it('returns 500 when the disk write fails (does not silently claim success)', async () => {
+    // Build an isolated app whose store points at a file path nested
+    // INSIDE an existing file — `writeFile` rejects with ENOTDIR. Without
+    // the `kind === 'io'` branch added in the disk-write fix, the route
+    // would return 200 + the new value while disk has the old value.
+    const sentinel = join(baseDir, 'sentinel.txt');
+    await writeFile(sentinel, 'hi', 'utf-8');
+    const blockedStore = new RelayConfigStore(join(sentinel, 'cfg.json'));
+    await blockedStore.load();
+
+    const blockedApp = Fastify({ logger: false });
+    await blockedApp.register(cookie);
+    await blockedApp.register(authPlugin);
+    await blockedApp.register(createRelayConfigRoutes({ configStore: blockedStore }));
+    await blockedApp.ready();
+    try {
+      const res = await blockedApp.inject({
+        method: 'PATCH',
+        url: '/api/relay-config',
+        headers: { cookie: cookieHeader, 'content-type': 'application/json' },
+        payload: { defaultSpawnCwd: baseDir },
+      });
+      expect(res.statusCode).toBe(500);
+      expect(res.json()).toHaveProperty('error');
+    } finally {
+      await blockedApp.close();
+    }
+  });
+
   it('ignores unknown fields without rejecting', async () => {
     // PATCH should be permissive on unknown keys so future fields can land
     // without breaking older clients. Only the validated subset is

--- a/relay/src/routes/__tests__/relay-config.test.ts
+++ b/relay/src/routes/__tests__/relay-config.test.ts
@@ -1,0 +1,177 @@
+/**
+ * Integration tests for `/api/relay-config`.
+ *
+ * Stands up a real Fastify instance with the auth plugin so the
+ * `requireSession` preHandler runs against actual JWT verification.
+ * Tests cover:
+ *   - 401 when no session cookie
+ *   - GET returns the persisted config
+ *   - PATCH updates the persisted config and rejects invalid values
+ */
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import Fastify, { type FastifyInstance } from 'fastify';
+import cookie from '@fastify/cookie';
+import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { authPlugin } from '../../plugins/auth.js';
+import { createSessionToken, SESSION_COOKIE } from '../../auth/session.js';
+import { createRelayConfigRoutes } from '../relay-config.js';
+import { RelayConfigStore } from '../../config/relay-config.js';
+
+let app: FastifyInstance;
+let baseDir: string;
+let configFile: string;
+let store: RelayConfigStore;
+let cookieHeader: string;
+
+beforeEach(async () => {
+  process.env['SESSION_SECRET'] = 'test-relay-config-secret-must-be-32-bytes!!';
+  baseDir = await mkdtemp(join(tmpdir(), 'relay-config-route-'));
+  configFile = join(baseDir, 'relay-config.json');
+  store = new RelayConfigStore(configFile);
+  await store.load();
+
+  app = Fastify({ logger: false });
+  await app.register(cookie);
+  await app.register(authPlugin);
+  await app.register(createRelayConfigRoutes({ configStore: store }));
+  await app.ready();
+
+  const token = await createSessionToken('test-user', 'tester@example.com', 'user-1', 'admin');
+  cookieHeader = `${SESSION_COOKIE}=${token}`;
+});
+
+afterEach(async () => {
+  await app.close();
+  await rm(baseDir, { recursive: true, force: true });
+});
+
+describe('GET /api/relay-config', () => {
+  it('rejects unauthenticated requests with 401', async () => {
+    const res = await app.inject({ method: 'GET', url: '/api/relay-config' });
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('returns an empty config when nothing is persisted', async () => {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/relay-config',
+      headers: { cookie: cookieHeader },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual({});
+  });
+
+  it('returns the persisted defaultSpawnCwd', async () => {
+    await store.save({ defaultSpawnCwd: baseDir });
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/relay-config',
+      headers: { cookie: cookieHeader },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual({ defaultSpawnCwd: baseDir });
+  });
+});
+
+describe('PATCH /api/relay-config', () => {
+  it('rejects unauthenticated requests with 401', async () => {
+    const res = await app.inject({
+      method: 'PATCH',
+      url: '/api/relay-config',
+      payload: { defaultSpawnCwd: baseDir },
+    });
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('persists a valid defaultSpawnCwd', async () => {
+    const res = await app.inject({
+      method: 'PATCH',
+      url: '/api/relay-config',
+      headers: { cookie: cookieHeader, 'content-type': 'application/json' },
+      payload: { defaultSpawnCwd: baseDir },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual({ defaultSpawnCwd: baseDir });
+
+    const fresh = new RelayConfigStore(configFile);
+    const loaded = await fresh.load();
+    expect(loaded.defaultSpawnCwd).toBe(baseDir);
+  });
+
+  it('clears defaultSpawnCwd when null is sent', async () => {
+    await store.save({ defaultSpawnCwd: baseDir });
+    const res = await app.inject({
+      method: 'PATCH',
+      url: '/api/relay-config',
+      headers: { cookie: cookieHeader, 'content-type': 'application/json' },
+      payload: { defaultSpawnCwd: null },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual({});
+
+    const fresh = new RelayConfigStore(configFile);
+    const loaded = await fresh.load();
+    expect(loaded.defaultSpawnCwd).toBeUndefined();
+  });
+
+  it('rejects defaultSpawnCwd that does not exist with 400', async () => {
+    const res = await app.inject({
+      method: 'PATCH',
+      url: '/api/relay-config',
+      headers: { cookie: cookieHeader, 'content-type': 'application/json' },
+      payload: { defaultSpawnCwd: '/no/such/dir/major-tom/test' },
+    });
+    expect(res.statusCode).toBe(400);
+    expect(res.json()).toHaveProperty('error');
+  });
+
+  it('rejects defaultSpawnCwd that points at a file with 400', async () => {
+    const filePath = join(baseDir, 'not-a-dir.txt');
+    await writeFile(filePath, 'hi', 'utf-8');
+    const res = await app.inject({
+      method: 'PATCH',
+      url: '/api/relay-config',
+      headers: { cookie: cookieHeader, 'content-type': 'application/json' },
+      payload: { defaultSpawnCwd: filePath },
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('rejects non-string defaultSpawnCwd with 400', async () => {
+    const res = await app.inject({
+      method: 'PATCH',
+      url: '/api/relay-config',
+      headers: { cookie: cookieHeader, 'content-type': 'application/json' },
+      payload: { defaultSpawnCwd: 12345 },
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('rejects non-object body with 400', async () => {
+    const res = await app.inject({
+      method: 'PATCH',
+      url: '/api/relay-config',
+      headers: { cookie: cookieHeader, 'content-type': 'application/json' },
+      payload: 'not-an-object',
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('ignores unknown fields without rejecting', async () => {
+    // PATCH should be permissive on unknown keys so future fields can land
+    // without breaking older clients. Only the validated subset is
+    // persisted.
+    const res = await app.inject({
+      method: 'PATCH',
+      url: '/api/relay-config',
+      headers: { cookie: cookieHeader, 'content-type': 'application/json' },
+      payload: { defaultSpawnCwd: baseDir, unknownField: 'whatever' },
+    });
+    expect(res.statusCode).toBe(200);
+    const persisted = await new RelayConfigStore(configFile).load();
+    expect(persisted).toEqual({ defaultSpawnCwd: baseDir });
+  });
+});

--- a/relay/src/routes/relay-config.ts
+++ b/relay/src/routes/relay-config.ts
@@ -77,7 +77,8 @@ export function createRelayConfigRoutes(deps: RelayConfigDeps): FastifyPluginAsy
           await configStore.save(next);
         } catch (err) {
           if (err instanceof RelayConfigError) {
-            return reply.code(400).send({ error: err.message });
+            const status = err.kind === 'io' ? 500 : 400;
+            return reply.code(status).send({ error: err.message });
           }
           logger.warn({ err }, 'Relay config save threw unexpectedly');
           return reply.code(500).send({ error: 'Failed to save relay config' });

--- a/relay/src/routes/relay-config.ts
+++ b/relay/src/routes/relay-config.ts
@@ -1,0 +1,93 @@
+/**
+ * Relay-config routes — GET/PATCH /api/relay-config.
+ *
+ * Currently exposes a single field: `defaultSpawnCwd` (the cwd new PTY
+ * tabs spawn into when no fresh per-tab workingDir is available). iOS
+ * Settings → Developer reads/writes through this endpoint; Ground
+ * Control will surface the same field later (closes QA-FIXES #19).
+ *
+ * Auth: required in both single- and multi-user mode. The setting is
+ * relay-wide, so any authenticated client can read/update it for now —
+ * an admin-only gate can layer on once multi-user mode hardens.
+ */
+import type { FastifyPluginAsync } from 'fastify';
+import { requireSession } from '../plugins/auth.js';
+import { logger } from '../utils/logger.js';
+import {
+  RelayConfigError,
+  type RelayConfig,
+  type RelayConfigStore,
+} from '../config/relay-config.js';
+
+interface RelayConfigDeps {
+  configStore: RelayConfigStore;
+}
+
+/**
+ * Validate an incoming PATCH body. Returns the normalized partial config
+ * (only fields the caller meant to set) or `null` on shape errors. The
+ * deeper "is this a real directory?" validation happens inside
+ * `RelayConfigStore.save`, which throws `RelayConfigError` — this layer
+ * stays cheap and focused on shape.
+ */
+function validatePatch(body: unknown): Partial<RelayConfig> | null {
+  if (!body || typeof body !== 'object') return null;
+  const b = body as Record<string, unknown>;
+  const out: Partial<RelayConfig> = {};
+
+  if ('defaultSpawnCwd' in b) {
+    const v = b['defaultSpawnCwd'];
+    if (v === null || v === '') {
+      // Explicit clear — falls back to env var / implicit defaults at
+      // resolve time. Represented as undefined in the persisted config.
+      out.defaultSpawnCwd = undefined;
+    } else if (typeof v === 'string') {
+      out.defaultSpawnCwd = v;
+    } else {
+      return null;
+    }
+  }
+
+  return out;
+}
+
+export function createRelayConfigRoutes(deps: RelayConfigDeps): FastifyPluginAsync {
+  const { configStore } = deps;
+
+  return async (fastify) => {
+    fastify.get(
+      '/api/relay-config',
+      { preHandler: requireSession },
+      async (_request, reply) => {
+        return reply.send(configStore.get());
+      },
+    );
+
+    fastify.patch(
+      '/api/relay-config',
+      { preHandler: requireSession },
+      async (request, reply) => {
+        const partial = validatePatch(request.body);
+        if (partial === null) {
+          return reply.code(400).send({ error: 'Invalid relay-config payload' });
+        }
+
+        const next: RelayConfig = { ...configStore.get(), ...partial };
+        try {
+          await configStore.save(next);
+        } catch (err) {
+          if (err instanceof RelayConfigError) {
+            return reply.code(400).send({ error: err.message });
+          }
+          logger.warn({ err }, 'Relay config save threw unexpectedly');
+          return reply.code(500).send({ error: 'Failed to save relay config' });
+        }
+        logger.info(
+          { fields: Object.keys(partial) },
+          'Relay config updated',
+        );
+        return reply.send(configStore.get());
+      },
+    );
+  };
+}

--- a/relay/src/routes/shell.ts
+++ b/relay/src/routes/shell.ts
@@ -14,6 +14,7 @@ import type { WebSocket } from 'ws';
 import { verifySessionToken, SESSION_COOKIE } from '../auth/session.js';
 import type { PtyAdapter, PtyClient } from '../adapters/pty-adapter.js';
 import type { TabRegistry } from '../tabs/tab-registry.js';
+import { DEFAULT_WORKING_DIR_TTL_MS } from '../tabs/tab-registry.js';
 import { MAJOR_TOM_CONFIG_DIR } from '../installer/install-hooks.js';
 import { logger } from '../utils/logger.js';
 
@@ -23,8 +24,18 @@ interface ShellRouteDeps {
    * Used to look up a tab's persisted workingDir (from the last SessionStart
    * hook) so reconnects after relay restart respawn in the tab's prior cwd
    * instead of HOME. Optional — when undefined, the adapter uses its default.
+   *
+   * The persisted dir is consulted only when its `workingDirUpdatedAt`
+   * stamp is within `workingDirTtlMs` (default 12h). Older values fall
+   * through to the adapter default — see QA-FIXES #17.
    */
   tabRegistry?: TabRegistry;
+  /**
+   * Override the freshness window used when consulting persisted workingDir.
+   * Defaults to `DEFAULT_WORKING_DIR_TTL_MS` (12h). Tests pass a smaller
+   * value; production uses the default.
+   */
+  workingDirTtlMs?: number;
 }
 
 interface ShellAuthResult {
@@ -136,6 +147,7 @@ function buildEnvExtras(tabId: string): Record<string, string> {
 
 export function createShellRoute(deps: ShellRouteDeps): FastifyPluginAsync {
   const { ptyAdapter, tabRegistry } = deps;
+  const workingDirTtlMs = deps.workingDirTtlMs ?? DEFAULT_WORKING_DIR_TTL_MS;
 
   return async (fastify) => {
     fastify.get<{
@@ -180,7 +192,12 @@ export function createShellRoute(deps: ShellRouteDeps): FastifyPluginAsync {
         // spawn. TabRegistry captures cwd at SessionStart hook-time and
         // persists it; the adapter validates the path before use and falls
         // back to its default if the directory is gone.
-        const persistedCwd = tabRegistry?.getTab(tabId)?.workingDir;
+        //
+        // QA-FIXES #17 — gate by freshness so a stamp captured weeks ago
+        // (e.g. user has not run `claude` in this tab since) cannot
+        // resurface and pin a reconnect to a stale dir. Falls through to
+        // the adapter default when stale, missing, or never-stamped.
+        const persistedCwd = tabRegistry?.getFreshWorkingDir(tabId, workingDirTtlMs);
         const outcome = ptyAdapter.attach(tabId, client, {
           cols,
           rows,

--- a/relay/src/tabs/__tests__/tab-registry-persistence.test.ts
+++ b/relay/src/tabs/__tests__/tab-registry-persistence.test.ts
@@ -61,6 +61,7 @@ describe('TabRegistryPersistence', () => {
           tabId: '../etc/passwd',
           userId: undefined,
           workingDir: undefined,
+          workingDirUpdatedAt: undefined,
           createdAt: new Date().toISOString(),
           lastSeenAt: new Date().toISOString(),
           sessionIds: new Set(),
@@ -205,6 +206,74 @@ describe('TabRegistryPersistence', () => {
       const fresh = new TabRegistry(persistence);
       await fresh.restoreFromDisk();
       expect(fresh.listTabs()).toEqual([]);
+    });
+  });
+
+  describe('workingDirUpdatedAt round-trip (QA-FIXES #17)', () => {
+    it('persists workingDirUpdatedAt and reads it back', async () => {
+      const registry = new TabRegistry(persistence);
+      registry.registerSessionStart('sess-1', 'tab-A', '/home/u/proj', 'user-1');
+      const stamp = registry.getTab('tab-A')!.workingDirUpdatedAt;
+      await new Promise((r) => setTimeout(r, 20));
+
+      const loaded = await persistence.load('tab-A');
+      expect(loaded?.workingDirUpdatedAt).toBe(stamp);
+    });
+
+    it('rehydrates workingDirUpdatedAt from disk', async () => {
+      let stamp: string | undefined;
+      {
+        const firstRegistry = new TabRegistry(persistence);
+        firstRegistry.registerSessionStart('sess-1', 'tab-A', '/proj', 'user-1');
+        stamp = firstRegistry.getTab('tab-A')!.workingDirUpdatedAt;
+        await new Promise((r) => setTimeout(r, 20));
+      }
+      const fresh = new TabRegistry(persistence);
+      await fresh.restoreFromDisk();
+      expect(fresh.getTab('tab-A')?.workingDirUpdatedAt).toBe(stamp);
+    });
+
+    it('treats legacy records without workingDirUpdatedAt as stale on rehydrate', async () => {
+      // Hand-write a v1 file that pre-dates the new field — accepted by the
+      // schema validator (the field is optional) and rehydrated with
+      // updatedAt=undefined so getFreshWorkingDir returns undefined.
+      await writeFile(
+        join(baseDir, 'tab-legacy.json'),
+        JSON.stringify({
+          version: 1,
+          tabId: 'tab-legacy',
+          userId: 'user-1',
+          workingDir: '/old/path',
+          createdAt: new Date().toISOString(),
+          lastSeenAt: new Date().toISOString(),
+          sessionIds: [],
+          status: 'idle',
+        }),
+        'utf-8',
+      );
+      const fresh = new TabRegistry(persistence);
+      await fresh.restoreFromDisk();
+      expect(fresh.getTab('tab-legacy')?.workingDir).toBe('/old/path');
+      expect(fresh.getTab('tab-legacy')?.workingDirUpdatedAt).toBeUndefined();
+    });
+
+    it('rejects records with non-string workingDirUpdatedAt', async () => {
+      await writeFile(
+        join(baseDir, 'tab-bad.json'),
+        JSON.stringify({
+          version: 1,
+          tabId: 'tab-bad',
+          workingDir: '/p',
+          workingDirUpdatedAt: 12345,
+          createdAt: new Date().toISOString(),
+          lastSeenAt: new Date().toISOString(),
+          sessionIds: [],
+          status: 'idle',
+        }),
+        'utf-8',
+      );
+      const loaded = await persistence.load('tab-bad');
+      expect(loaded).toBeNull();
     });
   });
 

--- a/relay/src/tabs/__tests__/tab-registry.test.ts
+++ b/relay/src/tabs/__tests__/tab-registry.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import { TabRegistry } from '../tab-registry.js';
+import { TabRegistry, DEFAULT_WORKING_DIR_TTL_MS } from '../tab-registry.js';
 
 describe('TabRegistry', () => {
   let registry: TabRegistry;
@@ -201,6 +201,94 @@ describe('TabRegistry', () => {
 
     it('is a no-op for an unknown tabId', () => {
       expect(() => registry.touch('ghost')).not.toThrow();
+    });
+  });
+
+  describe('workingDir freshness (QA-FIXES #17)', () => {
+    it('stamps workingDirUpdatedAt on first SessionStart', () => {
+      const before = Date.now();
+      registry.registerSessionStart('sess-1', 'tab-A', '/proj', 'user-1');
+      const after = Date.now();
+      const stamp = registry.getTab('tab-A')!.workingDirUpdatedAt;
+      expect(stamp).toBeDefined();
+      const ms = Date.parse(stamp!);
+      expect(ms).toBeGreaterThanOrEqual(before);
+      expect(ms).toBeLessThanOrEqual(after);
+    });
+
+    it('leaves updatedAt undefined when first SessionStart has empty cwd', () => {
+      registry.registerSessionStart('sess-1', 'tab-A', '', undefined);
+      expect(registry.getTab('tab-A')!.workingDirUpdatedAt).toBeUndefined();
+    });
+
+    it('re-stamps updatedAt on every later SessionStart that carries a cwd', async () => {
+      registry.registerSessionStart('sess-1', 'tab-A', '/proj', 'user-1');
+      const first = registry.getTab('tab-A')!.workingDirUpdatedAt!;
+      await new Promise((r) => setTimeout(r, 5));
+      registry.registerSessionStart('sess-2', 'tab-A', '/proj', 'user-1');
+      const second = registry.getTab('tab-A')!.workingDirUpdatedAt!;
+      expect(second > first).toBe(true);
+    });
+
+    it('upgrades workingDir + updatedAt when a later SessionStart supplies a non-empty cwd', () => {
+      registry.registerSessionStart('sess-1', 'tab-A', '', undefined);
+      expect(registry.getTab('tab-A')!.workingDir).toBe('');
+      expect(registry.getTab('tab-A')!.workingDirUpdatedAt).toBeUndefined();
+
+      registry.registerSessionStart('sess-2', 'tab-A', '/proj', 'user-1');
+      expect(registry.getTab('tab-A')!.workingDir).toBe('/proj');
+      expect(registry.getTab('tab-A')!.workingDirUpdatedAt).toBeDefined();
+    });
+
+    it('getFreshWorkingDir returns the path inside the TTL window', () => {
+      registry.registerSessionStart('sess-1', 'tab-A', '/proj', 'user-1');
+      const stamped = Date.parse(registry.getTab('tab-A')!.workingDirUpdatedAt!);
+      // 6 hours after stamp — well inside the 12h default window.
+      const fresh = registry.getFreshWorkingDir(
+        'tab-A',
+        DEFAULT_WORKING_DIR_TTL_MS,
+        stamped + 6 * 60 * 60 * 1000,
+      );
+      expect(fresh).toBe('/proj');
+    });
+
+    it('getFreshWorkingDir returns undefined once stale', () => {
+      registry.registerSessionStart('sess-1', 'tab-A', '/proj', 'user-1');
+      const stamped = Date.parse(registry.getTab('tab-A')!.workingDirUpdatedAt!);
+      // 13 hours after stamp — past the 12h default window.
+      const stale = registry.getFreshWorkingDir(
+        'tab-A',
+        DEFAULT_WORKING_DIR_TTL_MS,
+        stamped + 13 * 60 * 60 * 1000,
+      );
+      expect(stale).toBeUndefined();
+    });
+
+    it('getFreshWorkingDir returns undefined when updatedAt is missing (rehydrated legacy record)', async () => {
+      // Simulate a tab restored from disk without the new field.
+      registry.registerSessionStart('sess-1', 'tab-A', '/proj', 'user-1');
+      const tab = registry.getTab('tab-A')!;
+      tab.workingDirUpdatedAt = undefined;
+      expect(
+        registry.getFreshWorkingDir('tab-A', DEFAULT_WORKING_DIR_TTL_MS),
+      ).toBeUndefined();
+    });
+
+    it('getFreshWorkingDir returns undefined for unknown tabs', () => {
+      expect(
+        registry.getFreshWorkingDir('ghost', DEFAULT_WORKING_DIR_TTL_MS),
+      ).toBeUndefined();
+    });
+
+    it('getFreshWorkingDir returns undefined when workingDir is empty', () => {
+      registry.registerSessionStart('sess-1', 'tab-A', '', undefined);
+      expect(
+        registry.getFreshWorkingDir('tab-A', DEFAULT_WORKING_DIR_TTL_MS),
+      ).toBeUndefined();
+    });
+
+    it('default TTL is 12 hours', () => {
+      expect(DEFAULT_WORKING_DIR_TTL_MS).toBe(12 * 60 * 60 * 1000);
     });
   });
 

--- a/relay/src/tabs/tab-registry-persistence.ts
+++ b/relay/src/tabs/tab-registry-persistence.ts
@@ -27,6 +27,13 @@ export interface PersistedTabFile {
   tabId: string;
   userId?: string;
   workingDir?: string;
+  /**
+   * ISO timestamp of the last `workingDir` write. Optional — pre-existing
+   * records written before QA-FIXES #17 won't have it; the registry treats
+   * those as stale on rehydrate. New writes always include it when
+   * `workingDir` is set.
+   */
+  workingDirUpdatedAt?: string;
   createdAt: string;
   lastSeenAt: string;
   sessionIds: string[];
@@ -104,6 +111,9 @@ export class TabRegistryPersistence {
       tabId: meta.tabId,
       ...(meta.userId !== undefined ? { userId: meta.userId } : {}),
       ...(meta.workingDir !== undefined ? { workingDir: meta.workingDir } : {}),
+      ...(meta.workingDirUpdatedAt !== undefined
+        ? { workingDirUpdatedAt: meta.workingDirUpdatedAt }
+        : {}),
       createdAt: meta.createdAt,
       lastSeenAt: meta.lastSeenAt,
       sessionIds: [...meta.sessionIds],
@@ -191,5 +201,9 @@ function isValidPersistedFile(v: unknown): v is PersistedTabFile {
   if (status !== 'active' && status !== 'idle' && status !== 'closed') return false;
   if (o['userId'] !== undefined && typeof o['userId'] !== 'string') return false;
   if (o['workingDir'] !== undefined && typeof o['workingDir'] !== 'string') return false;
+  if (
+    o['workingDirUpdatedAt'] !== undefined &&
+    typeof o['workingDirUpdatedAt'] !== 'string'
+  ) return false;
   return true;
 }

--- a/relay/src/tabs/tab-registry.ts
+++ b/relay/src/tabs/tab-registry.ts
@@ -16,10 +16,29 @@ import type { TabRegistryPersistence } from './tab-registry-persistence.js';
 
 export type TabStatus = 'active' | 'idle' | 'closed';
 
+/**
+ * Default freshness TTL for `workingDir`. The persisted value is consulted
+ * on PTY respawn (e.g. relay restart, fresh attach after grace) only if it
+ * was set within this window. Older values are treated as stale and the
+ * cascade falls through to the configured default — see QA-FIXES #17.
+ *
+ * 12 hours covers a workday; a weeks-old SessionStart capture won't kick a
+ * reconnecting user into an unrelated dir. Easy to tune later if needed.
+ */
+export const DEFAULT_WORKING_DIR_TTL_MS = 12 * 60 * 60 * 1000;
+
 export interface TabMeta {
   tabId: string;
   userId: string | undefined;
   workingDir: string | undefined;
+  /**
+   * ISO timestamp of the last `workingDir` write. Stamped on first
+   * SessionStart and on every later upgrade. Used by `getFreshWorkingDir`
+   * to gate stale values out of the spawn cwd cascade.
+   * Optional for backwards-compat with persisted records that pre-date
+   * this field — those are treated as stale.
+   */
+  workingDirUpdatedAt: string | undefined;
   createdAt: string;
   lastSeenAt: string;
   sessionIds: Set<string>;
@@ -46,6 +65,11 @@ export class TabRegistry {
         tabId: f.tabId,
         userId: f.userId,
         workingDir: f.workingDir,
+        // Pre-existing persisted records may not have updatedAt — leave
+        // undefined so `getFreshWorkingDir` treats them as stale and the
+        // cascade falls through to the configured default. Once the user
+        // reconnects and a fresh SessionStart fires, the field gets stamped.
+        workingDirUpdatedAt: f.workingDirUpdatedAt,
         createdAt: f.createdAt,
         lastSeenAt: f.lastSeenAt,
         sessionIds: new Set<string>(),
@@ -73,6 +97,7 @@ export class TabRegistry {
         tabId,
         userId,
         workingDir: cwd,
+        workingDirUpdatedAt: cwd ? now : undefined,
         createdAt: now,
         lastSeenAt: now,
         sessionIds: new Set<string>(),
@@ -83,7 +108,15 @@ export class TabRegistry {
     } else {
       tab.lastSeenAt = now;
       if (!tab.userId && userId) tab.userId = userId;
-      if (!tab.workingDir && cwd) tab.workingDir = cwd;
+      // Re-stamp updatedAt whenever a SessionStart confirms the tab's
+      // current workingDir — even if the path matches what we already
+      // stored. The SessionStart hook fires inside the live shell, so any
+      // value it carries is by definition fresh; we want the freshness
+      // window to track that signal, not the original capture date.
+      if (cwd) {
+        tab.workingDir = cwd;
+        tab.workingDirUpdatedAt = now;
+      }
     }
     tab.sessionIds.add(sessionId);
     tab.status = 'active';
@@ -146,6 +179,31 @@ export class TabRegistry {
   /** Fetch a TabMeta by tabId. */
   getTab(tabId: string): TabMeta | undefined {
     return this.tabs.get(tabId);
+  }
+
+  /**
+   * Return the tab's persisted `workingDir` only when it was last stamped
+   * within `ttlMs`. Stale or never-stamped values return `undefined` so the
+   * caller (shell.ts) falls through to the adapter's configured default.
+   *
+   * QA-FIXES #17 — without this gate, a tab whose `workingDir` was captured
+   * weeks ago by an old SessionStart would resurface across relay restart,
+   * stranding the user in an unrelated dir on reconnect.
+   *
+   * `now` defaults to `Date.now()` and is overridable for tests.
+   */
+  getFreshWorkingDir(
+    tabId: string,
+    ttlMs: number,
+    now: number = Date.now(),
+  ): string | undefined {
+    const tab = this.tabs.get(tabId);
+    if (!tab || !tab.workingDir) return undefined;
+    if (!tab.workingDirUpdatedAt) return undefined;
+    const stamped = Date.parse(tab.workingDirUpdatedAt);
+    if (!Number.isFinite(stamped)) return undefined;
+    if (now - stamped > ttlMs) return undefined;
+    return tab.workingDir;
   }
 
   /**

--- a/relay/vitest.config.ts
+++ b/relay/vitest.config.ts
@@ -6,6 +6,10 @@ export default defineConfig({
     globals: false,
     setupFiles: ['./src/__tests__/setup.ts'],
     include: ['src/**/__tests__/**/*.test.ts', 'src/**/*.test.ts'],
+    // Stray git worktrees from prior agents (and their stale builds) live
+    // under `.claude/worktrees/`. Without this exclude, vitest discovers
+    // their `src/**` and runs old/broken copies of these tests.
+    exclude: ['**/node_modules/**', '**/dist/**', '**/.claude/**'],
     pool: 'forks',
     testTimeout: 10_000,
     hookTimeout: 10_000,


### PR DESCRIPTION
## Summary

Closes **QA-FIXES #17** (PTY cwd persistence misses plain-shell `cd` updates) and **QA-FIXES #19** (Ground Control: user-settable default cwd) in one bundled change. Approach is the **B′** path agreed in `project_qa17_handoff` — TTL freshness gate on the persisted `workingDir` + a real configurable default — chosen over pure OSC 7 because the same plumbing closes #19 with no shell-config glue.

### Cascade rewrite

`pty-adapter::resolveSpawnCwd` now walks:

1. Per-tab `workingDir` **only when `workingDirUpdatedAt` is within 12h** (`getFreshWorkingDir(tabId, ttlMs)`)
2. Configured `defaultSpawnCwd`:
   - `MAJORTOM_DEFAULT_CWD` env var
   - `~/.major-tom/relay-config.json` → `defaultSpawnCwd`
3. `$HOME/Documents/code/dev` if it exists
4. `$HOME`

The prior incidental `process.cwd()` fallback is removed — it was correct on the dev machine, wrong for distribution.

### What changed

- **Registry / persistence:** `workingDirUpdatedAt` stamped on every SessionStart, round-tripped through disk. Legacy records load with it `undefined` → treated as stale (no migration).
- **Adapter:** `cwd` opt now accepts a getter so a relay-config PATCH from iOS flows into the next PTY spawn with no restart.
- **Config module:** new `RelayConfigStore` over `~/.major-tom/relay-config.json` + `resolveDefaultSpawnCwd` cascade. Validates `defaultSpawnCwd` is a real directory before persisting.
- **REST:** `GET/PATCH /api/relay-config` (auth via `requireSession`).
- **iOS:** Settings → Developer → "Default Working Directory" navigates to a small editor calling the new endpoints.

### What is deferred

- Persisted tab-file TTL sweep (drop `tab-*.json` not seen in 30 days) — flagged as a separate follow-up in QA-FIXES.md.
- mDNS/Bonjour relay discovery (still on the table for distribution).
- OSC 7 layer — possible future on top of B′ if the 12h fallback feels coarse in practice.

## Test plan

### Relay
- [x] `tsc --noEmit` clean
- [x] All 354 vitest tests pass (22 files), including the 8 new tests for `getFreshWorkingDir` + persistence back-compat, 18 for `RelayConfigStore` + resolver, 11 for the REST route, and 2 for the adapter getter form.

### iOS
- [x] iOS sim build via XcodeBuildMCP — SUCCEEDED, no errors. Pre-existing warnings only.

### Device QA (post-merge)
- [ ] New tab opens directly into `~/Documents/code/dev` (default-of-default).
- [ ] Existing tab with claude session active in last 12h reconnects to the same cwd (no regression).
- [ ] Existing stale tab (last activity weeks ago) reconnects to the configured default, NOT the stale captured dir (the H4LA reproducer).
- [ ] Settings → Developer → Default Working Directory: read shows current value, save with valid dir succeeds, save with bogus path returns inline error.
- [ ] Setting `MAJORTOM_DEFAULT_CWD=/tmp` and restarting relay makes new tabs spawn in `/tmp`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
