### PR TITLE
fix: Bonjour IPv4 zone-id + tunnel HTTP/2 (unblock terminal connect)

### DIFF
--- a/ios/MajorTom/Core/Services/BonjourBrowser.swift
+++ b/ios/MajorTom/Core/Services/BonjourBrowser.swift
@@ -135,7 +135,9 @@ final class BonjourBrowser {
         case .name(let name, _):
             hostString = name
         case .ipv4(let ip):
-            hostString = "\(ip)"
+            // IPv4Address interpolation can append a "%en0" zone id; the '%'
+            // breaks URL(string:), and a literal IPv4 never needs one.
+            hostString = String("\(ip)".prefix { $0 != "%" })
         case .ipv6:
             return nil
         @unknown default:

--- a/tunnel/start.sh
+++ b/tunnel/start.sh
@@ -25,4 +25,7 @@ if [ -z "${TUNNEL_ID}" ]; then
   exit 1
 fi
 
-exec cloudflared tunnel --config "${CONFIG_FILE}" run "${TUNNEL_ID}"
+# Force the HTTP/2 edge transport. The QUIC default flaps on some networks
+# ("failed to accept QUIC stream: timeout: no recent network activity"),
+# repeatedly dropping the WebSocket before the PTY can spawn.
+exec cloudflared tunnel --config "${CONFIG_FILE}" --protocol http2 run "${TUNNEL_ID}"


### PR DESCRIPTION
Splits the two no-new-attack-surface fixes out of #176 so they can ship immediately. The LAN-preference feature stays in #176, held pending relay-identity binding (security follow-up).

## Commits
- **`%en0` Bonjour fix** — IPv4Address interpolation appended a `%en0` zone id that broke `URL(string:)`, making the discovered LAN relay unreachable / failing Google sign-in. Mirrors the existing IPv6 guard. *(verified on device)*
- **Tunnel HTTP/2** — pin cloudflared off the flapping QUIC transport, which was dropping the WebSocket before the PTY spawned.

Both already passed Tier 2 review clean in #176 (ship, 0 blocking — the only finding there was on the LAN-preference code, which is not in this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)