### PR TITLE
fix(ios): terminal relay scheme via normalizeBaseURL (unbreak /shell over the tunnel)

### DIFF
--- a/ios/MajorTom/Core/Services/AuthService.swift
+++ b/ios/MajorTom/Core/Services/AuthService.swift
@@ -69,7 +69,7 @@ final class AuthService {
     /// we default to https:// unless the address clearly points at LAN /
     /// localhost / an IP / an mDNS `.local` host (in which case http://
     /// is correct for dev and permitted by `NSAllowsLocalNetworking`).
-    static func normalizeBaseURL(_ address: String) -> String {
+    nonisolated static func normalizeBaseURL(_ address: String) -> String {
         if address.contains("://") { return address }
         let lower = address.lowercased()
         // Explicit loopback / localhost.

--- a/ios/MajorTom/Features/Terminal/ViewModels/TerminalViewModel.swift
+++ b/ios/MajorTom/Features/Terminal/ViewModels/TerminalViewModel.swift
@@ -391,37 +391,39 @@ final class TerminalViewModel {
         /// The raw `host[:port]` (or full URL) captured from the resolver.
         let base: String
 
-        /// The relay WebSocket URL for `/shell/:tabId` (`ws`/`wss`).
+        /// Full relay base URL (`http`/`https`) for the captured host. Scheme
+        /// inference is delegated to `AuthService.normalizeBaseURL` — the SAME
+        /// rule every other relay request uses — instead of a naive default.
+        /// This matters for the tunnel: a public DNS host MUST be `https://`
+        /// (iOS App Transport Security blocks plain `http://`/`ws://` to public
+        /// domains, so the old naive `http://`/`ws://` default made `/shell`
+        /// fail before it ever left the device). A LAN IP / `.local` / localhost
+        /// host correctly stays on `http://`.
+        var baseURL: String {
+            AuthService.normalizeBaseURL(base)
+        }
+
+        /// The relay WebSocket URL for `/shell/:tabId`, matching `baseURL`'s
+        /// scheme (`https`→`wss`, `http`→`ws`).
         var socketURL: String {
-            let scheme = base.contains("://") ? "" : "http://"
-            // Strip protocol prefix for the host, then decide ws/wss.
-            let fullBase = "\(scheme)\(base)"
-            let wsScheme = fullBase.hasPrefix("https://") ? "wss" : "ws"
-            let host = fullBase
+            let wsScheme = baseURL.hasPrefix("https://") ? "wss" : "ws"
+            let host = baseURL
                 .replacingOccurrences(of: "https://", with: "")
                 .replacingOccurrences(of: "http://", with: "")
             return "\(wsScheme)://\(host)"
         }
 
-        /// The relay domain for cookie injection (host only, no port).
+        /// The relay domain for cookie injection (host only, no scheme/port).
         var cookieDomain: String {
-            let cleaned = base
+            let cleaned = baseURL
                 .replacingOccurrences(of: "https://", with: "")
                 .replacingOccurrences(of: "http://", with: "")
             return cleaned.components(separatedBy: ":").first ?? cleaned
         }
 
-        /// Full relay base URL (http/https) — used to decide the cookie's
-        /// `secure` flag.
-        var baseURL: String {
-            let scheme = base.contains("://") ? "" : "http://"
-            return "\(scheme)\(base)"
-        }
-
         /// True when the relay uses a secure transport (`https`/`wss`).
         var isSecure: Bool {
-            let lowered = baseURL.lowercased()
-            return lowered.hasPrefix("https://") || lowered.hasPrefix("wss://")
+            baseURL.lowercased().hasPrefix("https://")
         }
     }
 


### PR DESCRIPTION
## What
The terminal `/shell` REST + WebSocket now use the correct scheme over the public Cloudflare tunnel, so the PTY actually spawns when the app rides the tunnel.

## The bug (found in device QA)
`RelaySnapshot` (added in #179) inferred the URL scheme **naively** — a scheme-less host (`auth.serverURL` = `Secrets.tunnelURL`, a bare host) defaulted to `http://` / `ws://`. So for the **public tunnel** the terminal dialed `ws://<tunnel>` + `http://<tunnel>/shell/tabs`. **iOS App Transport Security blocks plain http/ws to public domains**, so those requests never left the device → `/shell` never reached the relay → no PTY → "terminal won’t connect."

Relay-log proof: across the broken sessions, **`/shell` never appeared** even though `/auth/google`, `/identity`, and the main `/ws` all did. The terminal only ever worked over the LAN (where `http`/`ws` is permitted) — over the tunnel it was silently dead.

> This is **not** a regression from #179’s refactor — the old `relayURL`/`relayBaseURL` had the identical naive logic; the snapshot just preserved it. It surfaced now because the LAN-preference fail-closes to the tunnel (see #183), exposing the always-broken tunnel terminal path.

## The fix
Derive `RelaySnapshot.baseURL` / `socketURL` / `isSecure` / `cookieDomain` from **`AuthService.normalizeBaseURL`** — the canonical rule every other relay request already uses:
- public DNS host → `https://` / `wss://` (ATS-safe)
- LAN IP / `.local` / `localhost` → `http://` / `ws://`

`normalizeBaseURL` is pure string logic, so it’s marked `nonisolated` to be callable from the value-type `RelaySnapshot` off the main actor (existing `@MainActor` callers are unaffected).

## Verification
- **On device:** rebuilt, reinstalled, relaunched → relay logs `GET /shell/tabs` (200) and **`Fresh PTY attached`** over the tunnel (`wss`). Terminal connects.
- LAN behavior unchanged (LAN hosts still resolve to `http`/`ws`).

## Follow-up
LAN-preference still doesn’t engage on Wi-Fi (rides the tunnel) — separate Bonjour discovery-timing issue, fully analyzed in **#183**. App is functional via the tunnel meanwhile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)