### PR TITLE
ci(review): allow claude bot to trigger deep-review jobs

### DIFF
--- a/.github/workflows/claude-deep-review.yml
+++ b/.github/workflows/claude-deep-review.yml
@@ -64,6 +64,7 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          allowed_bots: claude
           additional_permissions: |
             actions: read
           prompt: |
@@ -157,6 +158,7 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          allowed_bots: claude
           additional_permissions: |
             actions: read
           prompt: |
@@ -235,6 +237,7 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          allowed_bots: claude
           additional_permissions: |
             actions: read
           prompt: |
@@ -305,6 +308,7 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          allowed_bots: claude
           additional_permissions: |
             actions: read
           prompt: |
@@ -388,6 +392,7 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          allowed_bots: claude
           prompt: |
             You are the DEEP VERDICT SYNTHESIZER for Major Tom.
 


### PR DESCRIPTION
## Summary

- Adds `allowed_bots: claude` to all 5 `anthropics/claude-code-action@v1` blocks in `.github/workflows/claude-deep-review.yml` (Security / Architecture / Correctness / Threat Model / Deep verdict synth).
- Unblocks Tier 3 auto-escalation: when Tier 2's synth adds the `claude-deep-review` label (e.g. on a >500-line PR), the deep workflow is dispatched under the `claude[bot]` actor and currently fails every job with `Workflow initiated by non-human actor: claude`. With the guard widened, the GitHub App identity we already trust can trigger the run.
- Scoped to Tier 3 only — Tier 2 auto-fires on `pull_request: opened` / `ready_for_review` (human actor) and round-2+ are `workflow_dispatch` from a human OAuth token, so the bot guard never trips there.
- Picks `claude` (not `'*'`) so a future misconfigured bot can't trigger costly deep-review runs.

Spec: [`docs/REVIEW-WORKFLOW-BOT-GUARD.md`](../blob/main/docs/REVIEW-WORKFLOW-BOT-GUARD.md).

## Test plan

- [x] YAML parses (`python3 -c "import yaml; yaml.safe_load(open('.github/workflows/claude-deep-review.yml'))"`)
- [x] `grep "allowed_bots: claude" .github/workflows/claude-deep-review.yml` returns 5 hits
- [x] Diff is 5 single-line additions, all at the same 10-space indent as sibling `with:` keys
- [ ] **Real verification:** next PR that auto-escalates to Tier 3 (>500 lines or other escalation trigger) runs through to a `<!-- MT-DEEP-VERDICT-STICKY -->` instead of failing on the bot guard. `workflow_dispatch` is human-initiated so it bypasses the guard — only an organic escalation proves the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
