### PR TITLE
feat(ios): prefer a verified LAN relay at connect time

### DIFF
--- a/ios/MajorTom.xcodeproj/project.pbxproj
+++ b/ios/MajorTom.xcodeproj/project.pbxproj
@@ -145,6 +145,7 @@
 		B7F0B7EF40820D1ACBD5720D /* Annotation.swift in Sources */ = {isa = PBXBuildFile; fileRef = A36A4C7C1708949F54A7FB29 /* Annotation.swift */; };
 		B80728DFDC6CDB7632A9C9F3 /* BonjourBrowser.swift in Sources */ = {isa = PBXBuildFile; fileRef = C069FA164159ADD13137E0D4 /* BonjourBrowser.swift */; };
 		DA7A9B0C1E2F3A4B5C6D7E8F /* RelayURLResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE9D8C7B6A5040312233445F /* RelayURLResolver.swift */; };
+		DA7A9B0C1E2F3A4B5C6D7E90 /* RelayIdentityVerifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE9D8C7B6A50403122334460 /* RelayIdentityVerifier.swift */; };
 		B9CFDC96DCA82CD435DD595A /* AchievementDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67A72007588F923516F48711 /* AchievementDetailView.swift */; };
 		BA5A66BBDF281BB44ECE265A /* SessionStatusWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DA07545B6E9F73EED9477FB /* SessionStatusWidget.swift */; };
 		BD4DE18F7D89A6E7BE778875 /* CharacterConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49975C50EF000FB470E30360 /* CharacterConfig.swift */; };
@@ -394,6 +395,7 @@
 		C0656AE4C6DEE802350E31BF /* MajorTomLiveActivityView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MajorTomLiveActivityView.swift; sourceTree = "<group>"; };
 		C069FA164159ADD13137E0D4 /* BonjourBrowser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BonjourBrowser.swift; sourceTree = "<group>"; };
 		FE9D8C7B6A5040312233445F /* RelayURLResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RelayURLResolver.swift; sourceTree = "<group>"; };
+		FE9D8C7B6A50403122334460 /* RelayIdentityVerifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RelayIdentityVerifier.swift; sourceTree = "<group>"; };
 		C13191C0A248C84CA6959981 /* WebSocketClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebSocketClient.swift; sourceTree = "<group>"; };
 		C1CCA0A46BE9EDE79DF3CB8F /* SessionCountWidget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionCountWidget.swift; sourceTree = "<group>"; };
 		C3905D6FC3ABC4A370246F3F /* FleetDashboardWidget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FleetDashboardWidget.swift; sourceTree = "<group>"; };
@@ -869,6 +871,7 @@
 				A2873A7A68C25BFA4E7C9756 /* AuthService.swift */,
 				C069FA164159ADD13137E0D4 /* BonjourBrowser.swift */,
 				FE9D8C7B6A5040312233445F /* RelayURLResolver.swift */,
+				FE9D8C7B6A50403122334460 /* RelayIdentityVerifier.swift */,
 				10F013B10B2AA2CD96B19588 /* DangerScoring.swift */,
 				0C7C2FED0200F1F7FCCC6ABA /* FeatureFlags.swift */,
 				11059EFAA85B7AEC69089941 /* GoogleOAuthService.swift */,
@@ -1678,6 +1681,7 @@
 				5C09E77A601A493E96E1CFF9 /* AutoApprovalBadge.swift in Sources */,
 				B80728DFDC6CDB7632A9C9F3 /* BonjourBrowser.swift in Sources */,
 				DA7A9B0C1E2F3A4B5C6D7E8F /* RelayURLResolver.swift in Sources */,
+				DA7A9B0C1E2F3A4B5C6D7E90 /* RelayIdentityVerifier.swift in Sources */,
 				4D8A276AB100B6546118BDCB /* CIPanelView.swift in Sources */,
 				559913FC6E46B681AB795212 /* CIRunsView.swift in Sources */,
 				BD4DE18F7D89A6E7BE778875 /* CharacterConfig.swift in Sources */,

--- a/ios/MajorTom.xcodeproj/project.pbxproj
+++ b/ios/MajorTom.xcodeproj/project.pbxproj
@@ -144,6 +144,7 @@
 		B6177A4A6F785D999DE4E458 /* SpriteResponseBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60796A9C3755F9334D0F7D8A /* SpriteResponseBanner.swift */; };
 		B7F0B7EF40820D1ACBD5720D /* Annotation.swift in Sources */ = {isa = PBXBuildFile; fileRef = A36A4C7C1708949F54A7FB29 /* Annotation.swift */; };
 		B80728DFDC6CDB7632A9C9F3 /* BonjourBrowser.swift in Sources */ = {isa = PBXBuildFile; fileRef = C069FA164159ADD13137E0D4 /* BonjourBrowser.swift */; };
+		DA7A9B0C1E2F3A4B5C6D7E8F /* RelayURLResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE9D8C7B6A5040312233445F /* RelayURLResolver.swift */; };
 		B9CFDC96DCA82CD435DD595A /* AchievementDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67A72007588F923516F48711 /* AchievementDetailView.swift */; };
 		BA5A66BBDF281BB44ECE265A /* SessionStatusWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DA07545B6E9F73EED9477FB /* SessionStatusWidget.swift */; };
 		BD4DE18F7D89A6E7BE778875 /* CharacterConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49975C50EF000FB470E30360 /* CharacterConfig.swift */; };
@@ -392,6 +393,7 @@
 		BF0C705C7B75FC8AADBDC2F9 /* ModelDistributionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelDistributionView.swift; sourceTree = "<group>"; };
 		C0656AE4C6DEE802350E31BF /* MajorTomLiveActivityView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MajorTomLiveActivityView.swift; sourceTree = "<group>"; };
 		C069FA164159ADD13137E0D4 /* BonjourBrowser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BonjourBrowser.swift; sourceTree = "<group>"; };
+		FE9D8C7B6A5040312233445F /* RelayURLResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RelayURLResolver.swift; sourceTree = "<group>"; };
 		C13191C0A248C84CA6959981 /* WebSocketClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebSocketClient.swift; sourceTree = "<group>"; };
 		C1CCA0A46BE9EDE79DF3CB8F /* SessionCountWidget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionCountWidget.swift; sourceTree = "<group>"; };
 		C3905D6FC3ABC4A370246F3F /* FleetDashboardWidget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FleetDashboardWidget.swift; sourceTree = "<group>"; };
@@ -866,6 +868,7 @@
 			children = (
 				A2873A7A68C25BFA4E7C9756 /* AuthService.swift */,
 				C069FA164159ADD13137E0D4 /* BonjourBrowser.swift */,
+				FE9D8C7B6A5040312233445F /* RelayURLResolver.swift */,
 				10F013B10B2AA2CD96B19588 /* DangerScoring.swift */,
 				0C7C2FED0200F1F7FCCC6ABA /* FeatureFlags.swift */,
 				11059EFAA85B7AEC69089941 /* GoogleOAuthService.swift */,
@@ -1674,6 +1677,7 @@
 				ED4F918BF0F4278063303B34 /* AuthService.swift in Sources */,
 				5C09E77A601A493E96E1CFF9 /* AutoApprovalBadge.swift in Sources */,
 				B80728DFDC6CDB7632A9C9F3 /* BonjourBrowser.swift in Sources */,
+				DA7A9B0C1E2F3A4B5C6D7E8F /* RelayURLResolver.swift in Sources */,
 				4D8A276AB100B6546118BDCB /* CIPanelView.swift in Sources */,
 				559913FC6E46B681AB795212 /* CIRunsView.swift in Sources */,
 				BD4DE18F7D89A6E7BE778875 /* CharacterConfig.swift in Sources */,

--- a/ios/MajorTom/App/MajorTomApp.swift
+++ b/ios/MajorTom/App/MajorTomApp.swift
@@ -10,6 +10,8 @@ struct MajorTomApp: App {
     @State private var watchConnectivity = PhoneWatchConnectivityService()
     @State private var titleStore: TabTitleStore
     @State private var terminalViewModel: TerminalViewModel
+    @State private var bonjour: BonjourBrowser
+    @State private var relayResolver: RelayURLResolver
     @State private var achievementsViewModel: AchievementsViewModel?
     @State private var selectedTab: AppTab = .terminal
 
@@ -19,9 +21,13 @@ struct MajorTomApp: App {
         // a per-tab iOS decision — no auto-creation tied to claude.
         let authService = AuthService()
         let store = TabTitleStore()
+        let browser = BonjourBrowser()
+        let resolver = RelayURLResolver(auth: authService, browser: browser)
         _auth = State(initialValue: authService)
         _titleStore = State(initialValue: store)
-        _terminalViewModel = State(initialValue: TerminalViewModel(auth: authService, titleStore: store))
+        _bonjour = State(initialValue: browser)
+        _relayResolver = State(initialValue: resolver)
+        _terminalViewModel = State(initialValue: TerminalViewModel(auth: authService, titleStore: store, relayResolver: resolver))
     }
     @Environment(\.scenePhase) private var scenePhase
 
@@ -75,8 +81,12 @@ struct MajorTomApp: App {
                 guard isPaired else { return }
                 Task {
                     _ = await notificationService.requestPermission()
-                    await relay.fetchAuthMethods(serverURL: auth.serverURL)
-                    try? await relay.connect(to: auth.serverURL)
+                    // Prefer a LAN relay (Bonjour) over the tunnel that login
+                    // froze into auth.serverURL — give discovery a brief window,
+                    // then connect to whatever it resolved.
+                    let url = await relayResolver.resolvePreferringLAN()
+                    await relay.fetchAuthMethods(serverURL: url)
+                    try? await relay.connect(to: url)
                 }
             }
             // Wave 4: flush queued /btw messages when the relay reconnects so
@@ -127,10 +137,19 @@ struct MajorTomApp: App {
             }
             // Check for cross-process shortcut actions (Siri / Shortcuts app) on scene phase change
             .onChange(of: scenePhase) { _, newPhase in
-                if newPhase == .active {
+                switch newPhase {
+                case .active:
+                    // Keep LAN discovery alive while foregrounded (paired only)
+                    // so reconnects prefer the LAN; tear it down in the
+                    // background to avoid needless mDNS browsing.
+                    if auth.isPaired { bonjour.start() }
                     if let action = ShortcutActionKey.consumeAction() {
                         handleShortcutAction(action)
                     }
+                case .background:
+                    bonjour.stop()
+                default:
+                    break
                 }
             }
         }

--- a/ios/MajorTom/Core/Services/AuthService.swift
+++ b/ios/MajorTom/Core/Services/AuthService.swift
@@ -125,6 +125,9 @@ final class AuthService {
                 try KeychainService.save(cookie, for: .deviceToken)
                 try KeychainService.save(deviceId, for: .deviceId)
                 try KeychainService.save(deviceName, for: .deviceName)
+                // Pin the relay identity against the host we actually authed to,
+                // before flipping to `.paired` (which kicks off the connect path).
+                await pinRelayIdentity(baseURL: baseURL)
                 sessionCookie = cookie
                 authState = .paired(deviceId: deviceId)
 
@@ -187,6 +190,9 @@ final class AuthService {
                 try KeychainService.save(cookie, for: .deviceToken)
                 try KeychainService.save(deviceId, for: .deviceId)
                 try KeychainService.save(deviceName, for: .deviceName)
+                // Pin the relay identity against the host we actually authed to,
+                // before flipping to `.paired` (which kicks off the connect path).
+                await pinRelayIdentity(baseURL: baseURL)
                 sessionCookie = cookie
                 authState = .paired(deviceId: deviceId)
 
@@ -214,6 +220,31 @@ final class AuthService {
             }
         } catch {
             authState = .error("Connection failed: \(error.localizedDescription)")
+        }
+    }
+
+    // MARK: - Relay Identity Pin
+
+    /// Capture and pin the relay's Ed25519 public key at pairing. Fetched from
+    /// `GET /identity` against the OAuth'd host (the one we trust because the
+    /// user just authed to it), so a later LAN-discovered host can be required
+    /// to prove possession of the matching private key before we trust it with
+    /// the session cookie (see `RelayURLResolver` / `RelayIdentityVerifier`).
+    ///
+    /// Best-effort: a relay without `/identity` (older build) simply never gets
+    /// a pinned key, so the resolver always falls back to the tunnel — safe.
+    private func pinRelayIdentity(baseURL: String) async {
+        guard let url = URL(string: "\(baseURL)/identity") else { return }
+        var request = URLRequest(url: url)
+        request.timeoutInterval = 4.0
+        do {
+            let (data, response) = try await URLSession.shared.data(for: request)
+            guard let http = response as? HTTPURLResponse, http.statusCode == 200,
+                  let identity = try? JSONDecoder().decode(RelayIdentityResponse.self, from: data),
+                  !identity.publicKey.isEmpty else { return }
+            try? KeychainService.save(identity.publicKey, for: .relayPublicKey)
+        } catch {
+            // Network/transport failure — leave any prior pin untouched.
         }
     }
 
@@ -252,6 +283,13 @@ private struct RelayLoginResponse: Codable {
     let picture: String?
     let userId: String?
     let role: String?
+}
+
+/// Shape returned by `GET /identity` — the relay's Ed25519 identity. We pin
+/// `publicKey` (base64url of the raw 32-byte key); `alg`/`fingerprint` are
+/// derivable from it and not stored.
+private struct RelayIdentityResponse: Decodable {
+    let publicKey: String
 }
 
 /// Error envelope returned by `/auth/*` routes on non-2xx responses.

--- a/ios/MajorTom/Core/Services/BonjourBrowser.swift
+++ b/ios/MajorTom/Core/Services/BonjourBrowser.swift
@@ -19,6 +19,12 @@ final class BonjourBrowser {
         /// be a `.local` mDNS hostname or a literal IP — both are accepted
         /// by the system resolver on subsequent HTTP requests.
         let address: String
+        /// Relay identity fingerprint advertised in the Bonjour TXT record
+        /// (`fp` = base64url(sha256(pubKey))), or `nil` if the responder
+        /// published none. A *discovery filter only* — the fingerprint is
+        /// public multicast, so trust is established by `RelayIdentityVerifier`'s
+        /// challenge-response, not by this value matching.
+        let fingerprint: String?
     }
 
     private(set) var services: [DiscoveredService] = []
@@ -84,11 +90,11 @@ final class BonjourBrowser {
             if services.contains(where: { $0.id == name }) { continue }
             if resolvers[name] != nil { continue }
             if services.count + resolvers.count >= Self.maxServices { break }
-            startResolve(for: result, name: name)
+            startResolve(for: result, name: name, fingerprint: Self.fingerprint(from: result))
         }
     }
 
-    private func startResolve(for result: NWBrowser.Result, name: String) {
+    private func startResolve(for result: NWBrowser.Result, name: String, fingerprint: String?) {
         let params = NWParameters.tcp
         params.prohibitedInterfaceTypes = [.cellular]
         let conn = NWConnection(to: result.endpoint, using: params)
@@ -100,7 +106,7 @@ final class BonjourBrowser {
                 switch state {
                 case .ready:
                     if let address = Self.address(from: conn.currentPath?.remoteEndpoint) {
-                        let entry = DiscoveredService(id: name, displayName: name, address: address)
+                        let entry = DiscoveredService(id: name, displayName: name, address: address, fingerprint: fingerprint)
                         if !self.services.contains(entry) {
                             self.services.append(entry)
                         }
@@ -119,6 +125,16 @@ final class BonjourBrowser {
 
     private static func serviceName(from result: NWBrowser.Result) -> String? {
         if case .service(let name, _, _, _) = result.endpoint { return name }
+        return nil
+    }
+
+    /// Pull the relay identity fingerprint (`fp`) from the Bonjour TXT record
+    /// carried on the browse result, if present. Absent for responders that
+    /// publish no TXT record — in which case the resolver still challenges the
+    /// host (the signature, not the fingerprint, is the trust anchor).
+    private static func fingerprint(from result: NWBrowser.Result) -> String? {
+        guard case .bonjour(let txtRecord) = result.metadata else { return nil }
+        if case .string(let fp) = txtRecord.getEntry(for: "fp") { return fp }
         return nil
     }
 

--- a/ios/MajorTom/Core/Services/KeychainService.swift
+++ b/ios/MajorTom/Core/Services/KeychainService.swift
@@ -9,6 +9,11 @@ enum KeychainService {
         case deviceId = "device_id"
         case deviceName = "device_name"
         case serverURL = "server_url"
+        /// base64url of the paired relay's raw Ed25519 public key, captured at
+        /// pairing from `GET /identity`. Pins the relay identity so a discovered
+        /// LAN host must prove possession of the matching private key (challenge-
+        /// response) before the session cookie is handed to it.
+        case relayPublicKey = "relay_public_key"
     }
 
     static func save(_ value: String, for key: Key) throws {
@@ -67,7 +72,7 @@ enum KeychainService {
     }
 
     static func deleteAll() {
-        for key in [Key.deviceToken, .deviceId, .deviceName, .serverURL] {
+        for key in [Key.deviceToken, .deviceId, .deviceName, .serverURL, .relayPublicKey] {
             delete(key)
         }
     }

--- a/ios/MajorTom/Core/Services/RelayIdentityVerifier.swift
+++ b/ios/MajorTom/Core/Services/RelayIdentityVerifier.swift
@@ -1,0 +1,144 @@
+import CryptoKit
+import Foundation
+
+/// Verifies that a discovered LAN host is the *same relay this device paired
+/// with*, by challenging it to sign a fresh nonce with the relay identity
+/// private key and checking the signature against the pinned public key.
+///
+/// mDNS is unauthenticated: any LAN peer can advertise `_majortom._tcp` and
+/// echo the relay's (public) fingerprint. The trust anchor is therefore not the
+/// fingerprint but *possession of the private key*, proven here. A host that
+/// merely replays the fingerprint cannot produce a valid signature, so it fails
+/// the challenge and never receives the session cookie. (This defeats an
+/// impersonating "first responder"; it does NOT by itself defeat an on-path
+/// MITM that forwards the nonce to the real relay — that needs TLS channel
+/// binding, tracked as follow-up hardening.)
+enum RelayIdentityVerifier {
+    /// Domain-separation prefix for challenge signatures. The relay signs
+    /// `challengeContext || nonce` (never the bare nonce), so we verify over the
+    /// identical byte construction.
+    ///
+    /// CANONICAL SOURCE: `relay/src/routes/identity.ts` (`CHALLENGE_CONTEXT`).
+    /// This string MUST stay byte-for-byte identical to it — a drift silently
+    /// breaks every LAN verification. The DEBUG `runSelfTest()` below verifies a
+    /// real relay-produced signature through this exact path so such a drift
+    /// trips immediately in a debug build.
+    static let challengeContext = "major-tom/relay-identity/v1:"
+
+    // MARK: - base64url
+
+    /// Decode a base64url string (unpadded) to `Data`. Foundation's
+    /// `Data(base64Encoded:)` only accepts *standard* base64, so translate the
+    /// alphabet and re-pad first. The relay sends `publicKey`/`signature` as
+    /// base64url.
+    static func data(fromBase64url s: String) -> Data? {
+        var b64 = s.replacingOccurrences(of: "-", with: "+")
+            .replacingOccurrences(of: "_", with: "/")
+        let remainder = b64.count % 4
+        if remainder != 0 {
+            b64 += String(repeating: "=", count: 4 - remainder)
+        }
+        return Data(base64Encoded: b64)
+    }
+
+    /// Encode `Data` as unpadded base64url.
+    static func base64url(_ data: Data) -> String {
+        data.base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
+    }
+
+    // MARK: - Fingerprint
+
+    /// `base64url(SHA256(rawPublicKey))` — matches the relay's mDNS TXT `fp`.
+    /// Used only as a fast discovery filter; the signature is the real anchor.
+    static func fingerprint(forRawPublicKey raw: Data) -> String {
+        base64url(Data(SHA256.hash(data: raw)))
+    }
+
+    // MARK: - Pure verification
+
+    /// Verify an Ed25519 `signature` over `challengeContext || nonce` against a
+    /// pinned raw (32-byte) public key. Pure — no I/O — so it is exercised
+    /// directly by `runSelfTest()` with a real relay vector.
+    static func isValidSignature(_ signature: Data, nonce: Data, pinnedRawPublicKey raw: Data) -> Bool {
+        guard let key = try? Curve25519.Signing.PublicKey(rawRepresentation: raw) else {
+            return false
+        }
+        var message = Data(challengeContext.utf8)
+        message.append(nonce)
+        return key.isValidSignature(signature, for: message)
+    }
+
+    // MARK: - Networked challenge
+
+    /// POST a fresh 32-byte nonce to `<baseURL>/identity/challenge` and verify
+    /// the returned signature against the pinned public key. Returns `true` ONLY
+    /// if the host proves possession of the pinned identity's private key.
+    /// Best-effort: any transport/parse error or non-200 returns `false`
+    /// (caller falls back to the tunnel).
+    static func challenge(baseURL: String, pinnedPublicKeyBase64url pinned: String) async -> Bool {
+        guard let pinnedRaw = data(fromBase64url: pinned),
+              let url = URL(string: "\(baseURL)/identity/challenge") else {
+            return false
+        }
+
+        // SystemRandomNumberGenerator is the platform CSPRNG on Apple OSes.
+        let nonce = Data((0..<32).map { _ in UInt8.random(in: UInt8.min...UInt8.max) })
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.timeoutInterval = 2.0
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        // The relay decodes the nonce with `Buffer.from(nonce, 'base64')` —
+        // send STANDARD base64 (not base64url).
+        request.httpBody = try? JSONEncoder().encode(["nonce": nonce.base64EncodedString()])
+
+        guard let (data, response) = try? await URLSession.shared.data(for: request),
+              let http = response as? HTTPURLResponse, http.statusCode == 200,
+              let parsed = try? JSONDecoder().decode(ChallengeResponse.self, from: data),
+              let signature = self.data(fromBase64url: parsed.signature) else {
+            return false
+        }
+
+        // Verify against the PINNED key (not the key the host reports): a host
+        // that signs with some other key it controls fails here.
+        return isValidSignature(signature, nonce: nonce, pinnedRawPublicKey: pinnedRaw)
+    }
+
+    private struct ChallengeResponse: Decodable {
+        let signature: String
+    }
+
+    #if DEBUG
+    /// In-process end-to-end guard (advisory #3 in
+    /// docs/HANDOFF-RELAY-IDENTITY-BINDING.md): verify a REAL relay-produced
+    /// Ed25519 vector through the exact path the app uses. If `challengeContext`,
+    /// the base64url decode, or the CryptoKit wiring ever drift from the relay,
+    /// this trips immediately in a debug build. The vector was produced by the
+    /// same byte construction as `relay/src/identity/relay-identity.ts`
+    /// (`sign(null, utf8(CHALLENGE_CONTEXT) || nonce, ed25519PrivKey)`).
+    static func runSelfTest() {
+        let publicKeyB64u = "q4pQhxT0AhdTFWnjIPoOMxPAdpvhS3MD3FIH99vdrSg"
+        let nonceB64 = "AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8="
+        let signatureB64u = "BEtOQAX7i_EacFiPJmeXoGzlf5P4LCz90oQL3myQB6q9CrumI2N86iHGISPp8cil76iAOeBkq3vQuO1v6jvkCQ"
+        let expectedFingerprint = "wJZelWR9DWLLvgFUBSq1F_N_x8gmTFBp_3z14su95sU"
+
+        guard let raw = data(fromBase64url: publicKeyB64u),
+              let nonce = Data(base64Encoded: nonceB64),
+              let signature = data(fromBase64url: signatureB64u) else {
+            assertionFailure("RelayIdentityVerifier self-test: fixture failed to decode")
+            return
+        }
+        assert(
+            isValidSignature(signature, nonce: nonce, pinnedRawPublicKey: raw),
+            "RelayIdentityVerifier self-test FAILED — challengeContext/base64url/CryptoKit drifted from the relay"
+        )
+        assert(
+            fingerprint(forRawPublicKey: raw) == expectedFingerprint,
+            "RelayIdentityVerifier fingerprint self-test FAILED — SHA256/base64url drifted from the relay"
+        )
+    }
+    #endif
+}

--- a/ios/MajorTom/Core/Services/RelayURLResolver.swift
+++ b/ios/MajorTom/Core/Services/RelayURLResolver.swift
@@ -1,49 +1,106 @@
 import Foundation
 
 /// Resolves the best relay base URL to connect to *at connect time*,
-/// preferring a live Bonjour-discovered LAN address over the frozen
-/// `auth.serverURL` (the tunnel/last-used host captured at login).
+/// preferring a Bonjour-discovered LAN host over the frozen `auth.serverURL`
+/// (the tunnel/last-used host captured at login) — but ONLY after that host
+/// proves it is the relay we paired with.
 ///
 /// Login freezes one URL into `auth.serverURL`. On Wi-Fi that's often the
 /// public Cloudflare tunnel — Bonjour can be racy at the moment of the
 /// sign-in tap — so every later connection needlessly rode the tunnel.
 /// Keeping an app-level `BonjourBrowser` alive and consulting it here lets
 /// the main socket and the terminal `/shell` socket prefer the LAN whenever
-/// the relay is reachable locally, falling back to the tunnel only when
-/// there's genuinely no local path (cellular/remote).
+/// the relay is reachable locally, falling back to the tunnel when there's no
+/// local path (cellular/remote) OR when a discovered host fails identity
+/// verification.
+///
+/// SECURITY: mDNS is unauthenticated, so a LAN peer can advertise
+/// `_majortom._tcp` and be the "first responder." Handing it the session
+/// cookie would let it replay the cookie to the real relay and get a shell.
+/// We therefore challenge a discovered host to sign a fresh nonce with the
+/// relay identity key (pinned at pairing) and verify it before trusting it —
+/// see `RelayIdentityVerifier`.
 @Observable
 @MainActor
 final class RelayURLResolver {
     private let auth: AuthService
     private let browser: BonjourBrowser
 
+    /// A LAN address proven THIS SESSION to belong to the pinned relay identity
+    /// via challenge-response. Only this — never an unverified mDNS responder —
+    /// is handed to the cookie-bearing connections.
+    private var verifiedLANAddress: String?
+
     init(auth: AuthService, browser: BonjourBrowser) {
         self.auth = auth
         self.browser = browser
+        #if DEBUG
+        // Trip immediately if our crypto / signed-byte construction ever drifts
+        // from the relay (verifies a real relay-produced signature).
+        RelayIdentityVerifier.runSelfTest()
+        #endif
     }
 
-    /// Best relay base URL right now: a live LAN address if Bonjour has
-    /// discovered one, else the frozen `auth.serverURL`. Returned in the
-    /// same raw `host[:port]` / hostname form as `auth.serverURL`, so
-    /// callers keep running it through `AuthService.normalizeBaseURL`.
+    /// Best relay base URL for a *synchronous* caller (e.g. the terminal
+    /// building its `/shell` URL): a LAN host we already verified this session
+    /// AND that is still being advertised, else the frozen `auth.serverURL`
+    /// (tunnel). Never returns an unverified host — verification happens only in
+    /// the async `resolvePreferringLAN`. Returned in the same raw `host[:port]`
+    /// form as `auth.serverURL`, so callers keep normalizing via `AuthService`.
     var bestRelayURL: String {
-        browser.services.first?.address ?? auth.serverURL
+        if let verified = verifiedLANAddress,
+           browser.services.contains(where: { $0.address == verified }) {
+            return verified
+        }
+        return auth.serverURL
     }
 
-    /// Resolve preferring the LAN, giving Bonjour a brief window to answer.
-    /// Returns the moment a LAN service is known (typical on a quiet home
-    /// network) and caps the wait at `timeout`, so a relay-less network
-    /// (cellular/remote) pays the delay at most once before falling back to
-    /// the tunnel. Idempotently starts discovery if it isn't already running.
+    /// Resolve preferring the LAN, but only after proving a discovered host is
+    /// the relay we paired with. Gives Bonjour a brief window to answer, then
+    /// for each discovered host fast-filters on the advertised fingerprint and
+    /// challenges it to sign a fresh nonce (`RelayIdentityVerifier`). The first
+    /// host that returns a valid signature against the pinned key is cached and
+    /// returned; otherwise we fall back to the tunnel. With no pinned identity
+    /// (paired against a relay that predates `/identity`) we never trust a LAN
+    /// host and always return the tunnel. Idempotently starts discovery.
     func resolvePreferringLAN(timeout: Duration = .seconds(2)) async -> String {
-        if let lan = browser.services.first?.address { return lan }
+        // Re-use a still-advertised verified host without re-challenging.
+        if let verified = verifiedLANAddress,
+           browser.services.contains(where: { $0.address == verified }) {
+            return verified
+        }
+        verifiedLANAddress = nil
+
+        guard let pinned = KeychainService.load(.relayPublicKey),
+              let pinnedRaw = RelayIdentityVerifier.data(fromBase64url: pinned) else {
+            return auth.serverURL
+        }
+        let expectedFingerprint = RelayIdentityVerifier.fingerprint(forRawPublicKey: pinnedRaw)
+
         browser.start()
         let clock = ContinuousClock()
         let deadline = clock.now.advanced(by: timeout)
-        while clock.now < deadline {
+        var challenged: Set<String> = []
+
+        while true {
+            // `browser.services` is snapshotted per for-loop; hosts that appear
+            // during an await are picked up on the next outer pass. `challenged`
+            // prevents re-issuing a challenge to the same address.
+            for service in browser.services where !challenged.contains(service.address) {
+                challenged.insert(service.address)
+                // A mismatched advertised fingerprint can't be our relay — skip
+                // the round-trip. A *missing* fingerprint is still challenged;
+                // the signature, not the fingerprint, is the trust anchor.
+                if let fp = service.fingerprint, fp != expectedFingerprint { continue }
+                let base = AuthService.normalizeBaseURL(service.address)
+                if await RelayIdentityVerifier.challenge(baseURL: base, pinnedPublicKeyBase64url: pinned) {
+                    verifiedLANAddress = service.address
+                    return service.address
+                }
+            }
+            if clock.now >= deadline { break }
             // Break (don't busy-spin) if the task is cancelled mid-wait.
             do { try await Task.sleep(for: .milliseconds(150)) } catch { break }
-            if let lan = browser.services.first?.address { return lan }
         }
         return auth.serverURL
     }

--- a/ios/MajorTom/Core/Services/RelayURLResolver.swift
+++ b/ios/MajorTom/Core/Services/RelayURLResolver.swift
@@ -41,7 +41,8 @@ final class RelayURLResolver {
         let clock = ContinuousClock()
         let deadline = clock.now.advanced(by: timeout)
         while clock.now < deadline {
-            try? await Task.sleep(for: .milliseconds(150))
+            // Break (don't busy-spin) if the task is cancelled mid-wait.
+            do { try await Task.sleep(for: .milliseconds(150)) } catch { break }
             if let lan = browser.services.first?.address { return lan }
         }
         return auth.serverURL

--- a/ios/MajorTom/Core/Services/RelayURLResolver.swift
+++ b/ios/MajorTom/Core/Services/RelayURLResolver.swift
@@ -1,0 +1,49 @@
+import Foundation
+
+/// Resolves the best relay base URL to connect to *at connect time*,
+/// preferring a live Bonjour-discovered LAN address over the frozen
+/// `auth.serverURL` (the tunnel/last-used host captured at login).
+///
+/// Login freezes one URL into `auth.serverURL`. On Wi-Fi that's often the
+/// public Cloudflare tunnel — Bonjour can be racy at the moment of the
+/// sign-in tap — so every later connection needlessly rode the tunnel.
+/// Keeping an app-level `BonjourBrowser` alive and consulting it here lets
+/// the main socket and the terminal `/shell` socket prefer the LAN whenever
+/// the relay is reachable locally, falling back to the tunnel only when
+/// there's genuinely no local path (cellular/remote).
+@Observable
+@MainActor
+final class RelayURLResolver {
+    private let auth: AuthService
+    private let browser: BonjourBrowser
+
+    init(auth: AuthService, browser: BonjourBrowser) {
+        self.auth = auth
+        self.browser = browser
+    }
+
+    /// Best relay base URL right now: a live LAN address if Bonjour has
+    /// discovered one, else the frozen `auth.serverURL`. Returned in the
+    /// same raw `host[:port]` / hostname form as `auth.serverURL`, so
+    /// callers keep running it through `AuthService.normalizeBaseURL`.
+    var bestRelayURL: String {
+        browser.services.first?.address ?? auth.serverURL
+    }
+
+    /// Resolve preferring the LAN, giving Bonjour a brief window to answer.
+    /// Returns the moment a LAN service is known (typical on a quiet home
+    /// network) and caps the wait at `timeout`, so a relay-less network
+    /// (cellular/remote) pays the delay at most once before falling back to
+    /// the tunnel. Idempotently starts discovery if it isn't already running.
+    func resolvePreferringLAN(timeout: Duration = .seconds(2)) async -> String {
+        if let lan = browser.services.first?.address { return lan }
+        browser.start()
+        let clock = ContinuousClock()
+        let deadline = clock.now.advanced(by: timeout)
+        while clock.now < deadline {
+            try? await Task.sleep(for: .milliseconds(150))
+            if let lan = browser.services.first?.address { return lan }
+        }
+        return auth.serverURL
+    }
+}

--- a/ios/MajorTom/Features/Terminal/ViewModels/TerminalViewModel.swift
+++ b/ios/MajorTom/Features/Terminal/ViewModels/TerminalViewModel.swift
@@ -127,8 +127,12 @@ final class TerminalViewModel {
         keybarViewModel.selectedTheme
     }
 
-    /// Reference to the auth service for relay URL and token.
+    /// Reference to the auth service for the session token.
     private let auth: AuthService
+
+    /// Resolves the relay base URL at access time, preferring a live LAN
+    /// (Bonjour) address over the tunnel frozen into `auth.serverURL`.
+    private let relayResolver: RelayURLResolver
 
     /// Shared store of user-supplied tab titles. Bidirectional — the
     /// Office Manager writes here too and this VM sees the change via
@@ -144,9 +148,10 @@ final class TerminalViewModel {
     /// UserDefaults key for the active tab ID (string).
     private static let persistedActiveTabIdKey = "mt-terminal-active-tab-id"
 
-    init(auth: AuthService, titleStore: TabTitleStore) {
+    init(auth: AuthService, titleStore: TabTitleStore, relayResolver: RelayURLResolver) {
         self.auth = auth
         self.titleStore = titleStore
+        self.relayResolver = relayResolver
         self.keybarViewModel = KeybarViewModel(auth: auth)
 
         // Restore persisted tab IDs. Tab-Keyed Offices (Wave 4) — we no
@@ -374,7 +379,7 @@ final class TerminalViewModel {
 
     /// Build the relay WebSocket URL for `/shell/:tabId`.
     var relayURL: String {
-        let base = auth.serverURL
+        let base = relayResolver.bestRelayURL
         let scheme = base.contains("://") ? "" : "http://"
         // Strip protocol prefix for the host, then decide ws/wss
         let fullBase = "\(scheme)\(base)"
@@ -392,7 +397,7 @@ final class TerminalViewModel {
 
     /// The relay domain for cookie injection.
     var relayDomain: String {
-        let base = auth.serverURL
+        let base = relayResolver.bestRelayURL
         let cleaned = base
             .replacingOccurrences(of: "https://", with: "")
             .replacingOccurrences(of: "http://", with: "")
@@ -402,7 +407,7 @@ final class TerminalViewModel {
 
     /// Full relay base URL (http/https) for cookie path.
     var relayBaseURL: String {
-        let base = auth.serverURL
+        let base = relayResolver.bestRelayURL
         let scheme = base.contains("://") ? "" : "http://"
         return "\(scheme)\(base)"
     }


### PR DESCRIPTION
## Summary
Prefer a Bonjour-discovered **LAN** relay over the frozen tunnel URL at connect time — but only after the discovered host **proves it is the relay this device paired with**. Closes the mDNS "first responder" cookie-theft hole that held this feature back.

This is the **iOS half** of relay-identity binding. The relay half shipped in #178 (persistent Ed25519 identity, `fp` in the mDNS TXT record, `GET /identity`, `POST /identity/challenge`).

> Rebased onto main: the `%en0` Bonjour fix and tunnel HTTP/2 transport originally bundled here shipped separately in #177, so they've dropped from this diff.

## The hole this closes
`RelayURLResolver` lets the app prefer a live LAN relay address over the tunnel that login froze into `auth.serverURL`. But mDNS is unauthenticated: a LAN peer can advertise `_majortom._tcp`, be the "first responder," receive the **authenticated session cookie**, replay it to the real relay, and get a **shell**. A TXT-fingerprint pin alone doesn't help — the fingerprint is public multicast, so an attacker just echoes it.

## How it's closed
Trust = a **pinned public key** + a **fresh signature** proving possession of the matching private key.

- **Pin at pairing** (`AuthService`): after OAuth/PIN login succeeds against the host the user actually authed to, `GET /identity` and persist the relay's Ed25519 public key in the Keychain (`relay_public_key`, cleared on unpair).
- **Verify before trusting** (`RelayURLResolver` + new `RelayIdentityVerifier`): for a discovered LAN host, fast-filter on the advertised TXT `fp`, then `POST /identity/challenge` with a fresh 32-byte nonce and verify the Ed25519 signature over `"major-tom/relay-identity/v1:" || nonce` (CryptoKit) against the **pinned** key. Only a host that verifies is handed the cookie; otherwise fall back to the tunnel. No pinned key (older relay) → always tunnel.
- **Fingerprint is a filter, not the anchor** (`BonjourBrowser`): the TXT `fp` is parsed only to skip obvious non-matches cheaply; the signature is the trust anchor, so a missing or echoed `fp` can't grant trust.

## Threat model
- Defeats an impersonating "first responder" — it cannot sign the nonce.
- Does **not** by itself defeat an on-path MITM that forwards the nonce to the real relay (needs TLS channel binding) — tracked as follow-up hardening, mirroring the relay-side note in #178.

## Contract / desync guard
`CHALLENGE_CONTEXT` is mirrored byte-for-byte from `relay/src/routes/identity.ts` (cited as canonical in-code). A DEBUG self-test in `RelayIdentityVerifier` verifies a **real relay-produced** Ed25519 vector (signature + fingerprint) through the exact app path, so any drift in the constant, base64url handling, or crypto wiring trips immediately in a debug build. (No iOS XCTest target exists yet, hence the in-process tripwire rather than a unit test.)

## Test plan
- [ ] Pair on the LAN → key pins → cold relaunch prefers the LAN address (verified), not the tunnel
- [ ] Stand up a rogue `_majortom._tcp` responder → it is **not** trusted; app stays on the tunnel
- [ ] Relay with no `/identity` (older build) → no pin → always tunnel, terminal still connects
- [ ] Off-LAN / cellular → tunnel fallback, terminal still connects
- [ ] DEBUG build launches without tripping the `RelayIdentityVerifier` self-test assertion

🤖 Generated with [Claude Code](https://claude.com/claude-code)
