### PR TITLE
feat(pairing): wave 2A item 2 — MAJORTOM_PIN_TTL_MIN env knob

### DIFF
--- a/relay/.env.example
+++ b/relay/.env.example
@@ -3,6 +3,10 @@
 # WebSocket server port (iOS app connects here)
 WS_PORT=4030
 
+# Pairing PIN lifetime in minutes (default 5, min 1). Bump to 30+ for long
+# dev sessions where you'd otherwise time out before scanning the PIN.
+MAJORTOM_PIN_TTL_MIN=5
+
 # Hook HTTP server port (Claude Code hooks POST here)
 HOOK_PORT=4031
 

--- a/relay/get-pin.sh
+++ b/relay/get-pin.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Generate a fresh 6-digit login PIN from the relay server.
-# PIN expires after 5 minutes.
+# PIN expires after MAJORTOM_PIN_TTL_MIN minutes (default 5).
 
 PORT="${WS_PORT:-9090}"
 RESPONSE=$(curl -sfS -X POST "http://localhost:${PORT}/auth/pin/generate" 2>&1)

--- a/relay/src/auth/pin-manager.ts
+++ b/relay/src/auth/pin-manager.ts
@@ -1,6 +1,7 @@
 /**
  * PIN manager — generates and validates 6-digit PINs for quick auth.
- * Only one active PIN at a time. 5-minute expiry, rate-limited.
+ * Only one active PIN at a time. Expiry defaults to 5 min, overridable
+ * via MAJORTOM_PIN_TTL_MIN. Rate-limited.
  */
 import { randomInt } from 'node:crypto';
 
@@ -15,7 +16,8 @@ interface AttemptRecord {
   windowStart: number;
 }
 
-const PIN_EXPIRY_MS = 5 * 60 * 1000; // 5 minutes
+const PIN_TTL_MIN = Math.max(1, parseInt(process.env['MAJORTOM_PIN_TTL_MIN'] ?? '5', 10) || 5);
+const PIN_EXPIRY_MS = PIN_TTL_MIN * 60_000;
 const RATE_LIMIT_WINDOW_MS = 10 * 60 * 1000; // 10 minutes
 const RATE_LIMIT_MAX_ATTEMPTS = 5;
 


### PR DESCRIPTION
## Summary

- Replaces hardcoded `PIN_EXPIRY_MS = 5 * 60 * 1000` in `relay/src/auth/pin-manager.ts` with a value derived from `MAJORTOM_PIN_TTL_MIN` (default 5). `parseInt`-with-fallback + `Math.max(1, ...)` so a typo of `0`, a negative, or non-numeric input can never ship an instantly-expired PIN.
- Documents the knob in `relay/.env.example` next to `WS_PORT`.
- Updates the `relay/get-pin.sh` comment to point at the env var instead of the stale "5 minutes" literal.
- No iOS change. PIN expiry is server-side and iOS already surfaces "Invalid or expired PIN" on 401. The startup banner in `relay/src/server.ts:81-94` derives `expiryMin` from `expiresAt - Date.now()`, so it tracks the env value automatically (no banner edit needed).

This is Wave 2A item 2 of the Pairing Reboot phase. Item 1 (Google OAuth in iOS PairingView) shipped via PR #171.

## Why

User pain: PIN TTL is 5 min and the dev-session loop (open laptop, walk to couch, find phone, type PIN) burns through it. Making it configurable lets the relay operator bump to 30+ min for long sessions while keeping the prod-safe 5-min default.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm test` — 357/357 passing (no new tests; no PIN-specific tests existed and behavior at default is identical)
- [x] Smoke-tested with `MAJORTOM_PIN_TTL_MIN=2` — startup banner read `Expires in  2 min`
- [ ] Manual: set `MAJORTOM_PIN_TTL_MIN=30`, restart relay, confirm banner + actual expiry honor the value
- [ ] Manual: omit the env var, confirm default 5-min behavior unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)
