### PR TITLE
fix(ios): make inspector more/less toggle actually expand text (#15)

### DIFF
--- a/ios/MajorTom/Features/Office/Views/SpriteInspectorView.swift
+++ b/ios/MajorTom/Features/Office/Views/SpriteInspectorView.swift
@@ -30,6 +30,10 @@ struct SpriteInspectorView: View {
     @State private var draft: String = ""
     @State private var responseExpanded: Bool = false
     @State private var questionExpanded: Bool = false
+    /// Sheet detent. The "More" toggles snap this to `.large` so the inspector
+    /// actually has room to show the full payload — at `.medium` the content
+    /// area is too tight for `.lineLimit(nil)` to grow visibly.
+    @State private var selectedDetent: PresentationDetent = .medium
     @State private var spriteScene: InspectorSpriteScene?
 
     /// Transient "agent completed" banner shown for ~2.5s when a linked agent
@@ -107,7 +111,7 @@ struct SpriteInspectorView: View {
         }
         .padding(MajorTomTheme.Spacing.lg)
         .background(MajorTomTheme.Colors.surface)
-        .presentationDetents([.medium, .large])
+        .presentationDetents([.medium, .large], selection: $selectedDetent)
         .presentationDragIndicator(.visible)
         .onAppear {
             // Mark any unread response as read (clears green glow on sprite)
@@ -128,6 +132,7 @@ struct SpriteInspectorView: View {
             draft = ""
             responseExpanded = false
             questionExpanded = false
+            selectedDetent = .medium
         }
         // Scenario 9 downgrade — was linked at tap, now idle.
         .onChange(of: currentAgent.linkedSubagentId) { oldValue, newValue in
@@ -416,16 +421,30 @@ struct SpriteInspectorView: View {
                 Spacer()
                 if question.count > 140 {
                     Button(questionExpanded ? "Less" : "More") {
-                        questionExpanded.toggle()
+                        withAnimation(.easeInOut(duration: 0.2)) {
+                            questionExpanded.toggle()
+                            if questionExpanded { selectedDetent = .large }
+                        }
                     }
                     .font(MajorTomTheme.Typography.caption)
                     .foregroundStyle(MajorTomTheme.Colors.accent)
                 }
             }
-            Text(question)
-                .font(MajorTomTheme.Typography.codeFontSmall)
-                .foregroundStyle(MajorTomTheme.Colors.textSecondary)
-                .lineLimit(questionExpanded ? nil : 3)
+            if questionExpanded {
+                ScrollView(.vertical, showsIndicators: true) {
+                    Text(question)
+                        .font(MajorTomTheme.Typography.codeFontSmall)
+                        .foregroundStyle(MajorTomTheme.Colors.textSecondary)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                }
+                .frame(maxHeight: 200)
+            } else {
+                Text(question)
+                    .font(MajorTomTheme.Typography.codeFontSmall)
+                    .foregroundStyle(MajorTomTheme.Colors.textSecondary)
+                    .lineLimit(3)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
         }
         .padding(MajorTomTheme.Spacing.sm)
         .background(MajorTomTheme.Colors.background)
@@ -444,16 +463,30 @@ struct SpriteInspectorView: View {
                 Spacer()
                 if response.count > 200 {
                     Button(responseExpanded ? "Less" : "More") {
-                        responseExpanded.toggle()
+                        withAnimation(.easeInOut(duration: 0.2)) {
+                            responseExpanded.toggle()
+                            if responseExpanded { selectedDetent = .large }
+                        }
                     }
                     .font(MajorTomTheme.Typography.caption)
                     .foregroundStyle(MajorTomTheme.Colors.accent)
                 }
             }
-            Text(response)
-                .font(MajorTomTheme.Typography.body)
-                .foregroundStyle(MajorTomTheme.Colors.textPrimary)
-                .lineLimit(responseExpanded ? nil : 6)
+            if responseExpanded {
+                ScrollView(.vertical, showsIndicators: true) {
+                    Text(response)
+                        .font(MajorTomTheme.Typography.body)
+                        .foregroundStyle(MajorTomTheme.Colors.textPrimary)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                }
+                .frame(maxHeight: 360)
+            } else {
+                Text(response)
+                    .font(MajorTomTheme.Typography.body)
+                    .foregroundStyle(MajorTomTheme.Colors.textPrimary)
+                    .lineLimit(6)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
         }
         .padding(MajorTomTheme.Spacing.sm)
         .background(MajorTomTheme.Colors.allow.opacity(0.08))


### PR DESCRIPTION
## Summary
- The /btw inspector's `More`/`Less` toggle was a no-op: the `@State responseExpanded` flag did flip and `.lineLimit(responseExpanded ? nil : 6)` re-applied, but the sheet was stuck at `.medium` where the content area is too tight for `.lineLimit(nil)` to visibly grow — the parent VStack's `Spacer` absorbed any extra room.
- Fix: bind the sheet detent to `selectedDetent` state, snap it to `.large` when the user taps `More`, and replace the in-place `.lineLimit(nil)` path with a bounded `ScrollView` so very long payloads stay reachable. Collapsed state keeps the existing truncation. Same treatment applied to the `pendingQuestionView` toggle (same bug, same shape).
- Detent resets to `.medium` alongside the existing draft/expansion resets when the sprite switches under the inspector.

Resolves QA-FIXES #15 (`docs/QA-FIXES.md` §15).

## Test plan
- [x] Build green via XcodeBuildMCP (verified locally, 0 warnings)
- [ ] Device QA: tap a working PTY subagent, send a long `/btw` prompt, wait for response, tap `More` — sheet snaps to `.large` and text expands (scrollable for very long responses).
- [ ] Device QA: tap `Less` — response re-truncates; sheet stays at `.large` so user can still see the actions row without re-dragging.
- [ ] Device QA: close and reopen inspector — starts fresh at `.medium` with truncated text.
- [ ] Device QA: while inspector open, tap a different sprite (scenario #2) — detent resets to `.medium` alongside other resets.
- [ ] Device QA: question side — pending state with a long `/btw` prompt — `More` on the question chip expands the same way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
