### PR TITLE
fix(relay): bash interactive shell flag + close Pairing Reboot phase doc

### DIFF
--- a/docs/PHASE-PAIRING-REBOOT.md
+++ b/docs/PHASE-PAIRING-REBOOT.md
@@ -69,3 +69,46 @@ To actually use Sign-in-with-Google from the iOS app, the relay operator needs t
 - No relay-side `/api/discovery` endpoint (Wave 2).
 - No `tunnel:setup`/cloudflared changes.
 - No PWA changes — PWA discovery is handled by `window.location` already.
+
+---
+
+## Phase Closeout (2026-05-23)
+
+Pairing Reboot is **closed**. The original pain (DHCP-drift LAN IP + 5-min PIN treadmill) is fully resolved by what shipped, and the remaining waves are obsolete because the PR-#173 consolidation simplified the UX past what they were designed to fix.
+
+### Shipped
+
+| Wave | PR | Merged | Effect |
+|------|----|--------|--------|
+| 1 — mDNS discovery + pre-flight ping | #170 | 2026-05-12 | LAN-IP drift fixed; "Server unreachable" replaces "Connection failed" |
+| 2A item 1 — Google OAuth in iOS PairingView | #171 | 2026-05-20 | ASWebAuthenticationSession + PKCE; 7-day session cookie |
+| 2A item 2 — `MAJORTOM_PIN_TTL_MIN` env knob | #172 | 2026-05-21 | PIN TTL now configurable (dormant after OAuth-only flip) |
+| OAuth-only consolidation | #173 | 2026-05-23 | PIN UI gone from iOS, URL UI gone, `AUTH_PIN_ENABLED=false` on relay returns 404 on PIN routes, tunnel URL hoisted into gitignored `Secrets.swift` |
+
+### Wave 2 — provenance + security UX → **OBSOLETE**
+
+The OAuth-only consolidation removed every UI surface Wave 2 was designed to harden:
+
+- `GET /api/discovery` was for surfacing the live tunnel URL on chips → no chips render anymore.
+- URL provenance tracking + stale-URL auto-clear → no URL input field for the user to manage.
+- Relay fingerprint chip → no chips.
+- Sanitize Bonjour `displayName` rendering → `displayName` no longer rendered anywhere (Bonjour is now silent infrastructure feeding `currentRelayURL`).
+
+The realistic threat model is now `ALLOWED_EMAIL`-gated: even if an attacker fronts an mDNS lookalike `_majortom._tcp` service on a hostile LAN, the OAuth flow won't mint a session unless the Google account's email matches `seantokuzo@gmail.com` on the real relay. Documented as an explicit design trade-off in PR #173's review responses.
+
+### Wave 2A item 3 — biometric quick-pair → **DEPRIORITIZED (subsumed)**
+
+Google passkey on the user's Google account + 7-day OAuth session cookie + ASWebAuthenticationSession's cookie reuse already deliver the Face-ID-only re-auth Wave 2A item 3 was designed to add. Revisit only if Sean reports signing out often.
+
+### Wave 3 — UX polish → **OBSOLETE**
+
+- Chip RTT labels → no chips.
+- "Recently used" history → no URL UI to history.
+- Manual override 🔒 lock icon → no manual override.
+
+The login screen is now logo + "Sign in with Google to connect" + one button. There is nothing left to polish at this layer.
+
+### Out of phase (still queued)
+
+- `docs/QA-FIXES.md` follow-ups — see `project_qa_followups_phase.md` and `project_qa_p3_handoff.md`.
+- README setup doc for fresh clones (someone has to copy `Secrets.swift.example` → `Secrets.swift` before iOS builds) — see PR #173 advisory thread for context.

--- a/relay/src/adapters/pty-adapter.ts
+++ b/relay/src/adapters/pty-adapter.ts
@@ -187,7 +187,13 @@ export class PtyAdapter {
       this.resolveDefaultCwd = homeFallback;
     }
     this.shell = opts.shell ?? this.env['SHELL'] ?? '/bin/bash';
-    this.shellArgs = opts.shellArgs ?? ['-l'];
+    // `-l -i`: login + explicit interactive. `-l` so the shell picks up the
+    // user's `.bash_profile` / `.zprofile` env (PATH, NVM, etc.); `-i` to
+    // force interactive mode so bash sources `.bashrc` even though the PTY
+    // stdin already qualifies as a TTY. Without `-i`, some bash setups skip
+    // the user's prompt-defining `.bashrc` on the very first render, leaving
+    // the default `\s-\v\$` PS1 visible until the next prompt (QA-FIXES #18).
+    this.shellArgs = opts.shellArgs ?? ['-l', '-i'];
     this.spawnFn = opts.spawn ?? pty.spawn;
     this.onTabClosed = opts.onTabClosed;
   }


### PR DESCRIPTION
## Summary

Two small, unrelated-but-bundled changes per request:

### 1. QA-FIXES #18 — Bash PS1 first-prompt missing `\W` _(probable fix, needs device QA)_

Changes `pty-adapter.ts` default `shellArgs` from `['-l']` to `['-l', '-i']`. Login mode (`-l`) stays so the shell picks up `.bash_profile` / `.zprofile` env (PATH, NVM, etc.); explicit interactive (`-i`) forces bash to treat the session as interactive from word zero, which on some setups makes `.bashrc`'s prompt-defining block fire on prompt #1 instead of after the next keystroke.

**Honest caveat:** I couldn't pin down the exact root cause without device access. Sean's bash setup probes correctly locally (login PS1 has `\W`, env `PWD` already seeded by the existing line at `pty-adapter.ts:410`), and there's no `cd` injection between spawn and first prompt. The `-i` add is the most plausible single-line shot. If the broken first prompt still repros after this lands, we iterate live on-device — likely a redraw / attach-timing issue I can't see from here.

### 2. Close out Pairing Reboot phase doc

`docs/PHASE-PAIRING-REBOOT.md` gains a **Phase Closeout (2026-05-23)** section:
- Records the four shipped PRs (#170 Wave 1, #171 Wave 2A item 1, #172 Wave 2A item 2, #173 OAuth-only consolidation).
- Marks **Wave 2** (provenance + security UX) **OBSOLETE** — every UI surface it was designed to harden was removed by the OAuth-only consolidation. Hostile-LAN mDNS lookalike is now `ALLOWED_EMAIL`-gated rather than chip-fingerprint-gated.
- Marks **Wave 2A item 3** (biometric quick-pair) **DEPRIORITIZED (subsumed)** — Google passkey + 7-day OAuth cookie already delivers Face-ID-only re-auth.
- Marks **Wave 3** (UX polish) **OBSOLETE** — login screen is one button, nothing to polish at this layer.

## Test plan

- [x] `npm run typecheck` (relay) — clean
- [x] `npm test` (relay) — 357/357 passing (existing tests pass `shellArgs: []` explicitly so the default-change is a no-op for them; the default is exercised by new spawns)
- [ ] **Device QA on Sean's phone:** open a fresh plain-bash tab, confirm first prompt includes `\W`. Repeat with 2–3 fresh tabs (the QA criterion from `project_qa_p3_handoff.md`).

## Out of scope (deferred)

- README setup doc explaining `Secrets.swift.example` → `Secrets.swift` copy step for fresh clones. Filed as a follow-up in PR #173's review thread; no README to extend today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
