### PR TITLE
feat(relay): Ed25519 relay identity + mDNS fingerprint + challenge

### DIFF
--- a/relay/src/app.ts
+++ b/relay/src/app.ts
@@ -24,10 +24,12 @@ import { createShellRoute, clearUserIdForTab, getUserIdForTab } from './routes/s
 import { createApiApprovalsRoutes } from './routes/api-approvals.js';
 import { createPreferencesRoutes } from './routes/preferences.js';
 import { createRelayConfigRoutes } from './routes/relay-config.js';
+import { createIdentityRoutes } from './routes/identity.js';
 import {
   RelayConfigStore,
   resolveDefaultSpawnCwd,
 } from './config/relay-config.js';
+import { RelayIdentity } from './identity/relay-identity.js';
 import { PtyAdapter } from './adapters/pty-adapter.js';
 
 // Phase 13 Wave 2 — shell-side approval routing
@@ -72,6 +74,9 @@ import { homedir } from 'node:os';
 declare module 'fastify' {
   interface FastifyInstance {
     userRegistry?: UserRegistry;
+    // base64url sha256 of the relay's Ed25519 public key. Set once in
+    // buildApp so server.ts can advertise it in the mDNS TXT record.
+    relayIdentityFingerprint: string;
   }
 }
 
@@ -123,6 +128,13 @@ export async function buildApp(config: AppConfig) {
   // up the new value without a restart (QA-FIXES #19).
   const relayConfigStore = new RelayConfigStore();
   await relayConfigStore.load();
+
+  // Relay identity — persistent Ed25519 keypair (`~/.major-tom/relay-identity.json`)
+  // giving the relay a stable, verifiable identity independent of the rotating
+  // SESSION_SECRET. The fingerprint is advertised over mDNS TXT and the key is
+  // proven via POST /identity/challenge, so the iOS app can pin it at pairing
+  // and refuse to hand the session cookie to an unverified LAN host.
+  const relayIdentity = await RelayIdentity.load();
 
   // Multi-user services — only created when multi-user mode is enabled
   const userRegistry = config.multiUserEnabled ? new UserRegistry() : undefined;
@@ -336,6 +348,7 @@ export async function buildApp(config: AppConfig) {
   await app.register(websocketPlugin);
 
   // ── Decorate with shared services ──────────────────────
+  app.decorate('relayIdentityFingerprint', relayIdentity.fingerprint);
   if (userRegistry) {
     app.decorate('userRegistry', userRegistry);
   }
@@ -350,6 +363,12 @@ export async function buildApp(config: AppConfig) {
     authGoogleEnabled: config.authGoogleEnabled,
     authPinEnabled: config.authPinEnabled,
   }));
+
+  // Relay identity (public) — Ed25519 public key + fingerprint and a
+  // nonce-signing challenge. Lets the iOS app pin the relay's identity at
+  // pairing and verify a discovered LAN host holds the matching private key
+  // before trusting it with the session cookie (LAN-preference binding).
+  await app.register(createIdentityRoutes({ identity: relayIdentity }));
 
   // ── Shell PTY adapter ──────────────────────────────────
   // Instantiated before any route that references it (health + shell).

--- a/relay/src/discovery/mdns.ts
+++ b/relay/src/discovery/mdns.ts
@@ -18,7 +18,7 @@ export interface MdnsHandle {
   stop: () => Promise<void>;
 }
 
-export function startMdns(port: number): MdnsHandle {
+export function startMdns(port: number, fingerprint?: string): MdnsHandle {
   const bonjour = new Bonjour();
   // Default to a generic label so the relay's mDNS broadcast doesn't leak
   // the OS hostname on every Wi-Fi it touches. `MAJORTOM_RELAY_NAME` lets
@@ -34,6 +34,13 @@ export function startMdns(port: number): MdnsHandle {
       txt: {
         version: '1',
         protocol: 'ws',
+        // Ed25519 public-key fingerprint (base64url sha256). The iOS app pins
+        // this at pairing and uses it as a fast discovery FILTER — it is NOT a
+        // security boundary, since mDNS TXT is plaintext multicast that any LAN
+        // host can echo. Trust is established by the signed /identity/challenge,
+        // verified against the pinned public key. Omitted if the relay has no
+        // identity (older callers / tests).
+        ...(fingerprint !== undefined ? { fp: fingerprint } : {}),
       },
     });
     log.info({ name: instanceName, port, type: `_${SERVICE_TYPE}._tcp` }, 'mDNS service published');

--- a/relay/src/identity/__tests__/relay-identity.test.ts
+++ b/relay/src/identity/__tests__/relay-identity.test.ts
@@ -1,0 +1,84 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { createHash, createPublicKey, randomBytes, verify } from 'node:crypto';
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { RelayIdentity } from '../relay-identity.js';
+
+let baseDir: string;
+let idFile: string;
+
+beforeEach(async () => {
+  baseDir = await mkdtemp(join(tmpdir(), 'relay-identity-'));
+  idFile = join(baseDir, 'relay-identity.json');
+});
+
+afterEach(async () => {
+  await rm(baseDir, { recursive: true, force: true });
+});
+
+/** Rebuild a verify-only public key from the base64url raw key the relay exposes. */
+function publicKeyFrom(b64u: string) {
+  return createPublicKey({ key: { kty: 'OKP', crv: 'Ed25519', x: b64u }, format: 'jwk' });
+}
+
+describe('RelayIdentity', () => {
+  it('generates and persists a keypair on first load', async () => {
+    const id = await RelayIdentity.load(idFile);
+    expect(id.publicKeyBase64url).toMatch(/^[A-Za-z0-9_-]+$/);
+    expect(Buffer.from(id.publicKeyBase64url, 'base64url')).toHaveLength(32);
+    expect(id.fingerprint).toMatch(/^[A-Za-z0-9_-]+$/);
+
+    const raw = JSON.parse(await readFile(idFile, 'utf-8')) as {
+      alg: string;
+      privateKeyPem: string;
+    };
+    expect(raw.alg).toBe('ed25519');
+    expect(raw.privateKeyPem).toContain('BEGIN PRIVATE KEY');
+  });
+
+  it('is stable across reloads — same fingerprint + public key', async () => {
+    const a = await RelayIdentity.load(idFile);
+    const b = await RelayIdentity.load(idFile);
+    expect(b.fingerprint).toBe(a.fingerprint);
+    expect(b.publicKeyBase64url).toBe(a.publicKeyBase64url);
+  });
+
+  it('fingerprint is base64url(sha256(public key))', async () => {
+    const id = await RelayIdentity.load(idFile);
+    const expected = createHash('sha256')
+      .update(Buffer.from(id.publicKeyBase64url, 'base64url'))
+      .digest('base64url');
+    expect(id.fingerprint).toBe(expected);
+  });
+
+  it('sign() produces a 64-byte signature that verifies against the public key', async () => {
+    const id = await RelayIdentity.load(idFile);
+    const msg = randomBytes(32);
+    const sig = id.sign(msg);
+    expect(sig).toHaveLength(64);
+    expect(verify(null, msg, publicKeyFrom(id.publicKeyBase64url), sig)).toBe(true);
+    // A different message must not verify against the same signature.
+    expect(verify(null, randomBytes(32), publicKeyFrom(id.publicKeyBase64url), sig)).toBe(false);
+  });
+
+  it('regenerates (no throw) when the file is corrupt JSON', async () => {
+    const first = await RelayIdentity.load(idFile);
+    await writeFile(idFile, 'not json at all', 'utf-8');
+    const second = await RelayIdentity.load(idFile);
+    expect(second.fingerprint).not.toBe(first.fingerprint);
+    const raw = JSON.parse(await readFile(idFile, 'utf-8')) as { alg: string };
+    expect(raw.alg).toBe('ed25519');
+  });
+
+  it('regenerates (no throw) when the schema is wrong', async () => {
+    await writeFile(
+      idFile,
+      JSON.stringify({ version: 1, alg: 'rsa', privateKeyPem: 123 }),
+      'utf-8',
+    );
+    const id = await RelayIdentity.load(idFile);
+    expect(id.publicKeyBase64url).toBeTruthy();
+  });
+});

--- a/relay/src/identity/relay-identity.ts
+++ b/relay/src/identity/relay-identity.ts
@@ -1,0 +1,191 @@
+// Relay identity — a persistent Ed25519 keypair stored in
+// `~/.major-tom/relay-identity.json`. Gives the relay a stable, verifiable
+// identity that is INDEPENDENT of the rotating `SESSION_SECRET` (which has
+// its own regenerate footgun) and of the VAPID push key (wrong semantics).
+//
+// Why it exists: the iOS LAN-preference feature discovers relays over mDNS
+// and would otherwise hand the authenticated session cookie to whichever
+// host answered `_majortom._tcp` first. mDNS is unauthenticated, so a hostile
+// LAN peer could impersonate the relay and harvest the cookie. This keypair
+// lets the relay PROVE its identity: the public-key fingerprint is advertised
+// (mDNS TXT) and the full key is exposed at `GET /identity`; the app pins it
+// at pairing and later challenges a discovered host to sign a fresh nonce
+// (`POST /identity/challenge`), verifying the signature against the pinned key
+// before trusting it with credentials.
+//
+// Failure modes (mirrors relay-config.ts):
+//   - Missing file  → fresh install, generate + persist (expected).
+//   - Corrupt/bad schema / unparseable key → WARN, regenerate. Already-paired
+//     devices must re-pair (their pinned key no longer matches). Rare.
+//   - I/O failure on save → WARN, NOT thrown. The in-memory key still works
+//     for this process; a new key is generated on the next boot.
+
+import {
+  createHash,
+  createPrivateKey,
+  createPublicKey,
+  generateKeyPairSync,
+  sign,
+  type KeyObject,
+} from 'node:crypto';
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { homedir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { logger } from '../utils/logger.js';
+
+const log = logger.child({ module: 'relay-identity' });
+
+export const DEFAULT_IDENTITY_FILE = join(
+  homedir(),
+  '.major-tom',
+  'relay-identity.json',
+);
+
+interface PersistedIdentity {
+  version: 1;
+  alg: 'ed25519';
+  /** PKCS#8 PEM of the Ed25519 private key. */
+  privateKeyPem: string;
+}
+
+/**
+ * Loads (or generates) the relay's Ed25519 identity. Construct via the async
+ * `RelayIdentity.load()` factory — the constructor is private because key
+ * material has to be read/derived before the instance is usable.
+ */
+export class RelayIdentity {
+  private privateKey!: KeyObject;
+  /** Raw 32-byte Ed25519 public key. */
+  private publicKeyRaw!: Buffer;
+  /** base64url of the raw public key — the wire form clients pin. */
+  private publicKeyB64u!: string;
+  /** base64url of sha256(raw public key) — short stable id for the TXT record. */
+  private fingerprintValue!: string;
+
+  private constructor(private readonly path: string) {}
+
+  static async load(path: string = DEFAULT_IDENTITY_FILE): Promise<RelayIdentity> {
+    const identity = new RelayIdentity(path);
+    await identity.init();
+    return identity;
+  }
+
+  private async init(): Promise<void> {
+    let pem = await this.readPersistedPem();
+
+    if (pem !== undefined) {
+      try {
+        this.privateKey = createPrivateKey(pem);
+      } catch (err) {
+        log.warn({ err }, 'relay-identity private key unparseable — regenerating (paired devices must re-pair)');
+        pem = undefined;
+      }
+    }
+
+    if (pem === undefined) {
+      const { privateKey } = generateKeyPairSync('ed25519');
+      this.privateKey = privateKey;
+      const generatedPem = privateKey.export({ type: 'pkcs8', format: 'pem' });
+      // `format: 'pem'` always yields a string; the union is just the broad
+      // KeyObject.export signature.
+      await this.persist(generatedPem as string);
+      log.info('Generated new relay identity keypair');
+    }
+
+    this.derivePublic();
+    log.info({ fingerprint: this.fingerprintValue }, 'Relay identity ready');
+  }
+
+  /** Returns the persisted private-key PEM, or undefined to regenerate. */
+  private async readPersistedPem(): Promise<string | undefined> {
+    let raw: string;
+    try {
+      raw = await readFile(this.path, 'utf-8');
+    } catch (err) {
+      const code = errnoCode(err);
+      if (code !== 'ENOENT') {
+        log.warn({ err, code, path: this.path }, 'relay-identity read failed — regenerating');
+      }
+      return undefined;
+    }
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(raw);
+    } catch (err) {
+      log.warn({ err, path: this.path }, 'relay-identity.json is invalid JSON — regenerating');
+      return undefined;
+    }
+    if (!isPersistedIdentity(parsed)) {
+      log.warn({ path: this.path }, 'relay-identity.json has invalid schema — regenerating (paired devices must re-pair)');
+      return undefined;
+    }
+    return parsed.privateKeyPem;
+  }
+
+  private derivePublic(): void {
+    const publicKey = createPublicKey(this.privateKey);
+    const jwk = publicKey.export({ format: 'jwk' });
+    if (typeof jwk.x !== 'string') {
+      throw new Error('Failed to derive Ed25519 public key (missing jwk.x)');
+    }
+    // JWK `x` for an OKP/Ed25519 key is the raw 32-byte public key, base64url.
+    this.publicKeyB64u = jwk.x;
+    this.publicKeyRaw = Buffer.from(jwk.x, 'base64url');
+    this.fingerprintValue = createHash('sha256')
+      .update(this.publicKeyRaw)
+      .digest('base64url');
+  }
+
+  private async persist(pem: string): Promise<void> {
+    const data: PersistedIdentity = {
+      version: 1,
+      alg: 'ed25519',
+      privateKeyPem: pem,
+    };
+    try {
+      await mkdir(dirname(this.path), { recursive: true });
+      // mode 0600 — the private key must not be world-readable. Applied on
+      // create (the only time we write); we never rewrite an existing file.
+      await writeFile(this.path, JSON.stringify(data, null, 2), { encoding: 'utf-8', mode: 0o600 });
+    } catch (err) {
+      log.warn({ err, path: this.path }, 'Failed to persist relay identity — a new key will be generated next boot');
+    }
+  }
+
+  /** Path the identity reads/writes — exposed for tests + diagnostics. */
+  get filePath(): string {
+    return this.path;
+  }
+
+  /** Raw Ed25519 public key as base64url — the value clients pin. */
+  get publicKeyBase64url(): string {
+    return this.publicKeyB64u;
+  }
+
+  /** base64url(sha256(public key)) — advertised in the mDNS TXT record. */
+  get fingerprint(): string {
+    return this.fingerprintValue;
+  }
+
+  /**
+   * Sign arbitrary bytes (a domain-separated client challenge) with the
+   * identity private key. Ed25519 → the algorithm argument is null.
+   */
+  sign(data: Buffer): Buffer {
+    return sign(null, data, this.privateKey);
+  }
+}
+
+function isPersistedIdentity(value: unknown): value is PersistedIdentity {
+  if (typeof value !== 'object' || value === null) return false;
+  const o = value as Record<string, unknown>;
+  return o['alg'] === 'ed25519' && typeof o['privateKeyPem'] === 'string';
+}
+
+function errnoCode(err: unknown): string | undefined {
+  if (typeof err === 'object' && err !== null && 'code' in err) {
+    const code = (err as { code: unknown }).code;
+    if (typeof code === 'string') return code;
+  }
+  return undefined;
+}

--- a/relay/src/plugins/auth.ts
+++ b/relay/src/plugins/auth.ts
@@ -18,6 +18,8 @@ const PUBLIC_PATHS = new Set([
   '/auth/me', // returns 401 if no session — frontend uses this to check auth state
   '/auth/methods', // public — clients need this to determine available auth methods
   '/auth/pin/login', // public — PIN auth handles its own rate limiting
+  '/identity', // public — exposes only the relay's PUBLIC identity key + fingerprint
+  '/identity/challenge', // public — signs a client nonce to prove key possession (LAN identity binding)
 ]);
 
 /** Path prefixes that are always public (static files handled by @fastify/static) */

--- a/relay/src/routes/__tests__/identity.test.ts
+++ b/relay/src/routes/__tests__/identity.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Integration tests for the public relay-identity routes.
+ *
+ * Registers the auth plugin so the test also proves `/identity` and
+ * `/identity/challenge` are in the PUBLIC_PATHS allowlist (reachable with no
+ * session cookie), and verifies the challenge signature against the relay's
+ * exposed public key over the domain-separated message.
+ */
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import Fastify, { type FastifyInstance } from 'fastify';
+import cookie from '@fastify/cookie';
+import { createPublicKey, randomBytes, verify } from 'node:crypto';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { authPlugin } from '../../plugins/auth.js';
+import { RelayIdentity } from '../../identity/relay-identity.js';
+import { CHALLENGE_CONTEXT, createIdentityRoutes } from '../identity.js';
+
+let app: FastifyInstance;
+let baseDir: string;
+let identity: RelayIdentity;
+
+beforeEach(async () => {
+  process.env['SESSION_SECRET'] = 'test-identity-route-secret-must-be-32-bytes!';
+  baseDir = await mkdtemp(join(tmpdir(), 'identity-route-'));
+  identity = await RelayIdentity.load(join(baseDir, 'relay-identity.json'));
+
+  app = Fastify({ logger: false });
+  await app.register(cookie);
+  await app.register(authPlugin);
+  await app.register(createIdentityRoutes({ identity }));
+  await app.ready();
+});
+
+afterEach(async () => {
+  await app.close();
+  await rm(baseDir, { recursive: true, force: true });
+});
+
+function publicKeyFrom(b64u: string) {
+  return createPublicKey({ key: { kty: 'OKP', crv: 'Ed25519', x: b64u }, format: 'jwk' });
+}
+
+describe('GET /identity', () => {
+  it('is public and returns the relay public key + fingerprint', async () => {
+    const res = await app.inject({ method: 'GET', url: '/identity' });
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual({
+      alg: 'ed25519',
+      publicKey: identity.publicKeyBase64url,
+      fingerprint: identity.fingerprint,
+    });
+  });
+});
+
+describe('POST /identity/challenge', () => {
+  it('signs a valid nonce; signature verifies over context||nonce', async () => {
+    const nonce = randomBytes(32);
+    const res = await app.inject({
+      method: 'POST',
+      url: '/identity/challenge',
+      headers: { 'content-type': 'application/json' },
+      payload: { nonce: nonce.toString('base64') },
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json() as { publicKey: string; signature: string };
+    expect(body.publicKey).toBe(identity.publicKeyBase64url);
+
+    const message = Buffer.concat([Buffer.from(CHALLENGE_CONTEXT, 'utf-8'), nonce]);
+    expect(
+      verify(null, message, publicKeyFrom(body.publicKey), Buffer.from(body.signature, 'base64')),
+    ).toBe(true);
+  });
+
+  it('does NOT verify over the bare nonce — proves domain separation', async () => {
+    const nonce = randomBytes(32);
+    const res = await app.inject({
+      method: 'POST',
+      url: '/identity/challenge',
+      headers: { 'content-type': 'application/json' },
+      payload: { nonce: nonce.toString('base64') },
+    });
+    const body = res.json() as { publicKey: string; signature: string };
+    expect(
+      verify(null, nonce, publicKeyFrom(body.publicKey), Buffer.from(body.signature, 'base64')),
+    ).toBe(false);
+  });
+
+  it('rejects a missing nonce with 400', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/identity/challenge',
+      headers: { 'content-type': 'application/json' },
+      payload: {},
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('rejects a too-short nonce with 400', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/identity/challenge',
+      headers: { 'content-type': 'application/json' },
+      payload: { nonce: Buffer.alloc(8).toString('base64') },
+    });
+    expect(res.statusCode).toBe(400);
+  });
+});

--- a/relay/src/routes/__tests__/identity.test.ts
+++ b/relay/src/routes/__tests__/identity.test.ts
@@ -70,7 +70,7 @@ describe('POST /identity/challenge', () => {
 
     const message = Buffer.concat([Buffer.from(CHALLENGE_CONTEXT, 'utf-8'), nonce]);
     expect(
-      verify(null, message, publicKeyFrom(body.publicKey), Buffer.from(body.signature, 'base64')),
+      verify(null, message, publicKeyFrom(body.publicKey), Buffer.from(body.signature, 'base64url')),
     ).toBe(true);
   });
 
@@ -84,7 +84,7 @@ describe('POST /identity/challenge', () => {
     });
     const body = res.json() as { publicKey: string; signature: string };
     expect(
-      verify(null, nonce, publicKeyFrom(body.publicKey), Buffer.from(body.signature, 'base64')),
+      verify(null, nonce, publicKeyFrom(body.publicKey), Buffer.from(body.signature, 'base64url')),
     ).toBe(false);
   });
 

--- a/relay/src/routes/identity.ts
+++ b/relay/src/routes/identity.ts
@@ -63,10 +63,12 @@ export function createIdentityRoutes(deps: IdentityDeps): FastifyPluginAsync {
 
       const message = Buffer.concat([Buffer.from(CHALLENGE_CONTEXT, 'utf-8'), nonce]);
       const signature = deps.identity.sign(message);
+      // Every binary field on the identity surface (publicKey, fingerprint,
+      // signature) is base64url so the iOS verifier uses a single decoder.
       return {
         alg: 'ed25519',
         publicKey: deps.identity.publicKeyBase64url,
-        signature: signature.toString('base64'),
+        signature: signature.toString('base64url'),
       };
     });
   };

--- a/relay/src/routes/identity.ts
+++ b/relay/src/routes/identity.ts
@@ -1,0 +1,73 @@
+// Relay identity routes (PUBLIC — no auth).
+//
+// These back the iOS LAN-preference identity binding:
+//   - GET  /identity            → the relay's Ed25519 public key + fingerprint.
+//                                  The app fetches this at pairing (against the
+//                                  OAuth'd host it trusts) and pins the key.
+//   - POST /identity/challenge  → signs a client-supplied random nonce with the
+//                                  identity private key. The app verifies this
+//                                  signature against the pinned key before
+//                                  trusting a discovered LAN host with the
+//                                  session cookie.
+//
+// SECURITY NOTE: the mDNS TXT `fp` and this public key are NOT secrets — they
+// are broadcast/served to anyone. The trust anchor is *possession of the
+// private key*, proven by the signature here. A host that merely echoes the
+// fingerprint or public key cannot produce a valid signature, so it fails the
+// challenge. (This defeats an impersonating "first responder"; it does not by
+// itself defeat an on-path MITM that forwards the nonce to the real relay —
+// that needs channel binding / TLS, tracked as follow-up hardening.)
+
+import type { FastifyPluginAsync } from 'fastify';
+import type { RelayIdentity } from '../identity/relay-identity.js';
+
+/**
+ * Domain-separation prefix for challenge signatures. The relay signs
+ * `CHALLENGE_CONTEXT_BYTES || nonce`, never the bare nonce, so a signature
+ * produced here can never be mistaken for a signature in some other protocol
+ * that signs raw bytes with the same key. iOS MUST verify over the identical
+ * byte construction.
+ */
+export const CHALLENGE_CONTEXT = 'major-tom/relay-identity/v1:';
+
+/** Bounds on the decoded client nonce — enough entropy, but not an open-ended
+ *  signing oracle for large attacker-chosen blobs. */
+const MIN_NONCE_BYTES = 16;
+const MAX_NONCE_BYTES = 64;
+
+interface IdentityDeps {
+  identity: RelayIdentity;
+}
+
+export function createIdentityRoutes(deps: IdentityDeps): FastifyPluginAsync {
+  return async (fastify) => {
+    fastify.get('/identity', async () => ({
+      alg: 'ed25519',
+      publicKey: deps.identity.publicKeyBase64url,
+      fingerprint: deps.identity.fingerprint,
+    }));
+
+    fastify.post('/identity/challenge', async (request, reply) => {
+      const body = request.body as { nonce?: unknown } | undefined;
+      const nonceB64 = body?.nonce;
+      if (typeof nonceB64 !== 'string' || nonceB64.length === 0) {
+        return reply.code(400).send({ error: 'nonce (base64 string) is required' });
+      }
+
+      const nonce = Buffer.from(nonceB64, 'base64');
+      if (nonce.length < MIN_NONCE_BYTES || nonce.length > MAX_NONCE_BYTES) {
+        return reply
+          .code(400)
+          .send({ error: `nonce must decode to ${MIN_NONCE_BYTES}-${MAX_NONCE_BYTES} bytes` });
+      }
+
+      const message = Buffer.concat([Buffer.from(CHALLENGE_CONTEXT, 'utf-8'), nonce]);
+      const signature = deps.identity.sign(message);
+      return {
+        alg: 'ed25519',
+        publicKey: deps.identity.publicKeyBase64url,
+        signature: signature.toString('base64'),
+      };
+    });
+  };
+}

--- a/relay/src/server.ts
+++ b/relay/src/server.ts
@@ -61,7 +61,9 @@ async function main() {
     // Advertise on the local network so the iOS app can discover us
     // without the user typing the Mac's LAN IP. Failures here are
     // non-fatal — the relay still serves HTTP, just without auto-discovery.
-    mdns = startMdns(PORT);
+    // The identity fingerprint rides along in the TXT record so the app can
+    // fast-filter discovered hosts before challenging them (see app.ts).
+    mdns = startMdns(PORT, app.relayIdentityFingerprint);
 
     // Startup info
     console.log('');


### PR DESCRIPTION
## Summary

Gives the relay a **persistent Ed25519 identity** so it can prove who it is on the LAN. This is the trust root that unblocks the held iOS LAN-preference feature (**#176**) — the app will pin this identity at pairing and verify it before handing the session cookie to any Bonjour-discovered host.

- **`relay/src/identity/relay-identity.ts`** — load-or-generate keypair persisted to `~/.major-tom/relay-identity.json` (mode `0600`); exposes base64url raw public key, `sha256` fingerprint, and `sign()`. Corrupt/missing file regenerates (modeled on `relay-config.ts`).
- **mDNS TXT** now carries `fp=<fingerprint>` — a fast discovery **filter only**, not a trust anchor (it is plaintext multicast, trivially spoofable).
- **`GET /identity`** (public) — `{ alg, publicKey, fingerprint }` for pairing capture against the OAuth'd host.
- **`POST /identity/challenge`** (public) — signs a **domain-separated** client nonce (`"major-tom/relay-identity/v1:" + nonce`) so a host proves possession of the private key. Echoed-fingerprint / bare-nonce impostors fail.

## Why signing (not just a fingerprint pin)

The original handoff called challenge-response "optional" and assumed a TXT-fingerprint pin alone closes the hole. It does not: the fingerprint is broadcast in plaintext mDNS, so any LAN attacker can copy the real relay's `fp` into their own TXT record and pass a pure pin check. **Possession of the private key (the signature) is the actual trust anchor;** the fingerprint is only a discovery filter.

## Security scope (honest limits)

- Defeats an impersonating **"first responder"** that harvests the session cookie — it cannot sign the nonce.
- Does **not** by itself defeat an active **on-path MITM** that forwards the nonce to the real relay. Full defense there needs channel binding (TLS with the pinned key). Tracked as **follow-up hardening**, not blocking this PR — matches the "ship the safe fix" call.

## Test plan

- [x] `RelayIdentity` unit tests — generate/persist, reload stability, fingerprint = base64url(sha256(pubkey)), sign+verify roundtrip, corrupt / bad-schema regenerates without throwing.
- [x] `/identity` + `/identity/challenge` route tests via Fastify `inject` — public (no cookie), challenge verifies over `context || nonce`, does NOT verify over the bare nonce (domain separation), 400 on missing / short nonce.
- [x] Full relay suite green (368 tests), `tsc --noEmit` clean.

## Follow-on

iOS side (BonjourBrowser TXT parse, Keychain pin at pairing, `RelayURLResolver` challenge-response gating) folds into **#176**. This relay PR is additive and independent — no client depends on these routes yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
