### PR TITLE
feat(pairing): OAuth-only iOS login + hoist tunnel URL out of source

### DIFF
--- a/ios/MajorTom.xcodeproj/project.pbxproj
+++ b/ios/MajorTom.xcodeproj/project.pbxproj
@@ -193,6 +193,7 @@
 		ECD4CC99C031E1B803D88C76 /* Session.swift in Sources */ = {isa = PBXBuildFile; fileRef = 591E0D4455AD31B2BBD8761C /* Session.swift */; };
 		ECE7FC357B702CB405A5F331 /* MajorTomActivity.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4BCC156442BF0A60A71BE43 /* MajorTomActivity.swift */; };
 		ED4F918BF0F4278063303B34 /* AuthService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2873A7A68C25BFA4E7C9756 /* AuthService.swift */; };
+		5644BBFA710B43CDACBD8F36 /* Secrets.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF11B5D163424D8787E0E238 /* Secrets.swift */; };
 		EEC364BAF46BDDC91935F90C /* GitHubPullRequestsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B08AE1A01F5A9974B81ABDC /* GitHubPullRequestsView.swift */; };
 		EED4F3F2058E244DD48046D0 /* WidgetData.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC2DDB367FB9D1034575BBC5 /* WidgetData.swift */; };
 		EFAA4EF100ED5F838DC54CC8 /* WatchModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91CC00DFBC23B1D7A0EC631C /* WatchModels.swift */; };
@@ -258,7 +259,7 @@
 		1B08AE1A01F5A9974B81ABDC /* GitHubPullRequestsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitHubPullRequestsView.swift; sourceTree = "<group>"; };
 		1CFE6DFB18C709862C80D1B4 /* SessionCostRankingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionCostRankingView.swift; sourceTree = "<group>"; };
 		2145B0466091139BF0BC856D /* Activities.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = Activities.json; sourceTree = "<group>"; };
-		2155A4D6123944C4CDE2BEE8 /* MajorTom.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = MajorTom.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		2155A4D6123944C4CDE2BEE8 /* Major Tom.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Major Tom.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		21F681FC6A3D7B14792DDC15 /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
 		252632F83335C10C98CF577C /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		27113A30A32A3F67614DC533 /* FleetWorkerCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FleetWorkerCard.swift; sourceTree = "<group>"; };
@@ -368,6 +369,7 @@
 		A0599D42F77C6262147106A2 /* ToolHumanizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolHumanizer.swift; sourceTree = "<group>"; };
 		A198759EB4EA086A9CBF595F /* AchievementsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AchievementsViewModel.swift; sourceTree = "<group>"; };
 		A2873A7A68C25BFA4E7C9756 /* AuthService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthService.swift; sourceTree = "<group>"; };
+		AF11B5D163424D8787E0E238 /* Secrets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Secrets.swift; sourceTree = "<group>"; };
 		A36A4C7C1708949F54A7FB29 /* Annotation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Annotation.swift; sourceTree = "<group>"; };
 		A41DCABE657223AAA37DDFCF /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		A68F8F8EAF85A677E32B2E34 /* WaypointPathfinder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WaypointPathfinder.swift; sourceTree = "<group>"; };
@@ -458,7 +460,7 @@
 		00EBF36EF8823CBEA092949A /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				2155A4D6123944C4CDE2BEE8 /* MajorTom.app */,
+				2155A4D6123944C4CDE2BEE8 /* Major Tom.app */,
 				9E41011D1A5C03C795509B68 /* MajorTomWatch.app */,
 				D136B4051E73808BE748883D /* MajorTomWidgets.appex */,
 			);
@@ -873,6 +875,7 @@
 				83DC9EE0B42BC2DFDC0BFBE3 /* PerfHUDPreferences.swift */,
 				28F93EA76007AD19338D6B61 /* PhoneWatchConnectivityService.swift */,
 				6EF58FBAC8341407F9E3E7A0 /* RelayService.swift */,
+				AF11B5D163424D8787E0E238 /* Secrets.swift */,
 				9EA1E31252AE384FC025109F /* TabTitleStore.swift */,
 			);
 			path = Services;
@@ -1526,7 +1529,7 @@
 			packageProductDependencies = (
 			);
 			productName = MajorTom;
-			productReference = 2155A4D6123944C4CDE2BEE8 /* MajorTom.app */;
+			productReference = 2155A4D6123944C4CDE2BEE8 /* Major Tom.app */;
 			productType = "com.apple.product-type.application";
 		};
 		1D494ABB3D630BF9E0170060 /* MajorTomWidgets */ = {
@@ -1574,14 +1577,9 @@
 				LastUpgradeCheck = 1600;
 				TargetAttributes = {
 					0F467BB7A12BEE96B6C65CF5 = {
-						DevelopmentTeam = "";
 						ProvisioningStyle = Automatic;
 					};
 					1D494ABB3D630BF9E0170060 = {
-						DevelopmentTeam = "";
-						ProvisioningStyle = Automatic;
-					};
-					466CF4A3CC1BD1A5FFC19FC3 = {
 						DevelopmentTeam = "";
 						ProvisioningStyle = Automatic;
 					};
@@ -1763,6 +1761,7 @@
 				95294489029F6CCA66271C3B /* RateLimitSettingsView.swift in Sources */,
 				3C07EFEF4D80196CACF66B4F /* RelayService.swift in Sources */,
 				DCC1DFB067FAF0EA4CB17690 /* RoleMapper.swift in Sources */,
+				5644BBFA710B43CDACBD8F36 /* Secrets.swift in Sources */,
 				ECD4CC99C031E1B803D88C76 /* Session.swift in Sources */,
 				7800B5EFB116E5708F3A6300 /* SessionCostRankingView.swift in Sources */,
 				8FBFC47F6355543CB70F368F /* SessionListView.swift in Sources */,
@@ -1853,6 +1852,9 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = 4B8499Z59P;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_GENERATION_MODE = GeneratedFile;
 				INFOPLIST_KEY_CFBundleDisplayName = "Major Tom";
@@ -1860,6 +1862,7 @@
 				INFOPLIST_KEY_WKRunsIndependentlyOfCompanionApp = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.majortom.app.watchkitapp;
 				PRODUCT_NAME = MajorTomWatch;
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SDKROOT = watchos;
 				SKIP_INSTALL = YES;
 				SUPPORTS_MACCATALYST = NO;
@@ -1873,6 +1876,9 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = 4B8499Z59P;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_GENERATION_MODE = GeneratedFile;
 				INFOPLIST_KEY_CFBundleDisplayName = "Major Tom";
@@ -1880,6 +1886,7 @@
 				INFOPLIST_KEY_WKRunsIndependentlyOfCompanionApp = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.majortom.app.watchkitapp;
 				PRODUCT_NAME = MajorTomWatch;
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SDKROOT = watchos;
 				SKIP_INSTALL = YES;
 				SUPPORTS_MACCATALYST = NO;
@@ -1895,6 +1902,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
+				DEVELOPMENT_TEAM = 4B8499Z59P;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = MajorTom/Info.plist;
 				INFOPLIST_GENERATION_MODE = GeneratedFile;
@@ -1956,7 +1964,7 @@
 				COPY_PHASE_STRIP = NO;
 				CURRENT_PROJECT_VERSION = 1;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = 4B8499Z59P;
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
@@ -1986,7 +1994,11 @@
 				INFOPLIST_FILE = MajorTomWidgets/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = "Major Tom Widgets";
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../../Frameworks @executable_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../../Frameworks",
+					"@executable_path/Frameworks",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.majortom.app.widgets;
 				PRODUCT_NAME = MajorTomWidgets;
 				SDKROOT = iphoneos;
@@ -2002,6 +2014,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
+				DEVELOPMENT_TEAM = 4B8499Z59P;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = MajorTom/Info.plist;
 				INFOPLIST_GENERATION_MODE = GeneratedFile;
@@ -2034,7 +2047,11 @@
 				INFOPLIST_FILE = MajorTomWidgets/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = "Major Tom Widgets";
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../../Frameworks @executable_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../../Frameworks",
+					"@executable_path/Frameworks",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.majortom.app.widgets;
 				PRODUCT_NAME = MajorTomWidgets;
 				SDKROOT = iphoneos;
@@ -2081,7 +2098,7 @@
 				COPY_PHASE_STRIP = NO;
 				CURRENT_PROJECT_VERSION = 1;
 				DEBUG_INFORMATION_FORMAT = dwarf;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = 4B8499Z59P;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu11;

--- a/ios/MajorTom/Core/Services/AuthService.swift
+++ b/ios/MajorTom/Core/Services/AuthService.swift
@@ -24,7 +24,7 @@ final class AuthService {
     var authState: AuthState = .unpaired
     /// Session cookie value obtained from PIN login (used for WebSocket auth).
     var sessionCookie: String?
-    var serverURL: String = "majortom.seantokuzodevtunnel.space"
+    var serverURL: String = Secrets.tunnelURL
     /// User ID from the relay (populated after login).
     var userId: String?
     /// User role from the relay (populated after login).

--- a/ios/MajorTom/Core/Services/AuthService.swift
+++ b/ios/MajorTom/Core/Services/AuthService.swift
@@ -22,7 +22,8 @@ enum AuthState: Equatable {
 @MainActor
 final class AuthService {
     var authState: AuthState = .unpaired
-    /// Session cookie value obtained from PIN login (used for WebSocket auth).
+    /// Session cookie value from the relay (Google OAuth or PIN login).
+    /// Used for WebSocket auth.
     var sessionCookie: String?
     var serverURL: String = Secrets.tunnelURL
     /// User ID from the relay (populated after login).

--- a/ios/MajorTom/Core/Services/Secrets.swift.example
+++ b/ios/MajorTom/Core/Services/Secrets.swift.example
@@ -1,0 +1,11 @@
+import Foundation
+
+/// Copy this file to `Secrets.swift` and fill in your relay's URLs.
+/// `Secrets.swift` is gitignored so your real URLs never reach GitHub.
+enum Secrets {
+    /// Public Cloudflare tunnel hostname for off-LAN access.
+    static let tunnelURL = "your-tunnel.example.com"
+
+    /// Stable Tailscale address for VPN-routed access.
+    static let tailscaleAddress = "100.x.x.x:9090"
+}

--- a/ios/MajorTom/Features/Pairing/ViewModels/PairingViewModel.swift
+++ b/ios/MajorTom/Features/Pairing/ViewModels/PairingViewModel.swift
@@ -1,5 +1,33 @@
 import Foundation
 
+// MARK: - Server Presets
+
+/// Relay URL targets picked from the device's current reachability.
+/// LAN deliberately falls through to the public tunnel — Bonjour
+/// discovery (see `currentRelayURL`) takes precedence when an mDNS
+/// broadcast is visible, so the tunnel is only used as a safety net
+/// when Bonjour can't see the relay (mDNS blocked, Mac asleep).
+enum ServerPreset {
+    case cloudflare
+    case tailscale
+
+    var address: String {
+        switch self {
+        case .cloudflare: return Secrets.tunnelURL
+        case .tailscale:  return Secrets.tailscaleAddress
+        }
+    }
+
+    init?(reachability: NetworkPathMonitor.Reachability) {
+        switch reachability {
+        case .tailscale: self = .tailscale
+        case .lan:       self = .cloudflare
+        case .cellular:  self = .cloudflare
+        case .offline:   return nil
+        }
+    }
+}
+
 @Observable
 @MainActor
 final class PairingViewModel {

--- a/ios/MajorTom/Features/Pairing/ViewModels/PairingViewModel.swift
+++ b/ios/MajorTom/Features/Pairing/ViewModels/PairingViewModel.swift
@@ -3,8 +3,6 @@ import Foundation
 @Observable
 @MainActor
 final class PairingViewModel {
-    var pin: String = ""
-    var serverAddress: String = ""
     var authMethods: AuthMethods?
     var isFetchingMethods = false
     /// Google iOS OAuth client ID surfaced by the relay (`/auth/google/client-id`).
@@ -30,7 +28,6 @@ final class PairingViewModel {
         self.network = network ?? NetworkPathMonitor()
         self.browser = browser ?? BonjourBrowser()
         self.googleOAuth = googleOAuth ?? GoogleOAuthService()
-        self.serverAddress = auth.serverURL
     }
 
     var authState: AuthState { auth.authState }
@@ -42,15 +39,6 @@ final class PairingViewModel {
         return nil
     }
 
-    var canSubmit: Bool {
-        pin.count == 6 && !isPairing
-    }
-
-    /// Whether PIN auth is available (or auth methods haven't been fetched yet).
-    var isPinEnabled: Bool {
-        authMethods?.pin ?? true
-    }
-
     /// Whether Google sign-in is offerable in the UI — relay must have Google
     /// auth enabled AND have an iOS client ID configured. The iOS app can't
     /// run the flow without a client ID, so we hide the button instead of
@@ -59,28 +47,24 @@ final class PairingViewModel {
         (authMethods?.google ?? false) && (googleIOSClientID?.isEmpty == false)
     }
 
-    /// Whether any auth method is available.
-    var hasAnyAuthMethod: Bool {
-        guard let methods = authMethods else { return true }
-        return methods.pin || methods.google
-    }
-
-    /// Live list of relays discovered on the local network via Bonjour
-    /// (`_majortom._tcp`). Empty when offline, browsing hasn't started,
-    /// or local-network permission has been denied.
-    var discoveredServices: [BonjourBrowser.DiscoveredService] {
-        browser.services
-    }
-
-    /// Whether Bonjour discovery is actively browsing (`false` after
-    /// stop or permission denial).
-    var isBrowsing: Bool {
-        browser.isBrowsing
+    /// Resolve the relay URL at call-time:
+    /// 1. First Bonjour-discovered service if any (lowest latency on LAN).
+    /// 2. Reachability-driven preset (Tailscale on VPN, tunnel otherwise).
+    /// 3. Tunnel hostname as a final safety net so signin never has nothing to hit.
+    var currentRelayURL: String {
+        if let discovered = browser.services.first {
+            return discovered.address
+        }
+        if let preset = ServerPreset(reachability: network.reachability) {
+            return preset.address
+        }
+        return Secrets.tunnelURL
     }
 
     /// Start mDNS discovery. Idempotent — safe to call repeatedly on
-    /// view appear. Wraps the Bonjour service to preserve MVVM so the
-    /// view doesn't reach into the discovery service directly.
+    /// view appear. The pairing UI no longer surfaces the discovered
+    /// services, but they still drive `currentRelayURL` so an on-LAN
+    /// relay is preferred over the tunnel.
     func startDiscovery() {
         browser.start()
     }
@@ -91,49 +75,17 @@ final class PairingViewModel {
         browser.stop()
     }
 
-    /// Single preset matched to the phone's current reachability — `nil`
-    /// when offline or before the path monitor has fired its first update.
-    var recommendedPreset: ServerPreset? {
-        ServerPreset(reachability: network.reachability)
-    }
-
-    /// Apply the auto-picked URL and refetch auth methods.
-    func useRecommended() async {
-        guard let preset = recommendedPreset else { return }
-        await applyAddress(preset.address)
-    }
-
-    /// Apply a Bonjour-discovered relay and refetch auth methods.
-    func useDiscovered(_ service: BonjourBrowser.DiscoveredService) async {
-        await applyAddress(service.address)
-    }
-
-    /// On first appear, if the user has no saved server URL, seed the field
-    /// with the first discovered service if one exists, falling back to the
-    /// path monitor's recommendation. Subsequent reachability changes do
-    /// NOT auto-overwrite — the user can tap a chip to refresh on demand.
-    func applyInitialRecommendationIfNeeded() {
-        guard serverAddress.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
-        if let discovered = discoveredServices.first {
-            serverAddress = discovered.address
-            return
-        }
-        if let preset = recommendedPreset {
-            serverAddress = preset.address
-        }
-    }
-
     /// Fetch auth methods from the relay to adapt the login UI.
     /// Also fetches the Google client-id payload when Google is enabled so
     /// the iOS app knows whether the relay is set up for native sign-in.
     func fetchAuthMethods() async {
-        let trimmed = serverAddress.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty else { return }
+        let target = currentRelayURL
+        guard !target.isEmpty else { return }
 
         isFetchingMethods = true
         defer { isFetchingMethods = false }
 
-        let baseURL = AuthService.normalizeBaseURL(trimmed)
+        let baseURL = AuthService.normalizeBaseURL(target)
         guard let url = URL(string: "\(baseURL)/auth/methods") else { return }
 
         do {
@@ -142,7 +94,6 @@ final class PairingViewModel {
                   httpResponse.statusCode == 200 else { return }
             authMethods = try JSONDecoder().decode(AuthMethods.self, from: data)
         } catch {
-            // Older relays may not have this endpoint — show all methods
             authMethods = nil
         }
 
@@ -155,7 +106,8 @@ final class PairingViewModel {
 
     /// Pull the relay's iOS Google client ID. Optional endpoint — older
     /// relays don't return `iosClientId`, in which case the Google button
-    /// stays hidden and the user falls back to PIN.
+    /// stays hidden and the user sees the "Google sign-in not available"
+    /// fallback.
     private func fetchGoogleClientID(baseURL: String) async {
         guard let url = URL(string: "\(baseURL)/auth/google/client-id") else { return }
         do {
@@ -182,22 +134,22 @@ final class PairingViewModel {
     /// the auth code for an ID token, then exchange the ID token for a
     /// relay session cookie. Pre-flights reachability so we surface
     /// "Server unreachable at <URL>" instead of "Connection failed" when
-    /// the user picked a stale chip.
+    /// the auto-picked relay can't be reached.
     func signInWithGoogle() async {
-        let trimmed = serverAddress.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty else { return }
+        let target = currentRelayURL
+        guard !target.isEmpty else { return }
         guard let clientID = googleIOSClientID, !clientID.isEmpty else {
             auth.authState = .error("Relay isn't configured for iOS Google sign-in")
             return
         }
 
-        if !(await reachable(trimmed)) {
-            auth.authState = .error("Server unreachable at \(trimmed). Pick a different relay or check your network.")
+        if !(await reachable(target)) {
+            auth.authState = .error("Server unreachable at \(target). Check your network or relay status.")
             HapticService.deny()
             return
         }
 
-        auth.saveServerURL(trimmed)
+        auth.saveServerURL(target)
         isSigningInWithGoogle = true
         defer { isSigningInWithGoogle = false }
 
@@ -217,65 +169,13 @@ final class PairingViewModel {
         }
     }
 
-    func submitPIN() async {
-        let trimmed = serverAddress.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty else { return }
-
-        // Pre-flight reachability ping — turns silent "Connection failed" into
-        // a specific "Server unreachable at <URL>" so the user knows whether
-        // to fix the URL or the PIN.
-        if !(await reachable(trimmed)) {
-            auth.authState = .error("Server unreachable at \(trimmed). Pick a different relay or check your network.")
-            HapticService.deny()
-            return
-        }
-
-        auth.saveServerURL(trimmed)
-        await auth.pair(pin: pin)
-
-        if auth.isPaired {
-            HapticService.celebrate()
-        } else {
-            HapticService.deny()
-            pin = ""
-        }
-    }
-
-    func appendDigit(_ digit: String) {
-        guard pin.count < 6 else { return }
-        pin += digit
-        HapticService.buttonTap()
-    }
-
-    func deleteDigit() {
-        guard !pin.isEmpty else { return }
-        pin.removeLast()
-        HapticService.buttonTap()
-    }
-
-    func clearPIN() {
-        pin = ""
-    }
-
     // MARK: - Helpers
-
-    private func applyAddress(_ address: String) async {
-        serverAddress = address
-        // Surface "Server unreachable at <URL>" on chip-tap the same way
-        // submitPIN does — keeps the spec's targeted error path consistent
-        // whether the user reaches the relay via chip or PIN submit.
-        if !(await reachable(address)) {
-            auth.authState = .error("Server unreachable at \(address). Pick a different relay or check your network.")
-            return
-        }
-        await fetchAuthMethods()
-    }
 
     /// 2-second probe against `/auth/methods`. Returns `true` for any
     /// HTTP response (including 4xx/5xx) — only transport errors mean
     /// unreachable. A reachable-but-broken server still gets the user
     /// past the targeted "Server unreachable at <URL>" message into the
-    /// PIN-exchange path where downstream errors carry more detail.
+    /// sign-in path where downstream errors carry more detail.
     private func reachable(_ address: String) async -> Bool {
         let baseURL = AuthService.normalizeBaseURL(address)
         guard let url = URL(string: "\(baseURL)/auth/methods") else { return false }

--- a/ios/MajorTom/Features/Pairing/Views/PairingView.swift
+++ b/ios/MajorTom/Features/Pairing/Views/PairingView.swift
@@ -2,30 +2,28 @@ import SwiftUI
 
 // MARK: - Server Presets
 
-enum ServerPreset: String {
-    case cloudflare = "majortom.seantokuzodevtunnel.space"
-    case tailscale  = "100.69.151.117:9090"
-    case localhost   = "localhost:9090"
+/// Relay URL targets picked from the device's current reachability.
+/// LAN deliberately falls through to the public tunnel — Bonjour
+/// discovery (see `PairingViewModel.currentRelayURL`) takes precedence
+/// when an mDNS broadcast is visible, so the tunnel is only used as a
+/// safety net when Bonjour can't see the relay (mDNS blocked, Mac asleep).
+enum ServerPreset {
+    case cloudflare
+    case tailscale
+    case localhost
 
-    var address: String { rawValue }
-
-    var label: String {
+    var address: String {
         switch self {
-        case .cloudflare: return "☁️ Tunnel"
-        case .tailscale:  return "🔒 Tailscale"
-        case .localhost:   return "💻 Local"
+        case .cloudflare: return Secrets.tunnelURL
+        case .tailscale:  return Secrets.tailscaleAddress
+        case .localhost:  return "localhost:9090"
         }
     }
 
-    /// Single preset for the device's current reachability. Tailscale
-    /// (or any VPN presenting as `.other`) wins over LAN; cellular-only
-    /// falls back to the public Cloudflare tunnel; offline returns nil.
-    /// LAN is intentionally NOT a preset — it's served by Bonjour
-    /// discovery in the pairing view, since the Mac's LAN IP drifts.
     init?(reachability: NetworkPathMonitor.Reachability) {
         switch reachability {
         case .tailscale: self = .tailscale
-        case .lan:       return nil
+        case .lan:       self = .cloudflare
         case .cellular:  self = .cloudflare
         case .offline:   return nil
         }
@@ -58,62 +56,20 @@ struct PairingView: View {
                     .font(.system(.largeTitle, design: .monospaced, weight: .bold))
                     .foregroundStyle(MajorTomTheme.Colors.textPrimary)
 
-                Text(headerSubtitle)
+                Text("Sign in with Google to connect")
                     .font(MajorTomTheme.Typography.body)
                     .foregroundStyle(MajorTomTheme.Colors.textSecondary)
                     .multilineTextAlignment(.center)
                     .padding(.horizontal, MajorTomTheme.Spacing.xxl)
             }
 
-            // Server address
-            VStack(spacing: MajorTomTheme.Spacing.sm) {
-                Text("Relay Server")
-                    .font(MajorTomTheme.Typography.caption)
-                    .foregroundStyle(MajorTomTheme.Colors.textTertiary)
-
-                TextField("host:port", text: $viewModel.serverAddress)
-                    .textFieldStyle(.plain)
-                    .font(MajorTomTheme.Typography.codeFont)
-                    .foregroundStyle(MajorTomTheme.Colors.textPrimary)
-                    .multilineTextAlignment(.center)
-                    .padding(MajorTomTheme.Spacing.md)
-                    .background(MajorTomTheme.Colors.surface)
-                    .clipShape(RoundedRectangle(cornerRadius: MajorTomTheme.Radius.small))
-                    .autocorrectionDisabled()
-                    .textInputAutocapitalization(.never)
-                    .onSubmit {
-                        Task { await viewModel.fetchAuthMethods() }
-                    }
-
-                // Bonjour-discovered chips (live local-network relays)
-                // sit above the static fallback so the user sees the
-                // current LAN target without typing the Mac's IP.
-                discoveredChips
-
-                // Static fallback presets (tunnel, Tailscale, localhost)
-                // for off-LAN access — LAN itself comes from Bonjour above.
-                recommendationChip
-                    .frame(maxWidth: .infinity, alignment: .center)
-            }
-            .padding(.horizontal, MajorTomTheme.Spacing.xxl)
-
             if viewModel.isFetchingMethods {
                 ProgressView()
                     .tint(MajorTomTheme.Colors.accent)
-            } else if !viewModel.hasAnyAuthMethod {
-                // No auth methods enabled on the relay
-                noAuthMethodsView
+            } else if viewModel.isGoogleEnabled {
+                googleSignInButton
             } else {
-                if viewModel.isGoogleEnabled {
-                    googleSignInButton
-                    if viewModel.isPinEnabled {
-                        orSeparator
-                    }
-                }
-                if viewModel.isPinEnabled {
-                    // PIN auth available — show PIN entry
-                    pinDisplay
-                }
+                noAuthMethodsView
             }
 
             // Error message
@@ -127,156 +83,19 @@ struct PairingView: View {
                     .hapticOnAppear(.heavy)
             }
 
-            if viewModel.isPinEnabled && viewModel.hasAnyAuthMethod {
-                // PIN keypad
-                pinKeypad
-
-                // Submit button
-                Button {
-                    HapticService.impact(.medium)
-                    Task { await viewModel.submitPIN() }
-                } label: {
-                    Group {
-                        if viewModel.isPairing {
-                            ProgressView()
-                                .tint(.white)
-                        } else {
-                            Text("Connect")
-                                .font(MajorTomTheme.Typography.headline)
-                        }
-                    }
-                    .foregroundStyle(.white)
-                    .frame(maxWidth: .infinity)
-                    .padding(.vertical, MajorTomTheme.Spacing.md)
-                    .background(viewModel.canSubmit ? MajorTomTheme.Colors.accent : MajorTomTheme.Colors.textTertiary)
-                    .clipShape(RoundedRectangle(cornerRadius: MajorTomTheme.Radius.medium))
-                }
-                .disabled(!viewModel.canSubmit)
-                .padding(.horizontal, MajorTomTheme.Spacing.xxl)
-            }
-
             Spacer()
         }
         .background(MajorTomTheme.Colors.background)
         .animation(.easeInOut(duration: 0.2), value: viewModel.authState)
         .task {
-            // Start Bonjour discovery for live local-network relays.
+            // Bonjour browses silently so LAN-resolved URLs are preferred
+            // over the tunnel when the relay is on the same network.
             viewModel.startDiscovery()
-            // Seed an empty server field — prefers a discovered service if
-            // one's already known, falls back to the path monitor's
-            // recommendation. One-shot so reachability flips don't fight a
-            // user-typed override.
-            viewModel.applyInitialRecommendationIfNeeded()
             await viewModel.fetchAuthMethods()
         }
         .onDisappear {
             viewModel.stopDiscovery()
         }
-    }
-
-    @ViewBuilder
-    private var discoveredChips: some View {
-        if !viewModel.discoveredServices.isEmpty {
-            VStack(spacing: 6) {
-                Text("Found on your network")
-                    .font(.system(.caption2, design: .monospaced))
-                    .foregroundStyle(MajorTomTheme.Colors.textTertiary)
-                ScrollView(.horizontal, showsIndicators: false) {
-                    HStack(spacing: 6) {
-                        ForEach(viewModel.discoveredServices) { service in
-                            Button {
-                                HapticService.impact(.light)
-                                Task { await viewModel.useDiscovered(service) }
-                            } label: {
-                                VStack(alignment: .leading, spacing: 1) {
-                                    HStack(spacing: 4) {
-                                        Image(systemName: "wifi")
-                                            .font(.system(size: 10))
-                                        Text(service.displayName)
-                                            .font(.system(.caption2, design: .monospaced))
-                                            .lineLimit(1)
-                                    }
-                                    // Surface the resolved address as a
-                                    // second line so the user can spot
-                                    // lookalike chips from a hostile peer
-                                    // (Bonjour names are attacker-controlled
-                                    // — see PHASE-PAIRING-REBOOT Wave 2).
-                                    Text(service.address)
-                                        .font(.system(size: 9, design: .monospaced))
-                                        .lineLimit(1)
-                                        .opacity(0.75)
-                                }
-                                .foregroundStyle(
-                                    viewModel.serverAddress == service.address
-                                        ? MajorTomTheme.Colors.background
-                                        : MajorTomTheme.Colors.textSecondary
-                                )
-                                .padding(.horizontal, MajorTomTheme.Spacing.sm)
-                                .padding(.vertical, 4)
-                                .background(
-                                    viewModel.serverAddress == service.address
-                                        ? MajorTomTheme.Colors.accent
-                                        : MajorTomTheme.Colors.surfaceElevated
-                                )
-                                .clipShape(Capsule())
-                            }
-                        }
-                    }
-                }
-            }
-        } else if viewModel.isBrowsing {
-            HStack(spacing: 6) {
-                ProgressView().scaleEffect(0.6)
-                Text("Looking for relay on your network...")
-                    .font(.system(.caption2, design: .monospaced))
-                    .foregroundStyle(MajorTomTheme.Colors.textTertiary)
-            }
-        }
-    }
-
-    @ViewBuilder
-    private var recommendationChip: some View {
-        if let preset = viewModel.recommendedPreset {
-            Button {
-                HapticService.impact(.light)
-                Task { await viewModel.useRecommended() }
-            } label: {
-                HStack(spacing: 4) {
-                    Text("Auto:")
-                        .font(.system(.caption2, design: .monospaced))
-                        .foregroundStyle(MajorTomTheme.Colors.textTertiary)
-                    Text(preset.label)
-                        .font(.system(.caption2, design: .monospaced))
-                        .foregroundStyle(
-                            viewModel.serverAddress == preset.address
-                                ? MajorTomTheme.Colors.background
-                                : MajorTomTheme.Colors.textSecondary
-                        )
-                }
-                .padding(.horizontal, MajorTomTheme.Spacing.sm)
-                .padding(.vertical, 4)
-                .background(
-                    viewModel.serverAddress == preset.address
-                        ? MajorTomTheme.Colors.accent
-                        : MajorTomTheme.Colors.surfaceElevated
-                )
-                .clipShape(Capsule())
-            }
-        } else {
-            Text("Offline — enter a relay URL above")
-                .font(.system(.caption2, design: .monospaced))
-                .foregroundStyle(MajorTomTheme.Colors.textTertiary)
-        }
-    }
-
-    private var headerSubtitle: String {
-        if !viewModel.hasAnyAuthMethod {
-            return "No authentication methods are enabled on the relay server"
-        }
-        if viewModel.isPinEnabled {
-            return "Enter the 6-digit PIN from your relay server"
-        }
-        return "Connect to your relay server"
     }
 
     // MARK: - Google Sign-In
@@ -311,32 +130,17 @@ struct PairingView: View {
         .padding(.horizontal, MajorTomTheme.Spacing.xxl)
     }
 
-    private var orSeparator: some View {
-        HStack(spacing: MajorTomTheme.Spacing.md) {
-            Rectangle()
-                .fill(MajorTomTheme.Colors.surfaceElevated)
-                .frame(height: 1)
-            Text("or use PIN")
-                .font(.system(.caption2, design: .monospaced))
-                .foregroundStyle(MajorTomTheme.Colors.textTertiary)
-            Rectangle()
-                .fill(MajorTomTheme.Colors.surfaceElevated)
-                .frame(height: 1)
-        }
-        .padding(.horizontal, MajorTomTheme.Spacing.xxl)
-    }
-
     private var noAuthMethodsView: some View {
         VStack(spacing: MajorTomTheme.Spacing.md) {
             Image(systemName: "lock.slash")
                 .font(.system(size: 36))
                 .foregroundStyle(MajorTomTheme.Colors.deny)
 
-            Text("No authentication methods enabled")
+            Text("Google sign-in not available")
                 .font(MajorTomTheme.Typography.headline)
                 .foregroundStyle(MajorTomTheme.Colors.textPrimary)
 
-            Text("Contact your relay administrator to enable PIN or Google authentication.")
+            Text("Make sure the relay is reachable and has Google OAuth configured for iOS.")
                 .font(MajorTomTheme.Typography.body)
                 .foregroundStyle(MajorTomTheme.Colors.textSecondary)
                 .multilineTextAlignment(.center)
@@ -352,86 +156,6 @@ struct PairingView: View {
             .padding(.top, MajorTomTheme.Spacing.sm)
         }
         .padding(.horizontal, MajorTomTheme.Spacing.xl)
-    }
-
-    // MARK: - PIN Display
-
-    private var pinDisplay: some View {
-        HStack(spacing: MajorTomTheme.Spacing.md) {
-            ForEach(0..<6, id: \.self) { index in
-                let isFilled = index < viewModel.pin.count
-                RoundedRectangle(cornerRadius: MajorTomTheme.Radius.small)
-                    .fill(isFilled ? MajorTomTheme.Colors.accent : MajorTomTheme.Colors.surface)
-                    .frame(width: 44, height: 52)
-                    .overlay {
-                        if isFilled {
-                            let pinIndex = viewModel.pin.index(viewModel.pin.startIndex, offsetBy: index)
-                            Text(String(viewModel.pin[pinIndex]))
-                                .font(.system(.title, design: .monospaced, weight: .bold))
-                                .foregroundStyle(MajorTomTheme.Colors.background)
-                        }
-                    }
-                    .overlay {
-                        RoundedRectangle(cornerRadius: MajorTomTheme.Radius.small)
-                            .stroke(
-                                index == viewModel.pin.count
-                                    ? MajorTomTheme.Colors.accent
-                                    : MajorTomTheme.Colors.surfaceElevated,
-                                lineWidth: index == viewModel.pin.count ? 2 : 1
-                            )
-                    }
-            }
-        }
-        .padding(.horizontal, MajorTomTheme.Spacing.xxl)
-    }
-
-    // MARK: - Keypad
-
-    private var pinKeypad: some View {
-        VStack(spacing: MajorTomTheme.Spacing.md) {
-            ForEach(keypadRows, id: \.self) { row in
-                HStack(spacing: MajorTomTheme.Spacing.md) {
-                    ForEach(row, id: \.self) { key in
-                        keypadButton(key)
-                    }
-                }
-            }
-        }
-        .padding(.horizontal, MajorTomTheme.Spacing.xxl)
-    }
-
-    private var keypadRows: [[String]] {
-        [
-            ["1", "2", "3"],
-            ["4", "5", "6"],
-            ["7", "8", "9"],
-            ["", "0", "⌫"],
-        ]
-    }
-
-    private func keypadButton(_ key: String) -> some View {
-        Group {
-            if key.isEmpty {
-                Color.clear
-                    .frame(width: 72, height: 52)
-            } else {
-                Button {
-                    HapticService.impact(.light)
-                    if key == "⌫" {
-                        viewModel.deleteDigit()
-                    } else {
-                        viewModel.appendDigit(key)
-                    }
-                } label: {
-                    Text(key)
-                        .font(.system(.title2, design: .monospaced, weight: .semibold))
-                        .foregroundStyle(MajorTomTheme.Colors.textPrimary)
-                        .frame(width: 72, height: 52)
-                        .background(MajorTomTheme.Colors.surfaceElevated)
-                        .clipShape(RoundedRectangle(cornerRadius: MajorTomTheme.Radius.small))
-                }
-            }
-        }
     }
 }
 

--- a/ios/MajorTom/Features/Pairing/Views/PairingView.swift
+++ b/ios/MajorTom/Features/Pairing/Views/PairingView.swift
@@ -1,35 +1,5 @@
 import SwiftUI
 
-// MARK: - Server Presets
-
-/// Relay URL targets picked from the device's current reachability.
-/// LAN deliberately falls through to the public tunnel — Bonjour
-/// discovery (see `PairingViewModel.currentRelayURL`) takes precedence
-/// when an mDNS broadcast is visible, so the tunnel is only used as a
-/// safety net when Bonjour can't see the relay (mDNS blocked, Mac asleep).
-enum ServerPreset {
-    case cloudflare
-    case tailscale
-    case localhost
-
-    var address: String {
-        switch self {
-        case .cloudflare: return Secrets.tunnelURL
-        case .tailscale:  return Secrets.tailscaleAddress
-        case .localhost:  return "localhost:9090"
-        }
-    }
-
-    init?(reachability: NetworkPathMonitor.Reachability) {
-        switch reachability {
-        case .tailscale: self = .tailscale
-        case .lan:       self = .cloudflare
-        case .cellular:  self = .cloudflare
-        case .offline:   return nil
-        }
-    }
-}
-
 struct PairingView: View {
     @State private var viewModel: PairingViewModel
 

--- a/relay/.env.example
+++ b/relay/.env.example
@@ -7,6 +7,11 @@ WS_PORT=4030
 # dev sessions where you'd otherwise time out before scanning the PIN.
 MAJORTOM_PIN_TTL_MIN=5
 
+# AUTH_PIN_ENABLED — set to 'false' to disable PIN auth entirely (Google
+# OAuth only). When false, /auth/pin/* routes return 404 early and the
+# startup banner skips PIN generation. Default true.
+# AUTH_PIN_ENABLED=true
+
 # Hook HTTP server port (Claude Code hooks POST here)
 HOOK_PORT=4031
 


### PR DESCRIPTION
## Summary

User feedback after Wave 2A item 1 shipped: the PIN flow is dead to him now that Google + 7-day session cookies cover the pairing pain. This PR:

- **Strips the entire PIN UI from iOS** — pairing screen is now logo + "Sign in with Google to connect" + a single Google button.
- **Hides URL/network UI** behind silent auto-routing — no text field, no Bonjour chip row, no "Auto:" preset, no "Offline — enter a relay" hint.
- **Neuters PIN routes on the relay** via `AUTH_PIN_ENABLED=false` — route-level guard returns 404 early (auth.ts:294-301). PIN code modules + `MAJORTOM_PIN_TTL_MIN` env knob stay intact for a future re-enable.
- **Pulls tunnel hostname + Tailscale address out of committed source** into a gitignored `Secrets.swift`. A committed `Secrets.swift.example` is the template.
- **Restores `DEVELOPMENT_TEAM`** across the build configs that PR #171 accidentally wiped.

## Why

Two motivating items, surfaced during on-device QA of Wave 2A item 1:
1. **OAuth + 7-day cookie covers the dev-session pain better than PIN ever could** — user only sees the Google button once a week, with passkey support behind the scenes turning even that into a Face-ID tap.
2. **Tunnel URL was committed in `PairingView.swift:6` and `AuthService.swift:27`** — anyone reading the public repo could probe `/auth/methods` and discovery endpoints. `ALLOWED_EMAIL` gates actual sign-in, but the URL leak is recon-surface we don't need to ship.

## URL resolution (now silent)

| Network state | URL picked | How |
|---|---|---|
| Bonjour finds relay on LAN | discovered `host:port` | mDNS (`_majortom._tcp`) |
| Tailscale / VPN reachable | `Secrets.tailscaleAddress` | `NWPathMonitor` sees `.other` |
| Cellular / off-LAN / Bonjour blocked on LAN | `Secrets.tunnelURL` | reachability preset (`.lan` now also falls back to `.cloudflare`) |
| Offline | tunnel hostname as last-resort | so signin never has nothing to hit |

`currentRelayURL` is computed at call-time in `PairingViewModel`, so Bonjour discovering the relay 2 seconds after view-load is still picked up when the user taps Google.

## Test plan

- [x] iOS build (generic iOS, `-allowProvisioningUpdates`) — **BUILD SUCCEEDED**
- [x] Installed to physical device — visual confirmation: pairing screen renders Google-only, no PIN UI, no URL UI.
- [x] `/auth/methods` returns `{google: true, pin: false}`.
- [x] `/auth/pin/generate` → 404 `{"error":"PIN authentication is disabled"}`.
- [x] `/auth/pin/login` → 404.
- [x] Banner reads `Auth: Google OAuth (seantokuzo@gmail.com)` only — no PIN generation block.
- [x] `grep` confirms zero references to `seantokuzodevtunnel.space` or `100.69.151.117` in any tracked file.
- [ ] OAuth round-trip on device — sign out → tap Google → ASWebAuth → consent → return → paired.
- [ ] Reachability regression check: turn Wi-Fi off → should pick `Secrets.tunnelURL`; turn Tailscale on → should pick Tailscale.

## Activation for new contributors

Anyone cloning the repo needs to copy `ios/MajorTom/Core/Services/Secrets.swift.example` to `Secrets.swift` and fill in their own tunnel URL + Tailscale address before the iOS build will succeed. The `.example` file has placeholder values.

## What's kept on purpose

- Relay `pin-manager.ts`, the PIN routes themselves, `MAJORTOM_PIN_TTL_MIN`, and `PinManager` tests all stay — flipping `AUTH_PIN_ENABLED=true` (or unsetting) re-enables the path cleanly.
- iOS `AuthService.pair(pin:)` stays — dead until something calls it, but the PWA path is untouched and this keeps the door open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
