### PR TITLE
fix(ios): snapshot bestRelayURL once per terminal connection (#179)

### DIFF
--- a/ios/MajorTom/Features/Terminal/ViewModels/TerminalViewModel.swift
+++ b/ios/MajorTom/Features/Terminal/ViewModels/TerminalViewModel.swift
@@ -212,7 +212,9 @@ final class TerminalViewModel {
     /// Call once after auth is established (e.g. from the terminal view's
     /// onAppear or after a successful auth check).
     func reconcileWithRelay() async {
-        let base = relayBaseURL
+        // One-shot REST call — snapshot the resolver once so the base URL is
+        // stable for this request (same capture-once discipline as #179).
+        let base = snapshotRelay().baseURL
         guard let url = URL(string: "\(base)/shell/tabs") else { return }
 
         var request = URLRequest(url: url)
@@ -325,7 +327,8 @@ final class TerminalViewModel {
     /// logged and swallowed — the PTY will eventually expire via the
     /// 30-minute grace timer, which is the existing fallback behavior.
     private func killTabOnRelay(tabId: String) async {
-        let base = relayBaseURL
+        // One-shot REST call — snapshot the resolver once for a stable base URL.
+        let base = snapshotRelay().baseURL
         guard let url = URL(string: "\(base)/shell/\(tabId)/kill") else { return }
 
         var request = URLRequest(url: url)
@@ -377,17 +380,57 @@ final class TerminalViewModel {
 
     // MARK: - Relay Configuration
 
-    /// Build the relay WebSocket URL for `/shell/:tabId`.
-    var relayURL: String {
-        let base = relayResolver.bestRelayURL
-        let scheme = base.contains("://") ? "" : "http://"
-        // Strip protocol prefix for the host, then decide ws/wss
-        let fullBase = "\(scheme)\(base)"
-        let wsScheme = fullBase.hasPrefix("https://") ? "wss" : "ws"
-        let host = fullBase
-            .replacingOccurrences(of: "https://", with: "")
-            .replacingOccurrences(of: "http://", with: "")
-        return "\(wsScheme)://\(host)"
+    /// An immutable view of the relay endpoint captured from a SINGLE read of
+    /// `RelayURLResolver.bestRelayURL`. All three derived values (socket URL,
+    /// cookie domain, secure flag) are computed from the one captured `base`,
+    /// so they can never diverge — see #179. `bestRelayURL` can flip
+    /// tunnel→verified-LAN across an `await` while a connection is being set
+    /// up; capturing it once and threading this snapshot through the connect
+    /// path keeps the cookie domain pinned to the same host the socket dials.
+    struct RelaySnapshot {
+        /// The raw `host[:port]` (or full URL) captured from the resolver.
+        let base: String
+
+        /// The relay WebSocket URL for `/shell/:tabId` (`ws`/`wss`).
+        var socketURL: String {
+            let scheme = base.contains("://") ? "" : "http://"
+            // Strip protocol prefix for the host, then decide ws/wss.
+            let fullBase = "\(scheme)\(base)"
+            let wsScheme = fullBase.hasPrefix("https://") ? "wss" : "ws"
+            let host = fullBase
+                .replacingOccurrences(of: "https://", with: "")
+                .replacingOccurrences(of: "http://", with: "")
+            return "\(wsScheme)://\(host)"
+        }
+
+        /// The relay domain for cookie injection (host only, no port).
+        var cookieDomain: String {
+            let cleaned = base
+                .replacingOccurrences(of: "https://", with: "")
+                .replacingOccurrences(of: "http://", with: "")
+            return cleaned.components(separatedBy: ":").first ?? cleaned
+        }
+
+        /// Full relay base URL (http/https) — used to decide the cookie's
+        /// `secure` flag.
+        var baseURL: String {
+            let scheme = base.contains("://") ? "" : "http://"
+            return "\(scheme)\(base)"
+        }
+
+        /// True when the relay uses a secure transport (`https`/`wss`).
+        var isSecure: Bool {
+            let lowered = baseURL.lowercased()
+            return lowered.hasPrefix("https://") || lowered.hasPrefix("wss://")
+        }
+    }
+
+    /// Capture `bestRelayURL` ONCE for a single connection attempt. The caller
+    /// (`TerminalWebView`) threads the returned snapshot through cookie
+    /// injection and the JS config so the cookie domain and socket host are
+    /// guaranteed consistent even if a LAN host gets verified mid-connect.
+    func snapshotRelay() -> RelaySnapshot {
+        RelaySnapshot(base: relayResolver.bestRelayURL)
     }
 
     /// The session JWT token for auth.
@@ -395,33 +438,18 @@ final class TerminalViewModel {
         auth.sessionCookie
     }
 
-    /// The relay domain for cookie injection.
-    var relayDomain: String {
-        let base = relayResolver.bestRelayURL
-        let cleaned = base
-            .replacingOccurrences(of: "https://", with: "")
-            .replacingOccurrences(of: "http://", with: "")
-        // Strip port if present for cookie domain
-        return cleaned.components(separatedBy: ":").first ?? cleaned
-    }
-
-    /// Full relay base URL (http/https) for cookie path.
-    var relayBaseURL: String {
-        let base = relayResolver.bestRelayURL
-        let scheme = base.contains("://") ? "" : "http://"
-        return "\(scheme)\(base)"
-    }
-
-    /// Build the config object to inject into the terminal page via WKUserScript.
+    /// Build the config object to inject into the terminal page via WKUserScript,
+    /// using the socket URL from the supplied connection snapshot so it matches
+    /// the host the auth cookie is pinned to.
     ///
     /// The token is included so the JS layer can use it as a query-param
     /// fallback if cookie auth fails (WKWebView edge cases). The JS side
     /// only appends `?token=` when `config.tokenFallback` is true — by
     /// default cookies are the primary auth path, keeping the JWT out of
     /// URLs/logs/proxies.
-    var bridgeConfig: [String: Any] {
+    func bridgeConfig(for snapshot: RelaySnapshot) -> [String: Any] {
         var config: [String: Any] = [
-            "relayURL": relayURL,
+            "relayURL": snapshot.socketURL,
             "tabId": tabId,
             "theme": themeConfig,
             "fontSize": keybarViewModel.fontSize,

--- a/ios/MajorTom/Features/Terminal/Views/TerminalWebView.swift
+++ b/ios/MajorTom/Features/Terminal/Views/TerminalWebView.swift
@@ -59,9 +59,16 @@ struct TerminalWebView: UIViewRepresentable {
         // The JS side calls: window.webkit.messageHandlers.majorTom.postMessage({...})
         contentController.add(context.coordinator, name: "majorTom")
 
+        // Snapshot the relay endpoint ONCE for this connection attempt (#179).
+        // `bestRelayURL` can flip tunnel→verified-LAN across the `await` inside
+        // injectAuthCookie; deriving the JS config, the cookie domain, and the
+        // secure flag from this single capture keeps the cookie host and the
+        // socket host from diverging (which silently breaks /shell auth).
+        let relaySnapshot = viewModel.snapshotRelay()
+
         // Inject the config as a WKUserScript that runs at document start,
         // so it's available before terminal.html's own scripts execute.
-        let configJSON = serializeConfig(viewModel.bridgeConfig)
+        let configJSON = serializeConfig(viewModel.bridgeConfig(for: relaySnapshot))
         let configScript = WKUserScript(
             source: "window.__MAJOR_TOM_CONFIG__ = \(configJSON);",
             injectionTime: .atDocumentStart,
@@ -103,9 +110,11 @@ struct TerminalWebView: UIViewRepresentable {
         // and the UIEditMenuInteraction so cleanup happens via dismantleUIView.
         context.coordinator.attachTouchGestures(to: webView)
 
-        // Inject the auth cookie, then load the terminal page.
+        // Inject the auth cookie, then load the terminal page. The same
+        // snapshot used for the JS config drives the cookie domain/secure
+        // flag, so the two can't diverge if a LAN host is verified mid-await.
         Task { @MainActor in
-            await injectAuthCookie(into: dataStore)
+            await injectAuthCookie(into: dataStore, relay: relaySnapshot)
             loadTerminalPage(webView)
         }
 
@@ -159,29 +168,31 @@ struct TerminalWebView: UIViewRepresentable {
 
     // MARK: - Cookie Injection
 
-    /// Returns true when the relay URL uses a secure transport (`https`/`wss`).
-    private func isRelaySecure() -> Bool {
-        let base = viewModel.relayBaseURL.lowercased()
-        return base.hasPrefix("https://") || base.hasPrefix("wss://")
-    }
-
     /// Inject the session JWT as an HTTPCookie into the WKWebsiteDataStore.
     /// This is the primary auth mechanism for the WebSocket connection.
     /// Cookie expiry matches the relay's 7-day JWT lifetime so reconnects
     /// don't fail with a dropped cookie while the token is still valid.
-    private func injectAuthCookie(into dataStore: WKWebsiteDataStore) async {
+    ///
+    /// The `relay` snapshot is captured once per connection attempt in
+    /// `makeUIView` (#179) so the cookie's domain/secure flag are derived from
+    /// the same host the `/shell` socket dials — they can't diverge even if a
+    /// LAN host is verified during the `await` below.
+    private func injectAuthCookie(
+        into dataStore: WKWebsiteDataStore,
+        relay: TerminalViewModel.RelaySnapshot
+    ) async {
         guard let token = viewModel.authToken else { return }
 
         var cookieProperties: [HTTPCookiePropertyKey: Any] = [
             .name: "mt-session",
             .value: token,
-            .domain: viewModel.relayDomain,
+            .domain: relay.cookieDomain,
             .path: "/",
             .expires: Date().addingTimeInterval(7 * 24 * 60 * 60), // 7 days — matches relay JWT lifetime
         ]
 
         // Mark secure when relay uses HTTPS/WSS; omit for local http/ws dev.
-        if isRelaySecure() {
+        if relay.isSecure {
             cookieProperties[.secure] = "TRUE"
         }
 


### PR DESCRIPTION
## What
Snapshot `bestRelayURL` **once** per terminal connection attempt so the auth cookie domain and the `/shell` socket host can't diverge.

## Why (#179)
`RelayURLResolver.bestRelayURL` can flip tunnel→verified-LAN across an `await` (`verifiedLANAddress` is mutated async by `resolvePreferringLAN`). The connect path read it at three points separated by suspension — cookie `.domain` (`injectAuthCookie`), secure flag (`isRelaySecure`), and the `/shell` socket URL (JS config). If a LAN host got verified mid-connect, the cookie pinned to the **tunnel** domain while the socket went to the **LAN** host → `mt-session` not sent → `/shell` auth failed until the next connect (transient/self-healing — why it was deferred from #176).

## Fix
- `TerminalWebView.makeUIView` captures `let relaySnapshot = viewModel.snapshotRelay()` synchronously **before any await** — the lone read of `bestRelayURL`.
- The immutable `RelaySnapshot` (single `let base`) is threaded into `bridgeConfig(for:)` (socket URL) and `injectAuthCookie(into:relay:)` (cookie domain + secure flag); all three derive from one frozen value.
- Removed the old live-reading computed props (`relayURL`/`relayDomain`/`relayBaseURL`) and `isRelaySecure()`; the one-shot REST helpers reuse the same `snapshotRelay().baseURL` discipline.

## Verification
- `xcodebuild … -sdk iphonesimulator` → **BUILD SUCCEEDED**.
- Pre-PR adversarial review (independent agent): **pass** — confirmed exactly one resolver read per attempt, no new race (`@MainActor`, no suspension between read+capture), zero dangling refs to the removed symbols.

Closes #179.

🤖 Generated with [Claude Code](https://claude.com/claude-code)