### PR TITLE
feat(pairing): wave 1 — mDNS discovery + pre-flight ping

### DIFF
--- a/docs/PHASE-PAIRING-REBOOT.md
+++ b/docs/PHASE-PAIRING-REBOOT.md
@@ -1,0 +1,50 @@
+# Phase — Pairing Reboot
+
+Sean's pairing UX has a hardcoded LAN IP (`PairingView.swift:8 — case lan = "192.168.1.210:9090"`). When his Mac's DHCP lease drifts (last seen `.210 → .254`), the "auto-recommended" LAN chip points at a dead IP, the app shows a generic "Connection failed" with no actionable signal, and the user has to either guess the new IP, fall back to Tailscale, or type it manually. This is a 100%-of-the-time blocker every time DHCP renews.
+
+Root cause: PR #166 wired `NetworkPathMonitor` correctly but mapped reachability → a frozen string literal. There is no live discovery and no reachability probing of saved URLs.
+
+## Scope
+
+Replace the hardcoded LAN constant with live mDNS/Bonjour discovery. Probe URLs before saving them. Surface real errors instead of "Connection failed".
+
+## Waves
+
+### Wave 1 — mDNS discovery + pre-flight ping (this PR)
+
+**Relay**
+- Add `bonjour-service` (v1.3.0) dep. Advertise `_majortom._tcp.local.` on `PORT` at startup. Cleanup on shutdown.
+- Service `txt` record exposes basic metadata: `version`, `protocol` ("ws"), `auth` ("pin,google").
+
+**iOS**
+- New `Core/Services/BonjourBrowser.swift` using `NWBrowser` (iOS 17+) browsing `_majortom._tcp`. Resolves found endpoints to `host:port` strings.
+- `Info.plist`: add `NSLocalNetworkUsageDescription` ("Major Tom uses local network discovery to find your relay automatically") and `NSBonjourServices` array with `_majortom._tcp`.
+- `ServerPreset` enum: **drop the hardcoded `.lan` case**. Discovered services become a NEW chip group rendered above the static fallback chips (tailscale, cloudflare, localhost).
+- `PairingViewModel.applyInitialRecommendationIfNeeded`: prefers a discovered service over `NetworkPathMonitor`'s `recommendedPreset`.
+- `submitPIN` and chip-tap: **pre-flight `/auth/methods` ping** before saving the URL. If unreachable, set `authState = .error("Server unreachable at <URL>")` instead of attempting the PIN exchange.
+
+### Wave 2 — provenance + tunnel discovery (deferred)
+
+- `GET /api/discovery` on relay returns live `lan` / `tailscale` URLs from `os.networkInterfaces()` for clients connected via the stable tunnel.
+- Track URL provenance (user-typed vs discovered vs auto) so we know which we can safely re-resolve.
+- Auto-clear stale stored URLs on app foreground when pre-flight ping fails.
+
+### Wave 3 — UX polish (deferred)
+
+- Chip labels show RTT from pre-flight ping.
+- "Recently used" history with last-known reachability.
+- Manual override flagged with a 🔒 lock icon to prevent surprise overwrites.
+
+## Success criteria (Wave 1)
+
+- User opens MajorTom on a fresh phone, on the same Wi-Fi as the relay → a chip labeled "📡 Local (<mDNS name>)" appears within 2s, tapping it auto-fills the URL and verifies reachability.
+- DHCP renewal between sessions does NOT break re-pairing — mDNS resolves to the current IP every time.
+- When the relay is down or unreachable, the user sees "Server unreachable at <URL>" — not "Connection failed". When the URL is reachable but the PIN is wrong, the existing PIN-error path stays.
+- Tailscale / Cloudflare tunnel chips remain available as manual fallbacks for off-LAN access.
+
+## Non-goals (Wave 1)
+
+- No mDNS cross-subnet (it's link-local by design — cellular falls back to tunnel).
+- No relay-side `/api/discovery` endpoint (Wave 2).
+- No `tunnel:setup`/cloudflared changes.
+- No PWA changes — PWA discovery is handled by `window.location` already.

--- a/ios/MajorTom.xcodeproj/project.pbxproj
+++ b/ios/MajorTom.xcodeproj/project.pbxproj
@@ -55,6 +55,7 @@
 		3C07EFEF4D80196CACF66B4F /* RelayService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EF58FBAC8341407F9E3E7A0 /* RelayService.swift */; };
 		9A1B2C3D4E5F60718293ABCD /* TabTitleStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A1B2C3D4E5F60718293BCDE /* TabTitleStore.swift */; };
 		BB21AA01CD8C672445BE8C70 /* NetworkPathMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB21AA00CD8C672445BE8C71 /* NetworkPathMonitor.swift */; };
+		BB21AA02CD8C672445BE8C72 /* BonjourBrowser.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB21AA03CD8C672445BE8C73 /* BonjourBrowser.swift */; };
 		3DC3F97C0E915D4328BA3D23 /* xterm-addon-fit.min.js in Resources */ = {isa = PBXBuildFile; fileRef = 70D288C1139CE55F81CA6B84 /* xterm-addon-fit.min.js */; };
 		3EBF323994DDFA263A66D119 /* FleetViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C243979CB87B28424C0EC73 /* FleetViewModel.swift */; };
 		3F2C8C3720ABDE4346DD4010 /* PhoneWatchConnectivityService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28F93EA76007AD19338D6B61 /* PhoneWatchConnectivityService.swift */; };
@@ -323,6 +324,7 @@
 		6EF58FBAC8341407F9E3E7A0 /* RelayService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RelayService.swift; sourceTree = "<group>"; };
 		9A1B2C3D4E5F60718293BCDE /* TabTitleStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabTitleStore.swift; sourceTree = "<group>"; };
 		BB21AA00CD8C672445BE8C71 /* NetworkPathMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkPathMonitor.swift; sourceTree = "<group>"; };
+		BB21AA03CD8C672445BE8C73 /* BonjourBrowser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BonjourBrowser.swift; sourceTree = "<group>"; };
 		70D288C1139CE55F81CA6B84 /* xterm-addon-fit.min.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = "xterm-addon-fit.min.js"; sourceTree = "<group>"; };
 		72D88CD4F990BB00B9695888 /* ActivitySelectionEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivitySelectionEngine.swift; sourceTree = "<group>"; };
 		735C53A97B86E2331E03A4F0 /* DelayCountdownView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DelayCountdownView.swift; sourceTree = "<group>"; };
@@ -863,6 +865,7 @@
 				72E9104D85D94935AD94E196 /* FeatureFlags.swift */,
 				7794C5813F5964F288D432AD /* HapticService.swift */,
 				A9BD8A95DFAD6160FF41E83F /* KeychainService.swift */,
+				BB21AA03CD8C672445BE8C73 /* BonjourBrowser.swift */,
 				BB21AA00CD8C672445BE8C71 /* NetworkPathMonitor.swift */,
 				1972DF8FED85D9290EA3F331 /* PerfHUDPreferences.swift */,
 				28F93EA76007AD19338D6B61 /* PhoneWatchConnectivityService.swift */,
@@ -1766,6 +1769,7 @@
 				662C3BE3B2B3A7F8C42FC4AD /* DefaultWorkingDirView.swift in Sources */,
 				3C07EFEF4D80196CACF66B4F /* RelayService.swift in Sources */,
 				BB21AA01CD8C672445BE8C70 /* NetworkPathMonitor.swift in Sources */,
+				BB21AA02CD8C672445BE8C72 /* BonjourBrowser.swift in Sources */,
 				9A1B2C3D4E5F60718293ABCD /* TabTitleStore.swift in Sources */,
 				ECD4CC99C031E1B803D88C76 /* Session.swift in Sources */,
 				7800B5EFB116E5708F3A6300 /* SessionCostRankingView.swift in Sources */,

--- a/ios/MajorTom/Core/Services/AuthService.swift
+++ b/ios/MajorTom/Core/Services/AuthService.swift
@@ -66,12 +66,16 @@ final class AuthService {
     /// Prepend the right scheme when the user typed a bare hostname. iOS
     /// App Transport Security blocks plain http:// to public domains, so
     /// we default to https:// unless the address clearly points at LAN /
-    /// localhost / an IP (in which case http:// is correct for dev).
+    /// localhost / an IP / an mDNS `.local` host (in which case http://
+    /// is correct for dev and permitted by `NSAllowsLocalNetworking`).
     static func normalizeBaseURL(_ address: String) -> String {
         if address.contains("://") { return address }
         let lower = address.lowercased()
         // Explicit loopback / localhost.
         if lower == "localhost" || lower.hasPrefix("localhost:") { return "http://\(address)" }
+        // mDNS / Bonjour `.local` hosts — link-local, plain HTTP allowed.
+        let hostPart = lower.split(separator: ":").first.map(String.init) ?? lower
+        if hostPart.hasSuffix(".local") { return "http://\(address)" }
         // IPv4 pattern (optionally followed by `:port`) — LAN / dev target.
         let ipv4 = #"^\d{1,3}(\.\d{1,3}){3}(:\d+)?$"#
         if address.range(of: ipv4, options: .regularExpression) != nil {

--- a/ios/MajorTom/Core/Services/BonjourBrowser.swift
+++ b/ios/MajorTom/Core/Services/BonjourBrowser.swift
@@ -1,0 +1,134 @@
+import Foundation
+import Network
+
+/// Discovers Major Tom relay instances on the local network via Bonjour
+/// (`_majortom._tcp`). Each discovered service is resolved to a `host:port`
+/// string suitable for `AuthService.normalizeBaseURL` so the pairing UI
+/// can populate the server-address field without the user typing the
+/// Mac's LAN IP (which drifts on DHCP renewal — see PHASE-PAIRING-REBOOT).
+@Observable
+@MainActor
+final class BonjourBrowser {
+    struct DiscoveredService: Identifiable, Hashable {
+        /// Stable across appearances of the same instance — derived from
+        /// the Bonjour service name.
+        let id: String
+        /// Human-readable display name (the publisher's `name` field).
+        let displayName: String
+        /// Resolved `host:port` ready to feed into `AuthService`. Host may
+        /// be a `.local` mDNS hostname or a literal IP — both are accepted
+        /// by the system resolver on subsequent HTTP requests.
+        let address: String
+    }
+
+    private(set) var services: [DiscoveredService] = []
+    private(set) var isBrowsing = false
+
+    private var browser: NWBrowser?
+    private var resolvers: [String: NWConnection] = [:]
+
+    func start() {
+        guard browser == nil else { return }
+        let descriptor = NWBrowser.Descriptor.bonjour(type: "_majortom._tcp", domain: nil)
+        let params = NWParameters()
+        params.includePeerToPeer = false
+        let browser = NWBrowser(for: descriptor, using: params)
+
+        browser.browseResultsChangedHandler = { [weak self] results, _ in
+            Task { @MainActor [weak self] in
+                self?.handleResults(results)
+            }
+        }
+        browser.stateUpdateHandler = { [weak self] state in
+            Task { @MainActor [weak self] in
+                if case .failed = state {
+                    self?.isBrowsing = false
+                }
+            }
+        }
+        self.browser = browser
+        isBrowsing = true
+        browser.start(queue: .main)
+    }
+
+    func stop() {
+        browser?.cancel()
+        browser = nil
+        for conn in resolvers.values { conn.cancel() }
+        resolvers.removeAll()
+        services.removeAll()
+        isBrowsing = false
+    }
+
+    private func handleResults(_ results: Set<NWBrowser.Result>) {
+        let activeNames = Set(results.compactMap(Self.serviceName(from:)))
+
+        // Drop services that no longer appear in the browse results.
+        services.removeAll { !activeNames.contains($0.id) }
+        for name in Array(resolvers.keys) where !activeNames.contains(name) {
+            resolvers[name]?.cancel()
+            resolvers.removeValue(forKey: name)
+        }
+
+        // Resolve newly-seen services.
+        for result in results {
+            guard let name = Self.serviceName(from: result) else { continue }
+            if services.contains(where: { $0.id == name }) { continue }
+            if resolvers[name] != nil { continue }
+            startResolve(for: result, name: name)
+        }
+    }
+
+    private func startResolve(for result: NWBrowser.Result, name: String) {
+        let params = NWParameters.tcp
+        params.prohibitedInterfaceTypes = [.cellular]
+        let conn = NWConnection(to: result.endpoint, using: params)
+        resolvers[name] = conn
+
+        conn.stateUpdateHandler = { [weak self] state in
+            Task { @MainActor [weak self] in
+                guard let self else { return }
+                switch state {
+                case .ready:
+                    if let address = Self.address(from: conn.currentPath?.remoteEndpoint) {
+                        let entry = DiscoveredService(id: name, displayName: name, address: address)
+                        if !self.services.contains(entry) {
+                            self.services.append(entry)
+                        }
+                    }
+                    conn.cancel()
+                    self.resolvers.removeValue(forKey: name)
+                case .failed, .cancelled:
+                    self.resolvers.removeValue(forKey: name)
+                default:
+                    break
+                }
+            }
+        }
+        conn.start(queue: .main)
+    }
+
+    private static func serviceName(from result: NWBrowser.Result) -> String? {
+        if case .service(let name, _, _, _) = result.endpoint { return name }
+        return nil
+    }
+
+    /// Convert an NWEndpoint's resolved peer to a "host:port" string
+    /// suitable for `AuthService.normalizeBaseURL`. Hostnames are
+    /// preferred over raw IPs so the value survives DHCP renewals.
+    private static func address(from endpoint: NWEndpoint?) -> String? {
+        guard case .hostPort(let host, let port) = endpoint else { return nil }
+        let hostString: String
+        switch host {
+        case .name(let name, _):
+            hostString = name
+        case .ipv4(let ip):
+            hostString = "\(ip)"
+        case .ipv6(let ip):
+            hostString = "[\(ip)]"
+        @unknown default:
+            return nil
+        }
+        return "\(hostString):\(port.rawValue)"
+    }
+}

--- a/ios/MajorTom/Core/Services/BonjourBrowser.swift
+++ b/ios/MajorTom/Core/Services/BonjourBrowser.swift
@@ -24,6 +24,13 @@ final class BonjourBrowser {
     private(set) var services: [DiscoveredService] = []
     private(set) var isBrowsing = false
 
+    /// Cap on concurrent resolvers + emitted services. A hostile peer on
+    /// the LAN can flood the multicast group with unique `_majortom._tcp`
+    /// names; without a cap each name opens an `NWConnection` and a chip
+    /// row, eventually pressuring layout + fd state. 16 is plenty for any
+    /// realistic deployment (home LAN typically has 1, lab setups <5).
+    private static let maxServices = 16
+
     private var browser: NWBrowser?
     private var resolvers: [String: NWConnection] = [:]
 
@@ -70,11 +77,13 @@ final class BonjourBrowser {
             resolvers.removeValue(forKey: name)
         }
 
-        // Resolve newly-seen services.
+        // Resolve newly-seen services, bounded by `maxServices` so
+        // multicast flood from a hostile peer can't grow the chip list.
         for result in results {
             guard let name = Self.serviceName(from: result) else { continue }
             if services.contains(where: { $0.id == name }) { continue }
             if resolvers[name] != nil { continue }
+            if services.count + resolvers.count >= Self.maxServices { break }
             startResolve(for: result, name: name)
         }
     }
@@ -116,6 +125,9 @@ final class BonjourBrowser {
     /// Convert an NWEndpoint's resolved peer to a "host:port" string
     /// suitable for `AuthService.normalizeBaseURL`. Hostnames are
     /// preferred over raw IPs so the value survives DHCP renewals.
+    /// Link-local IPv6 with a zone identifier (`fe80::1%en0`) is
+    /// intentionally skipped — the percent sign breaks `URL(string:)`
+    /// and the `.name` / `.ipv4` branches dominate Bonjour resolution.
     private static func address(from endpoint: NWEndpoint?) -> String? {
         guard case .hostPort(let host, let port) = endpoint else { return nil }
         let hostString: String
@@ -124,8 +136,8 @@ final class BonjourBrowser {
             hostString = name
         case .ipv4(let ip):
             hostString = "\(ip)"
-        case .ipv6(let ip):
-            hostString = "[\(ip)]"
+        case .ipv6:
+            return nil
         @unknown default:
             return nil
         }

--- a/ios/MajorTom/Features/Pairing/ViewModels/PairingViewModel.swift
+++ b/ios/MajorTom/Features/Pairing/ViewModels/PairingViewModel.swift
@@ -8,12 +8,14 @@ final class PairingViewModel {
     var authMethods: AuthMethods?
     var isFetchingMethods = false
     let network: NetworkPathMonitor
+    let browser: BonjourBrowser
 
     private let auth: AuthService
 
-    init(auth: AuthService, network: NetworkPathMonitor? = nil) {
+    init(auth: AuthService, network: NetworkPathMonitor? = nil, browser: BonjourBrowser? = nil) {
         self.auth = auth
         self.network = network ?? NetworkPathMonitor()
+        self.browser = browser ?? BonjourBrowser()
         self.serverAddress = auth.serverURL
     }
 
@@ -41,6 +43,13 @@ final class PairingViewModel {
         return methods.pin || methods.google
     }
 
+    /// Live list of relays discovered on the local network via Bonjour
+    /// (`_majortom._tcp`). Empty when offline, browsing hasn't started,
+    /// or local-network permission has been denied.
+    var discoveredServices: [BonjourBrowser.DiscoveredService] {
+        browser.services
+    }
+
     /// Single preset matched to the phone's current reachability — `nil`
     /// when offline or before the path monitor has fired its first update.
     var recommendedPreset: ServerPreset? {
@@ -50,18 +59,27 @@ final class PairingViewModel {
     /// Apply the auto-picked URL and refetch auth methods.
     func useRecommended() async {
         guard let preset = recommendedPreset else { return }
-        serverAddress = preset.address
-        await fetchAuthMethods()
+        await applyAddress(preset.address)
+    }
+
+    /// Apply a Bonjour-discovered relay and refetch auth methods.
+    func useDiscovered(_ service: BonjourBrowser.DiscoveredService) async {
+        await applyAddress(service.address)
     }
 
     /// On first appear, if the user has no saved server URL, seed the field
-    /// with whatever the path monitor is currently recommending. Subsequent
-    /// reachability changes do NOT auto-overwrite — the user can tap the
-    /// recommendation chip to refresh on demand.
+    /// with the first discovered service if one exists, falling back to the
+    /// path monitor's recommendation. Subsequent reachability changes do
+    /// NOT auto-overwrite — the user can tap a chip to refresh on demand.
     func applyInitialRecommendationIfNeeded() {
         guard serverAddress.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
-        guard let preset = recommendedPreset else { return }
-        serverAddress = preset.address
+        if let discovered = discoveredServices.first {
+            serverAddress = discovered.address
+            return
+        }
+        if let preset = recommendedPreset {
+            serverAddress = preset.address
+        }
     }
 
     /// Fetch auth methods from the relay to adapt the login UI.
@@ -90,6 +108,15 @@ final class PairingViewModel {
         let trimmed = serverAddress.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return }
 
+        // Pre-flight reachability ping — turns silent "Connection failed" into
+        // a specific "Server unreachable at <URL>" so the user knows whether
+        // to fix the URL or the PIN.
+        if !(await reachable(trimmed)) {
+            auth.authState = .error("Server unreachable at \(trimmed). Pick a different relay or check your network.")
+            HapticService.deny()
+            return
+        }
+
         auth.saveServerURL(trimmed)
         await auth.pair(pin: pin)
 
@@ -115,5 +142,28 @@ final class PairingViewModel {
 
     func clearPIN() {
         pin = ""
+    }
+
+    // MARK: - Helpers
+
+    private func applyAddress(_ address: String) async {
+        serverAddress = address
+        await fetchAuthMethods()
+    }
+
+    /// 2-second HEAD/GET probe against `/auth/methods`. Treats any
+    /// 2xx-or-4xx response as "reachable" (a 401/403 still proves the
+    /// server is alive) — only transport errors mean unreachable.
+    private func reachable(_ address: String) async -> Bool {
+        let baseURL = AuthService.normalizeBaseURL(address)
+        guard let url = URL(string: "\(baseURL)/auth/methods") else { return false }
+        var request = URLRequest(url: url)
+        request.timeoutInterval = 2.0
+        do {
+            let (_, response) = try await URLSession.shared.data(for: request)
+            return (response as? HTTPURLResponse)?.statusCode != nil
+        } catch {
+            return false
+        }
     }
 }

--- a/ios/MajorTom/Features/Pairing/ViewModels/PairingViewModel.swift
+++ b/ios/MajorTom/Features/Pairing/ViewModels/PairingViewModel.swift
@@ -7,10 +7,10 @@ final class PairingViewModel {
     var serverAddress: String = ""
     var authMethods: AuthMethods?
     var isFetchingMethods = false
-    let network: NetworkPathMonitor
-    let browser: BonjourBrowser
 
     private let auth: AuthService
+    private let network: NetworkPathMonitor
+    private let browser: BonjourBrowser
 
     init(auth: AuthService, network: NetworkPathMonitor? = nil, browser: BonjourBrowser? = nil) {
         self.auth = auth
@@ -48,6 +48,25 @@ final class PairingViewModel {
     /// or local-network permission has been denied.
     var discoveredServices: [BonjourBrowser.DiscoveredService] {
         browser.services
+    }
+
+    /// Whether Bonjour discovery is actively browsing (`false` after
+    /// stop or permission denial).
+    var isBrowsing: Bool {
+        browser.isBrowsing
+    }
+
+    /// Start mDNS discovery. Idempotent — safe to call repeatedly on
+    /// view appear. Wraps the Bonjour service to preserve MVVM so the
+    /// view doesn't reach into the discovery service directly.
+    func startDiscovery() {
+        browser.start()
+    }
+
+    /// Stop mDNS discovery and tear down active resolvers. Called on
+    /// view disappear.
+    func stopDiscovery() {
+        browser.stop()
     }
 
     /// Single preset matched to the phone's current reachability — `nil`
@@ -148,12 +167,21 @@ final class PairingViewModel {
 
     private func applyAddress(_ address: String) async {
         serverAddress = address
+        // Surface "Server unreachable at <URL>" on chip-tap the same way
+        // submitPIN does — keeps the spec's targeted error path consistent
+        // whether the user reaches the relay via chip or PIN submit.
+        if !(await reachable(address)) {
+            auth.authState = .error("Server unreachable at \(address). Pick a different relay or check your network.")
+            return
+        }
         await fetchAuthMethods()
     }
 
-    /// 2-second HEAD/GET probe against `/auth/methods`. Treats any
-    /// 2xx-or-4xx response as "reachable" (a 401/403 still proves the
-    /// server is alive) — only transport errors mean unreachable.
+    /// 2-second probe against `/auth/methods`. Returns `true` for any
+    /// HTTP response (including 4xx/5xx) — only transport errors mean
+    /// unreachable. A reachable-but-broken server still gets the user
+    /// past the targeted "Server unreachable at <URL>" message into the
+    /// PIN-exchange path where downstream errors carry more detail.
     private func reachable(_ address: String) async -> Bool {
         let baseURL = AuthService.normalizeBaseURL(address)
         guard let url = URL(string: "\(baseURL)/auth/methods") else { return false }
@@ -161,7 +189,7 @@ final class PairingViewModel {
         request.timeoutInterval = 2.0
         do {
             let (_, response) = try await URLSession.shared.data(for: request)
-            return (response as? HTTPURLResponse)?.statusCode != nil
+            return response is HTTPURLResponse
         } catch {
             return false
         }

--- a/ios/MajorTom/Features/Pairing/Views/PairingView.swift
+++ b/ios/MajorTom/Features/Pairing/Views/PairingView.swift
@@ -5,7 +5,6 @@ import SwiftUI
 enum ServerPreset: String {
     case cloudflare = "majortom.seantokuzodevtunnel.space"
     case tailscale  = "100.69.151.117:9090"
-    case lan        = "192.168.1.210:9090"
     case localhost   = "localhost:9090"
 
     var address: String { rawValue }
@@ -14,7 +13,6 @@ enum ServerPreset: String {
         switch self {
         case .cloudflare: return "☁️ Tunnel"
         case .tailscale:  return "🔒 Tailscale"
-        case .lan:        return "📡 LAN"
         case .localhost:   return "💻 Local"
         }
     }
@@ -22,10 +20,12 @@ enum ServerPreset: String {
     /// Single preset for the device's current reachability. Tailscale
     /// (or any VPN presenting as `.other`) wins over LAN; cellular-only
     /// falls back to the public Cloudflare tunnel; offline returns nil.
+    /// LAN is intentionally NOT a preset — it's served by Bonjour
+    /// discovery in the pairing view, since the Mac's LAN IP drifts.
     init?(reachability: NetworkPathMonitor.Reachability) {
         switch reachability {
         case .tailscale: self = .tailscale
-        case .lan:       self = .lan
+        case .lan:       return nil
         case .cellular:  self = .cloudflare
         case .offline:   return nil
         }
@@ -85,10 +85,13 @@ struct PairingView: View {
                         Task { await viewModel.fetchAuthMethods() }
                     }
 
-                // QA-FIXES #21: auto-pick a single relay URL based on
-                // the phone's network state. Tailscale wins over LAN
-                // (stable hostname, immune to LAN-IP drift); cellular-
-                // only falls back to the public Cloudflare tunnel.
+                // Bonjour-discovered chips (live local-network relays)
+                // sit above the static fallback so the user sees the
+                // current LAN target without typing the Mac's IP.
+                discoveredChips
+
+                // Static fallback presets (tunnel, Tailscale, localhost)
+                // for off-LAN access — LAN itself comes from Bonjour above.
                 recommendationChip
                     .frame(maxWidth: .infinity, alignment: .center)
             }
@@ -149,11 +152,66 @@ struct PairingView: View {
         .background(MajorTomTheme.Colors.background)
         .animation(.easeInOut(duration: 0.2), value: viewModel.authState)
         .task {
-            // Seed an empty server field with whatever the path monitor
-            // recommends, then fetch auth methods. The seeding is one-shot
-            // so reachability flips don't fight a user-typed override.
+            // Start Bonjour discovery for live local-network relays.
+            viewModel.browser.start()
+            // Seed an empty server field — prefers a discovered service if
+            // one's already known, falls back to the path monitor's
+            // recommendation. One-shot so reachability flips don't fight a
+            // user-typed override.
             viewModel.applyInitialRecommendationIfNeeded()
             await viewModel.fetchAuthMethods()
+        }
+        .onDisappear {
+            viewModel.browser.stop()
+        }
+    }
+
+    @ViewBuilder
+    private var discoveredChips: some View {
+        if !viewModel.discoveredServices.isEmpty {
+            VStack(spacing: 6) {
+                Text("Found on your network")
+                    .font(.system(.caption2, design: .monospaced))
+                    .foregroundStyle(MajorTomTheme.Colors.textTertiary)
+                ScrollView(.horizontal, showsIndicators: false) {
+                    HStack(spacing: 6) {
+                        ForEach(viewModel.discoveredServices) { service in
+                            Button {
+                                HapticService.impact(.light)
+                                Task { await viewModel.useDiscovered(service) }
+                            } label: {
+                                HStack(spacing: 4) {
+                                    Image(systemName: "wifi")
+                                        .font(.system(size: 10))
+                                    Text(service.displayName)
+                                        .font(.system(.caption2, design: .monospaced))
+                                        .lineLimit(1)
+                                }
+                                .foregroundStyle(
+                                    viewModel.serverAddress == service.address
+                                        ? MajorTomTheme.Colors.background
+                                        : MajorTomTheme.Colors.textSecondary
+                                )
+                                .padding(.horizontal, MajorTomTheme.Spacing.sm)
+                                .padding(.vertical, 4)
+                                .background(
+                                    viewModel.serverAddress == service.address
+                                        ? MajorTomTheme.Colors.accent
+                                        : MajorTomTheme.Colors.surfaceElevated
+                                )
+                                .clipShape(Capsule())
+                            }
+                        }
+                    }
+                }
+            }
+        } else if viewModel.browser.isBrowsing {
+            HStack(spacing: 6) {
+                ProgressView().scaleEffect(0.6)
+                Text("Looking for relay on your network...")
+                    .font(.system(.caption2, design: .monospaced))
+                    .foregroundStyle(MajorTomTheme.Colors.textTertiary)
+            }
         }
     }
 

--- a/ios/MajorTom/Features/Pairing/Views/PairingView.swift
+++ b/ios/MajorTom/Features/Pairing/Views/PairingView.swift
@@ -153,7 +153,7 @@ struct PairingView: View {
         .animation(.easeInOut(duration: 0.2), value: viewModel.authState)
         .task {
             // Start Bonjour discovery for live local-network relays.
-            viewModel.browser.start()
+            viewModel.startDiscovery()
             // Seed an empty server field — prefers a discovered service if
             // one's already known, falls back to the path monitor's
             // recommendation. One-shot so reachability flips don't fight a
@@ -162,7 +162,7 @@ struct PairingView: View {
             await viewModel.fetchAuthMethods()
         }
         .onDisappear {
-            viewModel.browser.stop()
+            viewModel.stopDiscovery()
         }
     }
 
@@ -180,12 +180,23 @@ struct PairingView: View {
                                 HapticService.impact(.light)
                                 Task { await viewModel.useDiscovered(service) }
                             } label: {
-                                HStack(spacing: 4) {
-                                    Image(systemName: "wifi")
-                                        .font(.system(size: 10))
-                                    Text(service.displayName)
-                                        .font(.system(.caption2, design: .monospaced))
+                                VStack(alignment: .leading, spacing: 1) {
+                                    HStack(spacing: 4) {
+                                        Image(systemName: "wifi")
+                                            .font(.system(size: 10))
+                                        Text(service.displayName)
+                                            .font(.system(.caption2, design: .monospaced))
+                                            .lineLimit(1)
+                                    }
+                                    // Surface the resolved address as a
+                                    // second line so the user can spot
+                                    // lookalike chips from a hostile peer
+                                    // (Bonjour names are attacker-controlled
+                                    // — see PHASE-PAIRING-REBOOT Wave 2).
+                                    Text(service.address)
+                                        .font(.system(size: 9, design: .monospaced))
                                         .lineLimit(1)
+                                        .opacity(0.75)
                                 }
                                 .foregroundStyle(
                                     viewModel.serverAddress == service.address
@@ -205,7 +216,7 @@ struct PairingView: View {
                     }
                 }
             }
-        } else if viewModel.browser.isBrowsing {
+        } else if viewModel.isBrowsing {
             HStack(spacing: 6) {
                 ProgressView().scaleEffect(0.6)
                 Text("Looking for relay on your network...")

--- a/ios/MajorTom/Info.plist
+++ b/ios/MajorTom/Info.plist
@@ -9,6 +9,12 @@
 		<key>NSAllowsArbitraryLoads</key>
 		<true/>
 	</dict>
+	<key>NSLocalNetworkUsageDescription</key>
+	<string>Major Tom discovers your relay server on the local network so you don't have to type its IP address.</string>
+	<key>NSBonjourServices</key>
+	<array>
+		<string>_majortom._tcp</string>
+	</array>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>

--- a/relay/package-lock.json
+++ b/relay/package-lock.json
@@ -16,6 +16,7 @@
         "@fastify/rate-limit": "^10.3.0",
         "@fastify/static": "^9.0.0",
         "@fastify/websocket": "^11.2.0",
+        "bonjour-service": "^1.3.0",
         "fastify": "^5.8.2",
         "fastify-plugin": "^5.1.0",
         "jose": "^6.2.2",
@@ -91,31 +92,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@emnapi/core": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
-      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
-      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -1170,6 +1146,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@leichtgewicht/ip-codec": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.5.tgz",
+      "integrity": "sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw==",
+      "license": "MIT"
+    },
     "node_modules/@lukeed/ms": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@lukeed/ms/-/ms-2.0.2.tgz",
@@ -1828,6 +1810,16 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/bonjour-service": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/bonjour-service/-/bonjour-service-1.3.0.tgz",
+      "integrity": "sha512-3YuAUiSkWykd+2Azjgyxei8OWf8thdn8AITIog2M4UICzoqfjlqr64WIjEXZllf/W6vK1goqleSR6brGomxQqA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "multicast-dns": "^7.2.5"
+      }
+    },
     "node_modules/brace-expansion": {
       "version": "5.0.5",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
@@ -2019,6 +2011,18 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/dns-packet": {
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-5.6.1.tgz",
+      "integrity": "sha512-l4gcSouhcgIKRvyy99RNVOgxXiicE+2jZoNmaNmZ6JXiGajBOJAesk1OBlJuM5k2c+eudGdLxDqXuPCKIj6kpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@leichtgewicht/ip-codec": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/dunder-proto": {
@@ -3217,6 +3221,19 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
+    "node_modules/multicast-dns": {
+      "version": "7.2.5",
+      "resolved": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-7.2.5.tgz",
+      "integrity": "sha512-2eznPJP8z2BFLX50tf0LuODrpINqP1RVIm/CObbTcBRITQgmC/TjcREF1NeTBzIcR5XO/ukWo+YHOjBbFwIupg==",
+      "license": "MIT",
+      "dependencies": {
+        "dns-packet": "^5.2.2",
+        "thunky": "^1.0.2"
+      },
+      "bin": {
+        "multicast-dns": "cli.js"
+      }
+    },
     "node_modules/nanoid": {
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
@@ -3990,6 +4007,12 @@
         "node": ">=20"
       }
     },
+    "node_modules/thunky": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/thunky/-/thunky-1.1.0.tgz",
+      "integrity": "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==",
+      "license": "MIT"
+    },
     "node_modules/tinybench": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
@@ -4686,50 +4709,6 @@
         "vite": {
           "optional": true
         }
-      }
-    },
-    "node_modules/vitest/node_modules/esbuild": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
-      "integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "esbuild": "bin/esbuild"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.28.0",
-        "@esbuild/android-arm": "0.28.0",
-        "@esbuild/android-arm64": "0.28.0",
-        "@esbuild/android-x64": "0.28.0",
-        "@esbuild/darwin-arm64": "0.28.0",
-        "@esbuild/darwin-x64": "0.28.0",
-        "@esbuild/freebsd-arm64": "0.28.0",
-        "@esbuild/freebsd-x64": "0.28.0",
-        "@esbuild/linux-arm": "0.28.0",
-        "@esbuild/linux-arm64": "0.28.0",
-        "@esbuild/linux-ia32": "0.28.0",
-        "@esbuild/linux-loong64": "0.28.0",
-        "@esbuild/linux-mips64el": "0.28.0",
-        "@esbuild/linux-ppc64": "0.28.0",
-        "@esbuild/linux-riscv64": "0.28.0",
-        "@esbuild/linux-s390x": "0.28.0",
-        "@esbuild/linux-x64": "0.28.0",
-        "@esbuild/netbsd-arm64": "0.28.0",
-        "@esbuild/netbsd-x64": "0.28.0",
-        "@esbuild/openbsd-arm64": "0.28.0",
-        "@esbuild/openbsd-x64": "0.28.0",
-        "@esbuild/openharmony-arm64": "0.28.0",
-        "@esbuild/sunos-x64": "0.28.0",
-        "@esbuild/win32-arm64": "0.28.0",
-        "@esbuild/win32-ia32": "0.28.0",
-        "@esbuild/win32-x64": "0.28.0"
       }
     },
     "node_modules/vitest/node_modules/vite": {

--- a/relay/package-lock.json
+++ b/relay/package-lock.json
@@ -39,9 +39,9 @@
       }
     },
     "node_modules/@anthropic-ai/claude-agent-sdk": {
-      "version": "0.2.107",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.2.107.tgz",
-      "integrity": "sha512-zH5CCjvFn4A+RN0LLaqKJYEcGEg2O/Bm+tDpkBGcEKaRZOqwXkKJ2d9JmboALGSxsCAN5K0+uQxPgzk9LhiQzg==",
+      "version": "0.2.139",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.2.139.tgz",
+      "integrity": "sha512-9zmitYoxCQiQZsTUbm9IGC6VyZt70J3NLtkRQPQvFVfz7bKDrhlZZKzXmyl2XmqedXEIeQy2ACmwdjwzPIVIAw==",
       "license": "SEE LICENSE IN README.md",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.81.0",
@@ -51,19 +51,122 @@
         "node": ">=18.0.0"
       },
       "optionalDependencies": {
-        "@img/sharp-darwin-arm64": "^0.34.2",
-        "@img/sharp-darwin-x64": "^0.34.2",
-        "@img/sharp-linux-arm": "^0.34.2",
-        "@img/sharp-linux-arm64": "^0.34.2",
-        "@img/sharp-linux-x64": "^0.34.2",
-        "@img/sharp-linuxmusl-arm64": "^0.34.2",
-        "@img/sharp-linuxmusl-x64": "^0.34.2",
-        "@img/sharp-win32-arm64": "^0.34.2",
-        "@img/sharp-win32-x64": "^0.34.2"
+        "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.2.139",
+        "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.2.139",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.2.139",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.2.139",
+        "@anthropic-ai/claude-agent-sdk-linux-x64": "0.2.139",
+        "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.2.139",
+        "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.2.139",
+        "@anthropic-ai/claude-agent-sdk-win32-x64": "0.2.139"
       },
       "peerDependencies": {
         "zod": "^4.0.0"
       }
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-darwin-arm64": {
+      "version": "0.2.139",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.2.139.tgz",
+      "integrity": "sha512-dnuO2E0x6o9GAk9iZZKlEd10h+0PQFdTfr5aQU4I0W+0ReKsFEoE9LAqfomS2EvLUQ9L62X0+n0iyZQmAVi1kw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-darwin-x64": {
+      "version": "0.2.139",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.2.139.tgz",
+      "integrity": "sha512-SXyldBIwpMHDXppPGObXZ1wjSSWf/YPgD6vK4nssIXarC/DtMRnAQ419Hb3q5MaBB29vSjOPKmG0MOkMltFR/A==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64": {
+      "version": "0.2.139",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.2.139.tgz",
+      "integrity": "sha512-qfnQ4SjEcq//iGAJkk25J6j4Tq+dvQe9wHks0dcaSdGOs2D96Teqrb358YJe+nke2DBKVUa9Y4ComW3aUBM29w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64-musl": {
+      "version": "0.2.139",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.2.139.tgz",
+      "integrity": "sha512-gzMfit9t7Fiy5taZ+miAaP8ZmOMc+hv8Ov3UOXGwJunK6H+0F88ctBSnolDPMPQaS6s2WoMD0o8fhUbBudtMVw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64": {
+      "version": "0.2.139",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.2.139.tgz",
+      "integrity": "sha512-2Gqy5hV/MyObbwSyNhj5ha2cY5EZnUfDLvpEwR1eeOaU1yqnxzsdNzXWgHIyWQGKGNE2ICwgLYtt6AtOJGWpPg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64-musl": {
+      "version": "0.2.139",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.2.139.tgz",
+      "integrity": "sha512-Fg/aQs1vdyqLrNXqGa1i7/ODpGxP6ud/K/2AgVarLteg2Z3ZnrHPvPQ6iQmTGI8+BhxAZ141t4Dg0CWz3CoqCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-win32-arm64": {
+      "version": "0.2.139",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.2.139.tgz",
+      "integrity": "sha512-HusAU/gSQ0G0AHU+Hj/ps0Tl5JaUF2nxkp+G42tU6hpnwLMOQMdLx/yqvSQnz4WSxggxiDFmYvMDLYAmuE9Qdg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-win32-x64": {
+      "version": "0.2.139",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.2.139.tgz",
+      "integrity": "sha512-eJjbtLvEBJcTrl4WJhmhP7FYdTVvx/XtioifH7OEnCoxQozMHhOmA0X90csplIRpttX+jX2PqnE5j2FwU20eCw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/@anthropic-ai/sdk": {
       "version": "0.81.0",
@@ -92,6 +195,31 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -779,9 +907,9 @@
       }
     },
     "node_modules/@fastify/static": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/@fastify/static/-/static-9.1.0.tgz",
-      "integrity": "sha512-EPRNQYqEYEYTK8yyGbcM0iHpyJaupb94bey5O6iCQfLTADr02kaZU+qeHSdd9H9TiMwTBVkrMa59V8CMbn3avQ==",
+      "version": "9.1.3",
+      "resolved": "https://registry.npmjs.org/@fastify/static/-/static-9.1.3.tgz",
+      "integrity": "sha512-aXrYtsiryLhRxRNaxNqsn7FUISeb7rB9q4eHUPIot5aeQBLNahnz1m6thzm7JWC1poSGXS9XrX8DvuMivp2hkQ==",
       "funding": [
         {
           "type": "github",
@@ -833,310 +961,6 @@
       },
       "peerDependencies": {
         "hono": "^4"
-      }
-    },
-    "node_modules/@img/sharp-darwin-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
-      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-darwin-arm64": "1.2.4"
-      }
-    },
-    "node_modules/@img/sharp-darwin-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
-      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-darwin-x64": "1.2.4"
-      }
-    },
-    "node_modules/@img/sharp-libvips-darwin-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
-      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-darwin-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
-      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-linux-arm": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
-      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
-      "cpu": [
-        "arm"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-linux-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
-      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-linux-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
-      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
-      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
-      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-linux-arm": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
-      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
-      "cpu": [
-        "arm"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm": "1.2.4"
-      }
-    },
-    "node_modules/@img/sharp-linux-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
-      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm64": "1.2.4"
-      }
-    },
-    "node_modules/@img/sharp-linux-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
-      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linux-x64": "1.2.4"
-      }
-    },
-    "node_modules/@img/sharp-linuxmusl-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
-      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
-      }
-    },
-    "node_modules/@img/sharp-linuxmusl-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
-      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
-      }
-    },
-    "node_modules/@img/sharp-win32-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
-      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "Apache-2.0 AND LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-win32-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
-      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "Apache-2.0 AND LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
@@ -1202,9 +1026,9 @@
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.3.tgz",
-      "integrity": "sha512-xK9sGVbJWYb08+mTJt3/YV24WxvxpXcXtP6B172paPZ+Ts69Re9dAr7lKwJoeIx8OoeuimEiRZ7umkiUVClmmQ==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
+      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -1221,9 +1045,9 @@
       }
     },
     "node_modules/@oxc-project/types": {
-      "version": "0.124.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.124.0.tgz",
-      "integrity": "sha512-VBFWMTBvHxS11Z5Lvlr3IWgrwhMTXV+Md+EQF0Xf60+wAdsGFTBx7X7K/hP4pi8N7dcm1RvcHwDxZ16Qx8keUg==",
+      "version": "0.129.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.129.0.tgz",
+      "integrity": "sha512-3oz8m3FGdr2nDXVqmFUw7jolKliC4MoyXYIG2c7gpjBnzUWQpUGIYcXYKxTdTi+N2jusvt610ckTMkxdwHkYEg==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -1237,9 +1061,9 @@
       "license": "MIT"
     },
     "node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.15.tgz",
-      "integrity": "sha512-YYe6aWruPZDtHNpwu7+qAHEMbQ/yRl6atqb/AhznLTnD3UY99Q1jE7ihLSahNWkF4EqRPVC4SiR4O0UkLK02tA==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0.tgz",
+      "integrity": "sha512-TWMZnRLMe63C2Lhyicviu7ZHaU4kxa6PS3rofvc9GmcvptzNN11BcfQ4Sl7MwTOsisQoa2keB/EBdNCAnUo8vA==",
       "cpu": [
         "arm64"
       ],
@@ -1254,9 +1078,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.15.tgz",
-      "integrity": "sha512-oArR/ig8wNTPYsXL+Mzhs0oxhxfuHRfG7Ikw7jXsw8mYOtk71W0OkF2VEVh699pdmzjPQsTjlD1JIOoHkLP1Fg==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0.tgz",
+      "integrity": "sha512-6XcD+8k0gPVItNagEw78/qqcBDwKcwDYS8V2hRmVsfUSIrd8cWe/CBvRDI5toqFyPfj+FJr6t8U6Xj2P2prEew==",
       "cpu": [
         "arm64"
       ],
@@ -1271,9 +1095,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.15.tgz",
-      "integrity": "sha512-YzeVqOqjPYvUbJSWJ4EDL8ahbmsIXQpgL3JVipmN+MX0XnXMeWomLN3Fb+nwCmP/jfyqte5I3XRSm7OfQrbyxw==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0.tgz",
+      "integrity": "sha512-iN/tWVXRQDWvmZlKdceP1Dwug9GDpEymhb9p4xnEe6zvCg5lFmzVljl+1qR1NVx3yfGpr2Na+CuLmv5IU8uzfQ==",
       "cpu": [
         "x64"
       ],
@@ -1288,9 +1112,9 @@
       }
     },
     "node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.15.tgz",
-      "integrity": "sha512-9Erhx956jeQ0nNTyif1+QWAXDRD38ZNjr//bSHrt6wDwB+QkAfl2q6Mn1k6OBPerznjRmbM10lgRb1Pli4xZPw==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0.tgz",
+      "integrity": "sha512-jjQMDvvwSOuhOwMszD/klSOjyWMM3zI64hWTj9KT5x4MxRbZAf+7vLQ6qouRhtsLVFHr3f0ILaJAfgENPiQdAQ==",
       "cpu": [
         "x64"
       ],
@@ -1305,9 +1129,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.15.tgz",
-      "integrity": "sha512-cVwk0w8QbZJGTnP/AHQBs5yNwmpgGYStL88t4UIaqcvYJWBfS0s3oqVLZPwsPU6M0zlW4GqjP0Zq5MnAGwFeGA==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0.tgz",
+      "integrity": "sha512-d//Dtg2x6/m3mbV64yUGNnDGNZaDGRpDLLNGerHQUVObuNaIQaaDp25yUiqGXtHEXX+NP2d0wAlmKgpYgIAJ2A==",
       "cpu": [
         "arm"
       ],
@@ -1322,9 +1146,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.15.tgz",
-      "integrity": "sha512-eBZ/u8iAK9SoHGanqe/jrPnY0JvBN6iXbVOsbO38mbz+ZJsaobExAm1Iu+rxa4S1l2FjG0qEZn4Rc6X8n+9M+w==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0.tgz",
+      "integrity": "sha512-n7Ofp0mx+aB2cC+Sdy5YtMnXtY9lchnHbY+3Yt0uq9JsWQExf4f5Whu0tK0R8Jdc9S6RchTHjIFY7uc92puOVQ==",
       "cpu": [
         "arm64"
       ],
@@ -1339,9 +1163,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.15.tgz",
-      "integrity": "sha512-ZvRYMGrAklV9PEkgt4LQM6MjQX2P58HPAuecwYObY2DhS2t35R0I810bKi0wmaYORt6m/2Sm+Z+nFgb0WhXNcQ==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0.tgz",
+      "integrity": "sha512-EIVjy2cgd7uuMMo94FVkBp7F6DhcZAUwNURkSG3RwUmvAXR6s0ISxM81U+IydcZByPG0pZIHsf1b6kTxoFDgJA==",
       "cpu": [
         "arm64"
       ],
@@ -1356,9 +1180,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.15.tgz",
-      "integrity": "sha512-VDpgGBzgfg5hLg+uBpCLoFG5kVvEyafmfxGUV0UHLcL5irxAK7PKNeC2MwClgk6ZAiNhmo9FLhRYgvMmedLtnQ==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0.tgz",
+      "integrity": "sha512-JEwwOPcwTLAcpDQlqSmjEmfs63xJnSiUNIGvLcDLUHCWK4XowpS/7c7tUsUH6uT/ct6bMUTdXKfI8967FYj6mg==",
       "cpu": [
         "ppc64"
       ],
@@ -1373,9 +1197,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.15.tgz",
-      "integrity": "sha512-y1uXY3qQWCzcPgRJATPSOUP4tCemh4uBdY7e3EZbVwCJTY3gLJWnQABgeUetvED+bt1FQ01OeZwvhLS2bpNrAQ==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0.tgz",
+      "integrity": "sha512-0wjCFhLrihtAubnT9iA0N++0pSV0z5Hg7tNGdNJ4RFaINceHadoF+kiFGyY1qSSNVIAZtLotG8Ju1bgDPkjnFA==",
       "cpu": [
         "s390x"
       ],
@@ -1390,9 +1214,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.15.tgz",
-      "integrity": "sha512-023bTPBod7J3Y/4fzAN6QtpkSABR0rigtrwaP+qSEabUh5zf6ELr9Nc7GujaROuPY3uwdSIXWrvhn1KxOvurWA==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0.tgz",
+      "integrity": "sha512-Dfn7iak9BcMMePxcoJfpSbWqnEyrp/dRF63/8qW/eHBdOZov6x5aShLLEYGYdIeSJ6vMLK/XCVB+lGIxm41bQA==",
       "cpu": [
         "x64"
       ],
@@ -1407,9 +1231,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.15.tgz",
-      "integrity": "sha512-witB2O0/hU4CgfOOKUoeFgQ4GktPi1eEbAhaLAIpgD6+ZnhcPkUtPsoKKHRzmOoWPZue46IThdSgdo4XneOLYw==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0.tgz",
+      "integrity": "sha512-5/utzzDmD/pD/bmuaUcbTf/sZYy0aztwIVlfpoW1fTjCZ0BaPOMVWGZL1zvgxyi7ZIVYWlxKONHmSbHuiOh8Jw==",
       "cpu": [
         "x64"
       ],
@@ -1424,9 +1248,9 @@
       }
     },
     "node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.15.tgz",
-      "integrity": "sha512-UCL68NJ0Ud5zRipXZE9dF5PmirzJE4E4BCIOOssEnM7wLDsxjc6Qb0sGDxTNRTP53I6MZpygyCpY8Aa8sPfKPg==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0.tgz",
+      "integrity": "sha512-ouJs8VcUomfLfpbUECqFMRqdV4x6aeAK3MA4m6vTrJJjKyWTV5KnxZx7Jd9G+GlDaQQxubcba00x16OyJ1meig==",
       "cpu": [
         "arm64"
       ],
@@ -1441,9 +1265,9 @@
       }
     },
     "node_modules/@rolldown/binding-wasm32-wasi": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.15.tgz",
-      "integrity": "sha512-ApLruZq/ig+nhaE7OJm4lDjayUnOHVUa77zGeqnqZ9pn0ovdVbbNPerVibLXDmWeUZXjIYIT8V3xkT58Rm9u5Q==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0.tgz",
+      "integrity": "sha512-E+oHKGiDA+lsKMmFtffDDw91EryDT7uJocrIuCHqhm6bCTM6xFK+3gaCkYOHfPwQr0cCNarSM2xaELoQDz9jJg==",
       "cpu": [
         "wasm32"
       ],
@@ -1451,18 +1275,18 @@
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/core": "1.9.2",
-        "@emnapi/runtime": "1.9.2",
-        "@napi-rs/wasm-runtime": "^1.1.3"
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0",
+        "@napi-rs/wasm-runtime": "^1.1.4"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": "^20.19.0 || >=22.12.0"
       }
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.15.tgz",
-      "integrity": "sha512-KmoUoU7HnN+Si5YWJigfTws1jz1bKBYDQKdbLspz0UaqjjFkddHsqorgiW1mxcAj88lYUE6NC/zJNwT+SloqtA==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0.tgz",
+      "integrity": "sha512-yYK02n8Rngo+gbm1y6G0+7jk1sJ/2Wt7K0me0Y7k/ErBpyf+LJ2gFpqWVTcRV1rUepBlQRmpgWkTQCiiwrK0Ow==",
       "cpu": [
         "arm64"
       ],
@@ -1477,9 +1301,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.15.tgz",
-      "integrity": "sha512-3P2A8L+x75qavWLe/Dll3EYBJLQmtkJN8rfh+U/eR3MqMgL/h98PhYI+JFfXuDPgPeCB7iZAKiqii5vqOvnA0g==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0.tgz",
+      "integrity": "sha512-14bpChMahXRRXiTwahSl+zzHPW6qQTXtkMuJBFlbo+pqSAews2d4BdCSHfrJ/MBsCZtpmTafsY+1QhBzitcmdg==",
       "cpu": [
         "x64"
       ],
@@ -1494,9 +1318,9 @@
       }
     },
     "node_modules/@rolldown/pluginutils": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.15.tgz",
-      "integrity": "sha512-UromN0peaE53IaBRe9W7CjrZgXl90fqGpK+mIZbA3qSTeYqg3pqpROBdIPvOG3F5ereDHNwoHBI2e50n1BDr1g==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0.tgz",
+      "integrity": "sha512-aKs/3GSWyV0mrhNmt/96/Z3yczC3yvrzYATCiCXQebBsGyYzjNdUphRVLeJQ67ySKVXRfMxt2lm12pmXvbPFQQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -1508,9 +1332,9 @@
       "license": "MIT"
     },
     "node_modules/@tybys/wasm-util": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
-      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
+      "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -1537,9 +1361,9 @@
       "license": "MIT"
     },
     "node_modules/@types/estree": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
-      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
       "dev": true,
       "license": "MIT"
     },
@@ -1574,16 +1398,16 @@
       }
     },
     "node_modules/@vitest/expect": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.4.tgz",
-      "integrity": "sha512-iPBpra+VDuXmBFI3FMKHSFXp3Gx5HfmSCE8X67Dn+bwephCnQCaB7qWK2ldHa+8ncN8hJU8VTMcxjPpyMkUjww==",
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.6.tgz",
+      "integrity": "sha512-7EHDquPthALSV0jhhjgEW8FXaviMx7rSqu8W6oqCoAuOhKov814P99QDV1pxMA3QPv21YudvJngIhjrNI4opLg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.1.0",
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "4.1.4",
-        "@vitest/utils": "4.1.4",
+        "@vitest/spy": "4.1.6",
+        "@vitest/utils": "4.1.6",
         "chai": "^6.2.2",
         "tinyrainbow": "^3.1.0"
       },
@@ -1592,9 +1416,9 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.4.tgz",
-      "integrity": "sha512-ddmDHU0gjEUyEVLxtZa7xamrpIefdEETu3nZjWtHeZX4QxqJ7tRxSteHVXJOcr8jhiLoGAhkK4WJ3WqBpjx42A==",
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.6.tgz",
+      "integrity": "sha512-h5SxD/IzNhZYnrSZRsUZQIC+vD0GY8cUvq0iwsmkFKixRCKLLWqCXa/FIQ4S1R+sI+PGoojkHsdNrbZiM9Qpgw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1605,13 +1429,13 @@
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.4.tgz",
-      "integrity": "sha512-xTp7VZ5aXP5ZJrn15UtJUWlx6qXLnGtF6jNxHepdPHpMfz/aVPx+htHtgcAL2mDXJgKhpoo2e9/hVJsIeFbytQ==",
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.6.tgz",
+      "integrity": "sha512-nOPCmn2+yD0ZNmKdsXGv/UxMMWbMuKeD6GyYncNwdkYDxpQvrPSKYj2rWuDjC2Y4b6w6hjip5dBKFzEUuZe3vA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "4.1.4",
+        "@vitest/utils": "4.1.6",
         "pathe": "^2.0.3"
       },
       "funding": {
@@ -1619,14 +1443,14 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.4.tgz",
-      "integrity": "sha512-MCjCFgaS8aZz+m5nTcEcgk/xhWv0rEH4Yl53PPlMXOZ1/Ka2VcZU6CJ+MgYCZbcJvzGhQRjVrGQNZqkGPttIKw==",
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.6.tgz",
+      "integrity": "sha512-YhsdE6xAVfTDmzjxL2ZDUvjj+ZsgyOKe+TdQzqkD72wIOmHka8NuGQ6NpTNZv9D2Z63fbwWKJPeVpEw4EQgYxw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.4",
-        "@vitest/utils": "4.1.4",
+        "@vitest/pretty-format": "4.1.6",
+        "@vitest/utils": "4.1.6",
         "magic-string": "^0.30.21",
         "pathe": "^2.0.3"
       },
@@ -1635,9 +1459,9 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.4.tgz",
-      "integrity": "sha512-XxNdAsKW7C+FLydqFJLb5KhJtl3PGCMmYwFRfhvIgxJvLSXhhVI1zM8f1qD3Zg7RCjTSzDVyct6sghs9UEgBEQ==",
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.6.tgz",
+      "integrity": "sha512-JFKxMx6udhwKh/Ldo270e17QX710vgunMkuPAvXjHSvC6oqLWAHhVhjg/I71q0u0CBSErIODV1Kjv0FQNSWjdg==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -1645,13 +1469,13 @@
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.4.tgz",
-      "integrity": "sha512-13QMT+eysM5uVGa1rG4kegGYNp6cnQcsTc67ELFbhNLQO+vgsygtYJx2khvdt4gVQqSSpC/KT5FZZxUpP3Oatw==",
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.6.tgz",
+      "integrity": "sha512-FxIY+U81R3LGKCxaHHFRQ5+g6/iRgGLmeHWdp2Amj4ljQRrEIWHmZyDfDYBRZlpyqA7qKxtS9DD1dhk8RnRIVQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.4",
+        "@vitest/pretty-format": "4.1.6",
         "convert-source-map": "^2.0.0",
         "tinyrainbow": "^3.1.0"
       },
@@ -1688,9 +1512,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
-      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
@@ -1821,9 +1645,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -2103,9 +1927,9 @@
       }
     },
     "node_modules/es-module-lexer": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
-      "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -2200,9 +2024,9 @@
       }
     },
     "node_modules/eventsource-parser": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
-      "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.8.tgz",
+      "integrity": "sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==",
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
@@ -2262,12 +2086,12 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.2.tgz",
-      "integrity": "sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg==",
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.1.tgz",
+      "integrity": "sha512-5O6KYmyJEpuPJV5hNTXKbAHWRqrzyu+OI3vUnSd2kXFubIVpG7ezpgxQy76Zo5GQZtrQBg86hF+CM/NX+cioiQ==",
       "license": "MIT",
       "dependencies": {
-        "ip-address": "10.1.0"
+        "ip-address": "^10.2.0"
       },
       "engines": {
         "node": ">= 16"
@@ -2301,9 +2125,9 @@
       "license": "MIT"
     },
     "node_modules/fast-json-stringify": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/fast-json-stringify/-/fast-json-stringify-6.3.0.tgz",
-      "integrity": "sha512-oRCntNDY/329HJPlmdNLIdogNtt6Vyjb1WuT01Soss3slIdyUp8kAcDU3saQTOquEK8KFVfwIIF7FebxUAu+yA==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stringify/-/fast-json-stringify-6.4.0.tgz",
+      "integrity": "sha512-ibRCQ0GZKJIQ+P3Et1h0LhPgp3PMTYk0MH8O+kW3lNYsvmaQww5Nn3f1jf73Q0jR1Yz3a1CDP4/NZD3vOajWJQ==",
       "funding": [
         {
           "type": "github",
@@ -2334,9 +2158,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "funding": [
         {
           "type": "github",
@@ -2447,9 +2271,9 @@
       }
     },
     "node_modules/find-my-way": {
-      "version": "9.5.0",
-      "resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-9.5.0.tgz",
-      "integrity": "sha512-VW2RfnmscZO5KgBY5XVyKREMW5nMZcxDy+buTOsL+zIPnBlbKm+00sgzoQzq1EVh4aALZLfKdwv6atBGcjvjrQ==",
+      "version": "9.6.0",
+      "resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-9.6.0.tgz",
+      "integrity": "sha512-Zf4Xve4RymLl7NgaavNebZ01joJ8MfVerOG43wy7SHLO+r+K0C6d/SE0BiR7AV5V1VOCFlOP7ecdo+I4qmiHrQ==",
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
@@ -2540,9 +2364,9 @@
       }
     },
     "node_modules/get-tsconfig": {
-      "version": "4.13.7",
-      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.7.tgz",
-      "integrity": "sha512-7tN6rFgBlMgpBML5j8typ92BKFi2sFQvIdpAqLA2beia5avZDrMs0FLZiM5etShWq5irVyGcGMEA1jcDaK7A/Q==",
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
+      "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2594,9 +2418,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -2615,9 +2439,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.12",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.12.tgz",
-      "integrity": "sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==",
+      "version": "4.12.18",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.18.tgz",
+      "integrity": "sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==",
       "license": "MIT",
       "peer": true,
       "engines": {
@@ -2689,18 +2513,18 @@
       "license": "ISC"
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
       }
     },
     "node_modules/ipaddr.js": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.3.0.tgz",
-      "integrity": "sha512-Zv/pA+ciVFbCSBBjGfaKUya/CcGmUHzTydLMaTwrUUEM2DIEO3iZvueGxmacvmN50fGpGVKeTXpb2LcYQxeVdg==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.4.0.tgz",
+      "integrity": "sha512-9VGk3HGanVE6JoZXHiCpnGy5X0jYDnN4EA4lntFPj+1vIWlFhIylq2CrrCOJH9EAhc5CYhq18F2Av2tgoAPsYQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 10"
@@ -2719,9 +2543,9 @@
       "license": "ISC"
     },
     "node_modules/jose": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.2.tgz",
-      "integrity": "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==",
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"
@@ -3091,9 +2915,9 @@
       }
     },
     "node_modules/lru-cache": {
-      "version": "11.3.5",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
-      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
+      "version": "11.3.6",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.6.tgz",
+      "integrity": "sha512-Gf/KoL3C/MlI7Bt0PGI9I+TeTC/I6r/csU58N4BSNc4lppLBeKsOdFYkK+dX0ABDUMJNfCHTyPpzwwO21Awd3A==",
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
@@ -3235,9 +3059,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
       "dev": true,
       "funding": [
         {
@@ -3459,9 +3283,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.9",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.9.tgz",
-      "integrity": "sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw==",
+      "version": "8.5.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
       "dev": true,
       "funding": [
         {
@@ -3638,14 +3462,14 @@
       "license": "MIT"
     },
     "node_modules/rolldown": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.15.tgz",
-      "integrity": "sha512-Ff31guA5zT6WjnGp0SXw76X6hzGRk/OQq2hE+1lcDe+lJdHSgnSX6nK3erbONHyCbpSj9a9E+uX/OvytZoWp2g==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0.tgz",
+      "integrity": "sha512-yD986aXDESFGS95spT1LAv0jssywP4npMEjmMHyN2/5+eE8qQJUype2AaKkRiLgBgyD0LFlubwAht7VmY8rGoA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@oxc-project/types": "=0.124.0",
-        "@rolldown/pluginutils": "1.0.0-rc.15"
+        "@oxc-project/types": "=0.129.0",
+        "@rolldown/pluginutils": "1.0.0"
       },
       "bin": {
         "rolldown": "bin/cli.mjs"
@@ -3654,21 +3478,21 @@
         "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rolldown/binding-android-arm64": "1.0.0-rc.15",
-        "@rolldown/binding-darwin-arm64": "1.0.0-rc.15",
-        "@rolldown/binding-darwin-x64": "1.0.0-rc.15",
-        "@rolldown/binding-freebsd-x64": "1.0.0-rc.15",
-        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.15",
-        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.15",
-        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.15",
-        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.15",
-        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.15",
-        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.15",
-        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.15",
-        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.15",
-        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.15",
-        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.15",
-        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.15"
+        "@rolldown/binding-android-arm64": "1.0.0",
+        "@rolldown/binding-darwin-arm64": "1.0.0",
+        "@rolldown/binding-darwin-x64": "1.0.0",
+        "@rolldown/binding-freebsd-x64": "1.0.0",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.0",
+        "@rolldown/binding-linux-arm64-musl": "1.0.0",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.0",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.0",
+        "@rolldown/binding-linux-x64-gnu": "1.0.0",
+        "@rolldown/binding-linux-x64-musl": "1.0.0",
+        "@rolldown/binding-openharmony-arm64": "1.0.0",
+        "@rolldown/binding-wasm32-wasi": "1.0.0",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.0",
+        "@rolldown/binding-win32-x64-msvc": "1.0.0"
       }
     },
     "node_modules/router": {
@@ -3708,9 +3532,9 @@
       "license": "MIT"
     },
     "node_modules/safe-regex2": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/safe-regex2/-/safe-regex2-5.1.0.tgz",
-      "integrity": "sha512-pNHAuBW7TrcleFHsxBr5QMi/Iyp0ENjUKz7GCcX1UO7cMh+NmVK6HxQckNL1tJp1XAJVjG6B8OKIPqodqj9rtw==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/safe-regex2/-/safe-regex2-5.1.1.tgz",
+      "integrity": "sha512-mOSBvHGDZMuIEZMdOz/aCEYDCv0E7nfcNsIhUF+/P+xC7Hyf3FkvymqgPbg9D1EdSGu+uKbJgy09K/RKKc7kJA==",
       "funding": [
         {
           "type": "github",
@@ -3761,9 +3585,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -3974,9 +3798,9 @@
       }
     },
     "node_modules/std-env": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.0.0.tgz",
-      "integrity": "sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -3996,16 +3820,22 @@
       }
     },
     "node_modules/thread-stream": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-4.0.0.tgz",
-      "integrity": "sha512-4iMVL6HAINXWf1ZKZjIPcz5wYaOdPhtO8ATvZ+Xqp3BTdaqtAwQkNmKORqcIo5YkQqGXq5cwfswDwMqqQNrpJA==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-4.1.0.tgz",
+      "integrity": "sha512-Bw6h2iBDt16v6iHLChBIoVYU8CBo9GPsW8TG7h1hRVhqKhIkH6N8qkxNSmiOZTKsCLPbtWG4ViWLkU6KeKXpig==",
       "license": "MIT",
       "dependencies": {
-        "real-require": "^0.2.0"
+        "real-require": "^1.0.0"
       },
       "engines": {
         "node": ">=20"
       }
+    },
+    "node_modules/thread-stream/node_modules/real-require": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/real-require/-/real-require-1.0.0.tgz",
+      "integrity": "sha512-P4nbQYQfePJxRSmY+v/KINxVucm4NF3p3s7pJveMTtom52FR4YGltUQLB8idDXwDDWW+eYrWDFbuzUnjoWHF7g==",
+      "license": "MIT"
     },
     "node_modules/thunky": {
       "version": "1.1.0",
@@ -4021,9 +3851,9 @@
       "license": "MIT"
     },
     "node_modules/tinyexec": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.1.tgz",
-      "integrity": "sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.2.tgz",
+      "integrity": "sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4170,19 +4000,19 @@
       }
     },
     "node_modules/vitest": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.4.tgz",
-      "integrity": "sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg==",
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.6.tgz",
+      "integrity": "sha512-6lvjbS3p9b4CrdCmguzbh2/4uoXhGE2q71R4OX5sqF9R1bo9Xd6fGrMAfvp5wnCzlBnFVdCOp6onuTQVbo8iUQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/expect": "4.1.4",
-        "@vitest/mocker": "4.1.4",
-        "@vitest/pretty-format": "4.1.4",
-        "@vitest/runner": "4.1.4",
-        "@vitest/snapshot": "4.1.4",
-        "@vitest/spy": "4.1.4",
-        "@vitest/utils": "4.1.4",
+        "@vitest/expect": "4.1.6",
+        "@vitest/mocker": "4.1.6",
+        "@vitest/pretty-format": "4.1.6",
+        "@vitest/runner": "4.1.6",
+        "@vitest/snapshot": "4.1.6",
+        "@vitest/spy": "4.1.6",
+        "@vitest/utils": "4.1.6",
         "es-module-lexer": "^2.0.0",
         "expect-type": "^1.3.0",
         "magic-string": "^0.30.21",
@@ -4210,12 +4040,12 @@
         "@edge-runtime/vm": "*",
         "@opentelemetry/api": "^1.9.0",
         "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-        "@vitest/browser-playwright": "4.1.4",
-        "@vitest/browser-preview": "4.1.4",
-        "@vitest/browser-webdriverio": "4.1.4",
-        "@vitest/coverage-istanbul": "4.1.4",
-        "@vitest/coverage-v8": "4.1.4",
-        "@vitest/ui": "4.1.4",
+        "@vitest/browser-playwright": "4.1.6",
+        "@vitest/browser-preview": "4.1.6",
+        "@vitest/browser-webdriverio": "4.1.6",
+        "@vitest/coverage-istanbul": "4.1.6",
+        "@vitest/coverage-v8": "4.1.6",
+        "@vitest/ui": "4.1.6",
         "happy-dom": "*",
         "jsdom": "*",
         "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
@@ -4685,13 +4515,13 @@
       }
     },
     "node_modules/vitest/node_modules/@vitest/mocker": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.4.tgz",
-      "integrity": "sha512-R9HTZBhW6yCSGbGQnDnH3QHfJxokKN4KB+Yvk9Q1le7eQNYwiCyKxmLmurSpFy6BzJanSLuEUDrD+j97Q+ZLPg==",
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.6.tgz",
+      "integrity": "sha512-MCFc63czMjEInOlcY2cpQCvCN+KgbAn+60xu9cMgP4sKaLC5JNAKw7JH8QdAnoAC88hW1IiSNZ+GgVXlN1UcMQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "4.1.4",
+        "@vitest/spy": "4.1.6",
         "estree-walker": "^3.0.3",
         "magic-string": "^0.30.21"
       },
@@ -4711,19 +4541,63 @@
         }
       }
     },
+    "node_modules/vitest/node_modules/esbuild": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
+      "integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.0",
+        "@esbuild/android-arm": "0.28.0",
+        "@esbuild/android-arm64": "0.28.0",
+        "@esbuild/android-x64": "0.28.0",
+        "@esbuild/darwin-arm64": "0.28.0",
+        "@esbuild/darwin-x64": "0.28.0",
+        "@esbuild/freebsd-arm64": "0.28.0",
+        "@esbuild/freebsd-x64": "0.28.0",
+        "@esbuild/linux-arm": "0.28.0",
+        "@esbuild/linux-arm64": "0.28.0",
+        "@esbuild/linux-ia32": "0.28.0",
+        "@esbuild/linux-loong64": "0.28.0",
+        "@esbuild/linux-mips64el": "0.28.0",
+        "@esbuild/linux-ppc64": "0.28.0",
+        "@esbuild/linux-riscv64": "0.28.0",
+        "@esbuild/linux-s390x": "0.28.0",
+        "@esbuild/linux-x64": "0.28.0",
+        "@esbuild/netbsd-arm64": "0.28.0",
+        "@esbuild/netbsd-x64": "0.28.0",
+        "@esbuild/openbsd-arm64": "0.28.0",
+        "@esbuild/openbsd-x64": "0.28.0",
+        "@esbuild/openharmony-arm64": "0.28.0",
+        "@esbuild/sunos-x64": "0.28.0",
+        "@esbuild/win32-arm64": "0.28.0",
+        "@esbuild/win32-ia32": "0.28.0",
+        "@esbuild/win32-x64": "0.28.0"
+      }
+    },
     "node_modules/vitest/node_modules/vite": {
-      "version": "8.0.8",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.8.tgz",
-      "integrity": "sha512-dbU7/iLVa8KZALJyLOBOQ88nOXtNG8vxKuOT4I2mD+Ya70KPceF4IAmDsmU0h1Qsn5bPrvsY9HJstCRh3hG6Uw==",
+      "version": "8.0.12",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.12.tgz",
+      "integrity": "sha512-w2dDofOWv2QB09ZITZBsvKTVAlYvPR4IAmrY/v0ir9KvLs0xybR7i48wxhM1/oyBWO34wPns+bPGw5ZrZqDpZg==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
-        "postcss": "^8.5.8",
-        "rolldown": "1.0.0-rc.15",
-        "tinyglobby": "^0.2.15"
+        "postcss": "^8.5.14",
+        "rolldown": "1.0.0",
+        "tinyglobby": "^0.2.16"
       },
       "bin": {
         "vite": "bin/vite.js"
@@ -4739,7 +4613,7 @@
       },
       "peerDependencies": {
         "@types/node": "^20.19.0 || >=22.12.0",
-        "@vitejs/devtools": "^0.1.0",
+        "@vitejs/devtools": "^0.1.18",
         "esbuild": "^0.27.0 || ^0.28.0",
         "jiti": ">=1.21.0",
         "less": "^4.0.0",
@@ -4869,9 +4743,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
-      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
       "peer": true,
       "funding": {

--- a/relay/package.json
+++ b/relay/package.json
@@ -27,6 +27,7 @@
     "@fastify/rate-limit": "^10.3.0",
     "@fastify/static": "^9.0.0",
     "@fastify/websocket": "^11.2.0",
+    "bonjour-service": "^1.3.0",
     "fastify": "^5.8.2",
     "fastify-plugin": "^5.1.0",
     "jose": "^6.2.2",

--- a/relay/src/discovery/mdns.ts
+++ b/relay/src/discovery/mdns.ts
@@ -6,12 +6,13 @@
  * (which drifts on DHCP renewal — see PHASE-PAIRING-REBOOT).
  */
 import { Bonjour, type Service } from 'bonjour-service';
-import { hostname } from 'node:os';
 import { logger } from '../utils/logger.js';
 
 const log = logger.child({ module: 'mdns' });
 
 const SERVICE_TYPE = 'majortom';
+const DEFAULT_NAME = 'Major Tom Relay';
+const STOP_TIMEOUT_MS = 1_000;
 
 export interface MdnsHandle {
   stop: () => Promise<void>;
@@ -19,7 +20,10 @@ export interface MdnsHandle {
 
 export function startMdns(port: number): MdnsHandle {
   const bonjour = new Bonjour();
-  const instanceName = `Major Tom Relay (${hostname()})`;
+  // Default to a generic label so the relay's mDNS broadcast doesn't leak
+  // the OS hostname on every Wi-Fi it touches. `MAJORTOM_RELAY_NAME` lets
+  // multi-host setups distinguish their relays explicitly.
+  const instanceName = process.env['MAJORTOM_RELAY_NAME']?.trim() || DEFAULT_NAME;
 
   let service: Service | undefined;
   try {
@@ -39,10 +43,18 @@ export function startMdns(port: number): MdnsHandle {
 
   return {
     stop: async () => {
-      if (service?.stop) {
-        await new Promise<void>((resolve) => {
-          service!.stop!(() => resolve());
-        });
+      const s = service;
+      if (s) {
+        // Race the stop callback against a deadline so a stalled
+        // bonjour-service teardown doesn't hang `app.close()` during
+        // shutdown (the next signal would be SIGKILL with state loss).
+        // Optional call on `s.stop` matches the bonjour-service type,
+        // which marks the method as optional — if it's absent the
+        // inner promise never resolves and the timeout wins.
+        await Promise.race([
+          new Promise<void>((resolve) => { s.stop?.(() => resolve()); }),
+          new Promise<void>((resolve) => setTimeout(resolve, STOP_TIMEOUT_MS)),
+        ]);
       }
       bonjour.destroy();
     },

--- a/relay/src/discovery/mdns.ts
+++ b/relay/src/discovery/mdns.ts
@@ -1,0 +1,50 @@
+/**
+ * mDNS / Bonjour advertise for the relay.
+ *
+ * Advertises `_majortom._tcp.local.` so the iOS app can discover the relay
+ * by name on the local network without the user typing the Mac's LAN IP
+ * (which drifts on DHCP renewal — see PHASE-PAIRING-REBOOT).
+ */
+import { Bonjour, type Service } from 'bonjour-service';
+import { hostname } from 'node:os';
+import { logger } from '../utils/logger.js';
+
+const log = logger.child({ module: 'mdns' });
+
+const SERVICE_TYPE = 'majortom';
+
+export interface MdnsHandle {
+  stop: () => Promise<void>;
+}
+
+export function startMdns(port: number): MdnsHandle {
+  const bonjour = new Bonjour();
+  const instanceName = `Major Tom Relay (${hostname()})`;
+
+  let service: Service | undefined;
+  try {
+    service = bonjour.publish({
+      name: instanceName,
+      type: SERVICE_TYPE,
+      port,
+      txt: {
+        version: '1',
+        protocol: 'ws',
+      },
+    });
+    log.info({ name: instanceName, port, type: `_${SERVICE_TYPE}._tcp` }, 'mDNS service published');
+  } catch (err) {
+    log.warn({ err }, 'Failed to publish mDNS service — discovery will not work on this network');
+  }
+
+  return {
+    stop: async () => {
+      if (service?.stop) {
+        await new Promise<void>((resolve) => {
+          service!.stop!(() => resolve());
+        });
+      }
+      bonjour.destroy();
+    },
+  };
+}

--- a/relay/src/server.ts
+++ b/relay/src/server.ts
@@ -9,6 +9,7 @@ import { resolve, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { buildApp } from './app.js';
 import { pinManager } from './auth/pin-manager.js';
+import { startMdns, type MdnsHandle } from './discovery/mdns.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const PIN_FILE = resolve(__dirname, '..', '.pin');
@@ -40,10 +41,13 @@ async function main() {
     process.exit(1);
   }
 
+  let mdns: MdnsHandle | undefined;
+
   // Graceful shutdown
   const shutdown = async (signal: string) => {
     app.log.info({ signal }, 'Received shutdown signal');
     try { unlinkSync(PIN_FILE); } catch { /* ignore */ }
+    if (mdns) await mdns.stop();
     await app.close();
     process.exit(0);
   };
@@ -53,6 +57,11 @@ async function main() {
 
   try {
     await app.listen({ port: PORT, host: '0.0.0.0' });
+
+    // Advertise on the local network so the iOS app can discover us
+    // without the user typing the Mac's LAN IP. Failures here are
+    // non-fatal — the relay still serves HTTP, just without auto-discovery.
+    mdns = startMdns(PORT);
 
     // Startup info
     console.log('');


### PR DESCRIPTION
## Why this PR exists

Pairing has a hardcoded LAN IP in `PairingView.swift:8` (`case lan = "192.168.1.210:9090"`). When the Mac's DHCP lease drifts (last seen `.210 → .254`), the "auto-recommended" LAN chip points at a dead IP and the app shows a generic "Connection failed" — 100% blocker on every DHCP renewal. PR #166 wired `NetworkPathMonitor` correctly but mapped reachability → a frozen string literal. No live discovery, no reachability probe.

This PR replaces the hardcoded LAN constant with live mDNS/Bonjour discovery and adds pre-flight reachability ping. Tailscale, Cloudflare tunnel, and localhost stay as off-LAN / dev fallbacks.

## What changed

**Relay**
- Adds `bonjour-service` (1.3.0). New `discovery/mdns.ts` advertises `_majortom._tcp` on `PORT` at startup with a `txt` record (`version`, `protocol`). Cleans up on shutdown via the existing graceful-close hook.

**iOS**
- New `Core/Services/BonjourBrowser.swift` using `NWBrowser` to find `_majortom._tcp` services; resolves each via a short-lived `NWConnection` and exposes `DiscoveredService(id, displayName, address)` for the UI.
- `PairingViewModel` holds a `BonjourBrowser`, exposes `discoveredServices`, and adds `useDiscovered(_:)`. `applyInitialRecommendationIfNeeded` now prefers a discovered service over the network-recommended preset when the address field is empty.
- `submitPIN` does a 2s pre-flight `GET /auth/methods` first — if unreachable, sets `authState = .error("Server unreachable at <URL>. Pick a different relay or check your network.")` instead of attempting the PIN exchange.
- `PairingView` renders a new "Found on your network" chip row above the static fallback chips; shows a "Looking for relay…" hint while browsing returns nothing.
- `ServerPreset.lan` is **dropped**; `ServerPreset(reachability: .lan)` now returns `nil` (Bonjour fills that role). Tailscale / Cloudflare / localhost remain.
- `Info.plist` gains `NSLocalNetworkUsageDescription` and `NSBonjourServices = ["_majortom._tcp"]` for the iOS local-network permission prompt.
- `AuthService.normalizeBaseURL` treats `.local` mDNS hosts as `http://` (permitted by existing `NSAllowsLocalNetworking`).

**Docs**
- `docs/PHASE-PAIRING-REBOOT.md` — phase spec, wave breakdown, success criteria. Wave 2 (`GET /api/discovery`, URL provenance, auto-clear stale URLs on foreground) is explicitly deferred.

## Test plan
- [x] Relay typecheck clean (`npm run lint`).
- [x] Relay tests green (`vitest`): 22 files / 357 tests pass.
- [x] iOS simulator build clean via XcodeBuildMCP (0 warnings, 0 errors).
- [ ] Device QA: open MajorTom on Sean's iPhone on the same Wi-Fi → grant local-network permission when prompted → "Found on your network" chip appears within ~2s with the Mac's hostname → tap chip → PIN screen reachable → enter PIN → paired.
- [ ] Device QA: stop the relay → tap connect on a stale saved URL → see "Server unreachable at <URL>" (not generic "Connection failed").
- [ ] Device QA: cellular-only (Wi-Fi off, no Tailscale) → Cloudflare tunnel chip is still selectable and pairs successfully.
- [ ] Device QA: deny the local-network permission prompt → static fallback chips still work (tunnel, Tailscale, localhost).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
