### PR TITLE
fix(ios): make LAN preference actually engage on Wi-Fi (#183)

### DIFF
--- a/docs/HANDOFF-RELAY-OAUTH-RESTART.md
+++ b/docs/HANDOFF-RELAY-OAUTH-RESTART.md
@@ -144,6 +144,34 @@ panel will scrutinize it.
   URL entry was removed in PR #173 OAuth-only consolidation — check
   `project_ios_secrets_indirection.md` before re-adding any URL UI.)
 
+> **STATUS UPDATE (PR #191) — this is now the ONLY LAN path into pairing, and
+> it does not exist. `bash start.sh --local` + iOS pairing is UNSUPPORTED on
+> plain Wi-Fi.**
+>
+> PR #191 removed the Bonjour branch from `PairingViewModel.currentRelayURL`
+> for a security reason that stands: pre-pairing there is no pinned relay
+> identity, so `RelayIdentityVerifier` structurally cannot challenge a
+> discovered host — and `signInWithGoogle` POSTs the Google ID token to
+> whatever `currentRelayURL` returns, then pins *that* host's key. An mDNS
+> first-responder could take the entire pairing flow. **Do not revert it.**
+>
+> Consequence: `currentRelayURL` is now reachability-preset → tunnel only, and
+> `PairingView` has had no manual-URL field since PR #173. So the "trap"
+> described above is no longer mDNS-miss-dependent — with the tunnel off there
+> is simply nothing reachable to pair against, and the Retry button on
+> "Google sign-in not available" can never succeed.
+>
+> Escape hatch that still works: the relay binds `0.0.0.0`
+> (`relay/src/server.ts:59`), so with Tailscale connected
+> `ServerPreset(reachability: .tailscale)` reaches a `--local` relay fine.
+> Plain Wi-Fi without Tailscale is the broken case. Post-pairing LAN
+> preference is unaffected — `RelayURLResolver` still prefers a
+> challenge-verified LAN host.
+>
+> Tracked in **#198**. P1 above matters more than ever: today "couldn't reach
+> the relay" and "relay has no Google auth configured" render the same
+> dead-end screen, which is what makes this failure mode so confusing.
+
 ### P3 — relay: kill the `SESSION_SECRET` append/regenerate footgun
 `relay/src/auth/session.ts:24-48` (`getSessionSecret`).
 - Never silently regenerate when a `.env` with a `SESSION_SECRET` exists on

--- a/ios/MajorTom/App/MajorTomApp.swift
+++ b/ios/MajorTom/App/MajorTomApp.swift
@@ -28,6 +28,15 @@ struct MajorTomApp: App {
         _bonjour = State(initialValue: browser)
         _relayResolver = State(initialValue: resolver)
         _terminalViewModel = State(initialValue: TerminalViewModel(auth: authService, titleStore: store, relayResolver: resolver))
+        // #183: pre-warm mDNS discovery at the earliest possible moment.
+        // `resolvePreferringLAN` used to start the browser itself, at the same
+        // instant it began waiting — so discover → TCP handshake → `.ready`
+        // never finished inside its window and the LAN never won. Browsing is
+        // unauthenticated and cheap (no credentials leave the device); trust is
+        // still gated downstream by the signed Ed25519 challenge. Started here
+        // rather than in `.onAppear` so it can't race the `isPaired` handler,
+        // and torn down on `.background` by the scenePhase handler below.
+        browser.start()
     }
     @Environment(\.scenePhase) private var scenePhase
 
@@ -37,7 +46,10 @@ struct MajorTomApp: App {
                 if auth.isPaired {
                     mainTabView
                 } else {
-                    PairingView(auth: auth)
+                    // Share the app-level browser so the cache the pairing view
+                    // warms is the same one `resolvePreferringLAN` reads the
+                    // moment sign-in flips `isPaired` (#183).
+                    PairingView(auth: auth, browser: bonjour)
                 }
             }
             .tint(MajorTomTheme.Colors.accent)
@@ -139,10 +151,14 @@ struct MajorTomApp: App {
             .onChange(of: scenePhase) { _, newPhase in
                 switch newPhase {
                 case .active:
-                    // Keep LAN discovery alive while foregrounded (paired only)
-                    // so reconnects prefer the LAN; tear it down in the
-                    // background to avoid needless mDNS browsing.
-                    if auth.isPaired { bonjour.start() }
+                    // Keep LAN discovery alive for the whole foreground session
+                    // so both sign-in and later reconnects find a warm cache
+                    // (#183); tear it down in the background so nothing browses
+                    // mDNS while the app is off-screen. No longer gated on
+                    // `isPaired` — an unpaired device needs the warm cache most,
+                    // since sign-in completing is exactly when the first
+                    // `resolvePreferringLAN` fires.
+                    bonjour.start()
                     if let action = ShortcutActionKey.consumeAction() {
                         handleShortcutAction(action)
                     }

--- a/ios/MajorTom/App/MajorTomApp.swift
+++ b/ios/MajorTom/App/MajorTomApp.swift
@@ -165,6 +165,25 @@ struct MajorTomApp: App {
                     // since sign-in completing is exactly when the first
                     // `resolvePreferringLAN` fires.
                     bonjour.start()
+                    // The other half of the `.background` invalidation below.
+                    // `resolvePreferringLAN` otherwise has exactly one trigger —
+                    // the `auth.isPaired` transition — which does NOT fire on
+                    // foreground, so a proof dropped on background could never be
+                    // re-earned: `bestRelayURL` is synchronous and can't
+                    // challenge, so every terminal tab opened for the rest of the
+                    // process would ride the tunnel. On a phone that background
+                    // round-trip happens within minutes of every launch, i.e.
+                    // #183's headline symptom for the dominant usage pattern.
+                    //
+                    // Fire-and-forget on purpose: nothing awaits it, so it can't
+                    // stall the UI or the connect path. A tab opened before it
+                    // lands just gets the tunnel for that one connection and the
+                    // next one gets the LAN. Overlap with the cold-launch resolve
+                    // is deduplicated inside `resolvePreferringLAN`, so a launch
+                    // costs one pass, not two.
+                    if auth.isPaired {
+                        Task { _ = await relayResolver.resolvePreferringLAN() }
+                    }
                     if let action = ShortcutActionKey.consumeAction() {
                         handleShortcutAction(action)
                     }
@@ -175,7 +194,9 @@ struct MajorTomApp: App {
                     // can advertise the same `host:port` string we verified at
                     // home. Drop the proof so the next connect re-challenges (or
                     // fails closed to the tunnel) instead of handing the session
-                    // cookie to whoever now answers at that address.
+                    // cookie to whoever now answers at that address. The
+                    // re-challenge is the `.active` re-resolve above — these two
+                    // only make sense as a pair.
                     relayResolver.invalidateVerifiedLANHost()
                 default:
                     break

--- a/ios/MajorTom/App/MajorTomApp.swift
+++ b/ios/MajorTom/App/MajorTomApp.swift
@@ -28,15 +28,6 @@ struct MajorTomApp: App {
         _bonjour = State(initialValue: browser)
         _relayResolver = State(initialValue: resolver)
         _terminalViewModel = State(initialValue: TerminalViewModel(auth: authService, titleStore: store, relayResolver: resolver))
-        // #183: pre-warm mDNS discovery at the earliest possible moment.
-        // `resolvePreferringLAN` used to start the browser itself, at the same
-        // instant it began waiting — so discover → TCP handshake → `.ready`
-        // never finished inside its window and the LAN never won. Browsing is
-        // unauthenticated and cheap (no credentials leave the device); trust is
-        // still gated downstream by the signed Ed25519 challenge. Started here
-        // rather than in `.onAppear` so it can't race the `isPaired` handler,
-        // and torn down on `.background` by the scenePhase handler below.
-        browser.start()
     }
     @Environment(\.scenePhase) private var scenePhase
 
@@ -55,6 +46,21 @@ struct MajorTomApp: App {
             .tint(MajorTomTheme.Colors.accent)
             .preferredColorScheme(.dark)
             .onAppear {
+                // #183: pre-warm mDNS discovery so `resolvePreferringLAN` reads a
+                // warm cache instead of starting the browser at the same instant
+                // it begins waiting. Deliberately here and NOT in `init()`: three
+                // App Intents ship with `openAppWhenRun = false`
+                // (`FleetStatusIntent`, `SessionSummaryIntent`,
+                // `ToggleGodModeIntent`) and the Watch counterpart wakes us via
+                // `sendMessage`/`transferUserInfo`, so the process can be launched
+                // with no UI scene at all — `init()` would browse mDNS and open
+                // `:9090` TCP resolves entirely off-screen, where the Local
+                // Network permission can't even be prompted for. `.onAppear` runs
+                // only when a scene is connected, which is exactly the gate we
+                // want. Racing the `isPaired` handler below is harmless because
+                // `resolvePreferringLAN` starts the browser itself if needed and
+                // measures its grace window from `BonjourBrowser.startedAt`.
+                bonjour.start()
                 let achievementsVM = AchievementsViewModel(auth: auth)
                 achievementsViewModel = achievementsVM
                 relay.officeSceneManager = officeSceneManager
@@ -164,6 +170,13 @@ struct MajorTomApp: App {
                     }
                 case .background:
                     bonjour.stop()
+                    // Backgrounding is the boundary across which the device can
+                    // wake up on a completely different LAN, where a hostile peer
+                    // can advertise the same `host:port` string we verified at
+                    // home. Drop the proof so the next connect re-challenges (or
+                    // fails closed to the tunnel) instead of handing the session
+                    // cookie to whoever now answers at that address.
+                    relayResolver.invalidateVerifiedLANHost()
                 default:
                     break
                 }

--- a/ios/MajorTom/Core/Services/BonjourBrowser.swift
+++ b/ios/MajorTom/Core/Services/BonjourBrowser.swift
@@ -37,6 +37,21 @@ final class BonjourBrowser {
     private(set) var services: [DiscoveredService] = []
     private(set) var isBrowsing = false
 
+    /// The instant the *current* browser was actually created. `start()` is
+    /// idempotent, so a repeat call does NOT push this forward — it marks when
+    /// mDNS browsing genuinely began. `RelayURLResolver` anchors its discovery
+    /// grace window here instead of at its own start: a resolve that fires right
+    /// after launch still gets a full browse window, while one that fires long
+    /// after a warm start pays almost nothing (#183). `nil` while stopped.
+    private(set) var startedAt: ContinuousClock.Instant?
+
+    /// Bumped every time a NEW browser is created. Anything that caches a
+    /// discovery-derived *trust* decision (see `RelayURLResolver.verifiedLAN`)
+    /// binds to this, so a `stop()`/`start()` cycle — background→foreground, an
+    /// explicit teardown — voids that cache by construction instead of relying
+    /// on a caller remembering to clear it.
+    private(set) var generation = 0
+
     /// Browse results currently mid-resolve (TCP handshake in flight).
     /// `RelayURLResolver` polls this to hold its LAN window open **only**
     /// while a local responder is genuinely being resolved — with nothing
@@ -53,15 +68,27 @@ final class BonjourBrowser {
     /// realistic deployment (home LAN typically has 1, lab setups <5).
     private static let maxServices = 16
 
-    /// Hard bound on a single resolve's TCP handshake. Without it a peer that
-    /// black-holes SYNs to `:9090` keeps `pendingResolveCount` above zero for
-    /// the platform default (tens of seconds), which would pin
-    /// `RelayURLResolver`'s adaptive window at its ceiling on every connect.
-    /// 3s is far above a real LAN handshake (single-digit ms).
-    private static let resolveConnectTimeoutSeconds = 3
+    /// Hard bound on a single resolve. Applied twice, because one mechanism is
+    /// not enough:
+    ///
+    /// - As `NWProtocolTCP.Options.connectionTimeout`, which bounds the TCP
+    ///   handshake — without it a peer that black-holes SYNs to `:9090` keeps
+    ///   `pendingResolveCount` above zero for the platform default (tens of
+    ///   seconds) and pins `RelayURLResolver`'s window at its ceiling.
+    /// - As a wall-clock watchdog (`watchdogs`), because `connectionTimeout`
+    ///   bounds neither `.waiting` (an `NWConnection` with no viable path — easy
+    ///   to hit, since `.cellular` is prohibited below, so dropping Wi-Fi parks
+    ///   the connection there indefinitely) nor the mDNS/DNS resolution phase of
+    ///   a `.service` endpoint.
+    ///
+    /// 3s is far above a real LAN handshake (single-digit ms) and strictly below
+    /// `RelayURLResolver.maxWait` (4s), which the adaptive window depends on.
+    private static let resolveDeadlineSeconds = 3
 
     private var browser: NWBrowser?
     private var resolvers: [String: NWConnection] = [:]
+    /// One per in-flight resolver, keyed identically to `resolvers`.
+    private var watchdogs: [String: Task<Void, Never>] = [:]
 
     private let clock = ContinuousClock()
 
@@ -73,13 +100,22 @@ final class BonjourBrowser {
         params.includePeerToPeer = false
         let browser = NWBrowser(for: descriptor, using: params)
 
-        browser.browseResultsChangedHandler = { [weak self] results, _ in
-            Task { @MainActor [weak self] in
-                self?.handleResults(results)
+        // Both handlers hop through a `Task`, so a delivery can land after a
+        // `stop()` (or after a *replacement* browser was started). Without the
+        // identity guard, a queued browse result would call `startResolve` while
+        // `browser == nil`, registering a resolver that browse-result eviction
+        // can never reach — and whose name the next browser then skips
+        // (`resolvers[name] != nil`), so the service never resolves again and
+        // every connect falls back to the tunnel for the rest of the session.
+        browser.browseResultsChangedHandler = { [weak self, weak browser] results, _ in
+            Task { @MainActor in
+                guard let self, let browser, self.browser === browser else { return }
+                self.handleResults(results)
             }
         }
-        browser.stateUpdateHandler = { [weak self] state in
-            Task { @MainActor [weak self] in
+        browser.stateUpdateHandler = { [weak self, weak browser] state in
+            Task { @MainActor in
+                guard let self, let browser, self.browser === browser else { return }
                 switch state {
                 case .ready:
                     discoveryLog.info("browser ready")
@@ -88,8 +124,15 @@ final class BonjourBrowser {
                     // permission — worth its own line in the #183 timing pass.
                     discoveryLog.notice("browser waiting: \(error.localizedDescription, privacy: .public)")
                 case .failed(let error):
+                    // Tear the failed browser down completely. Merely flipping
+                    // `isBrowsing` would leave `browser` non-nil, making
+                    // `start()`'s `guard browser == nil` a permanent no-op — so
+                    // discovery would stay dead for the whole process and every
+                    // resolve would silently ride the tunnel (#183 reproduced for
+                    // that launch). `start()` is now the recovery mechanism, so
+                    // it has to be able to build a fresh browser.
                     discoveryLog.error("browser failed: \(error.localizedDescription, privacy: .public)")
-                    self?.isBrowsing = false
+                    self.stop()
                 case .cancelled:
                     discoveryLog.info("browser cancelled")
                 default:
@@ -99,6 +142,8 @@ final class BonjourBrowser {
         }
         self.browser = browser
         isBrowsing = true
+        generation &+= 1
+        startedAt = clock.now
         browser.start(queue: .main)
     }
 
@@ -111,8 +156,8 @@ final class BonjourBrowser {
         }
         browser?.cancel()
         browser = nil
-        for conn in resolvers.values { conn.cancel() }
-        resolvers.removeAll()
+        startedAt = nil
+        for name in Array(resolvers.keys) { cancelResolver(name) }
         services.removeAll()
         isBrowsing = false
     }
@@ -124,8 +169,7 @@ final class BonjourBrowser {
         // Drop services that no longer appear in the browse results.
         services.removeAll { !activeNames.contains($0.id) }
         for name in Array(resolvers.keys) where !activeNames.contains(name) {
-            resolvers[name]?.cancel()
-            resolvers.removeValue(forKey: name)
+            cancelResolver(name)
         }
 
         // Resolve newly-seen services, bounded by `maxServices` so
@@ -143,17 +187,17 @@ final class BonjourBrowser {
         let params = NWParameters.tcp
         params.prohibitedInterfaceTypes = [.cellular]
         if let tcp = params.defaultProtocolStack.transportProtocol as? NWProtocolTCP.Options {
-            tcp.connectionTimeout = Self.resolveConnectTimeoutSeconds
+            tcp.connectionTimeout = Self.resolveDeadlineSeconds
         }
         let conn = NWConnection(to: result.endpoint, using: params)
-        let startedAt = clock.now
+        let resolveStartedAt = clock.now
         resolvers[name] = conn
         discoveryLog.info("resolve start \(name, privacy: .public) (fp \(Self.shortFingerprint(fingerprint), privacy: .public))")
 
         conn.stateUpdateHandler = { [weak self] state in
             Task { @MainActor [weak self] in
                 guard let self else { return }
-                let elapsed = Self.elapsedMS(from: startedAt, clock: self.clock)
+                let elapsed = Self.elapsedMS(from: resolveStartedAt, clock: self.clock)
                 switch state {
                 case .ready:
                     // State callbacks hop through a `Task`, so a `stop()` or a
@@ -175,8 +219,23 @@ final class BonjourBrowser {
                     }
                     conn.cancel()
                     self.clearResolver(name, ifIdenticalTo: conn)
+                case .waiting(let error):
+                    // NOT terminal and NOT bounded by `connectionTimeout`: an
+                    // `NWConnection` with no viable path parks here until one
+                    // appears. Logged rather than cancelled so a transient
+                    // ECONNREFUSED can still recover; the watchdog below is what
+                    // guarantees the slot is eventually freed.
+                    discoveryLog.notice("resolve waiting \(name, privacy: .public) after \(elapsed, privacy: .public)ms: \(error.localizedDescription, privacy: .public)")
                 case .failed(let error):
                     discoveryLog.notice("resolve failed \(name, privacy: .public) after \(elapsed, privacy: .public)ms: \(error.localizedDescription, privacy: .public)")
+                    // `NWConnection` releases its state handler only after
+                    // `.cancelled`, and that handler captures `conn` — so
+                    // dropping the dictionary entry without cancelling strands
+                    // the connection + handler for the life of the process. With
+                    // a relay asleep behind a Bonjour sleep proxy (still
+                    // advertised, SYNs unanswered) that is one leak per mDNS TTL
+                    // refresh.
+                    conn.cancel()
                     self.clearResolver(name, ifIdenticalTo: conn)
                 case .cancelled:
                     self.clearResolver(name, ifIdenticalTo: conn)
@@ -186,6 +245,20 @@ final class BonjourBrowser {
             }
         }
         conn.start(queue: .main)
+
+        // Wall-clock backstop for every state `connectionTimeout` doesn't cover
+        // (`.waiting`, a stalled mDNS/DNS resolution phase). Without it a
+        // connection that loses its path — Wi-Fi → cellular mid-resolve, with
+        // `.cellular` prohibited — holds a `maxServices` slot and a non-zero
+        // `pendingResolveCount` forever, which then defeats `RelayURLResolver`'s
+        // grace break and stalls every later connect out to its 4s ceiling.
+        watchdogs[name] = Task { @MainActor [weak self] in
+            try? await Task.sleep(for: .seconds(Self.resolveDeadlineSeconds))
+            guard !Task.isCancelled, let self, self.resolvers[name] === conn else { return }
+            discoveryLog.notice("resolve watchdog \(name, privacy: .public): cancelling after \(Self.resolveDeadlineSeconds, privacy: .public)s")
+            conn.cancel()
+            self.clearResolver(name, ifIdenticalTo: conn)
+        }
     }
 
     /// Drop a finished resolver, but only if the slot still holds *this*
@@ -196,6 +269,16 @@ final class BonjourBrowser {
     private func clearResolver(_ name: String, ifIdenticalTo conn: NWConnection) {
         guard resolvers[name] === conn else { return }
         resolvers.removeValue(forKey: name)
+        watchdogs.removeValue(forKey: name)?.cancel()
+    }
+
+    /// Unconditionally tear down the resolver registered for `name` — connection
+    /// cancelled, watchdog cancelled, slot freed. Used where the *slot* is being
+    /// reclaimed (browse eviction, `stop()`) rather than a specific connection
+    /// finishing.
+    private func cancelResolver(_ name: String) {
+        resolvers.removeValue(forKey: name)?.cancel()
+        watchdogs.removeValue(forKey: name)?.cancel()
     }
 
     /// Whole milliseconds since `start` — the unit every discovery/resolve log

--- a/ios/MajorTom/Core/Services/BonjourBrowser.swift
+++ b/ios/MajorTom/Core/Services/BonjourBrowser.swift
@@ -1,5 +1,12 @@
 import Foundation
 import Network
+import OSLog
+
+/// Discovery timing lives under `com.majortom.app` / `discovery` so an
+/// on-device pass can be read straight out of Console.app. Only service
+/// names, `.local` hostnames and NWError text are emitted — never keys,
+/// cookies or tokens (this browser never sees any).
+private let discoveryLog = Logger(subsystem: "com.majortom.app", category: "discovery")
 
 /// Discovers Major Tom relay instances on the local network via Bonjour
 /// (`_majortom._tcp`). Each discovered service is resolved to a `host:port`
@@ -30,6 +37,15 @@ final class BonjourBrowser {
     private(set) var services: [DiscoveredService] = []
     private(set) var isBrowsing = false
 
+    /// Browse results currently mid-resolve (TCP handshake in flight).
+    /// `RelayURLResolver` polls this to hold its LAN window open **only**
+    /// while a local responder is genuinely being resolved — with nothing
+    /// answering on the LAN (cellular / remote) it stays 0 and the resolver
+    /// falls through to the tunnel as soon as its short grace window closes.
+    /// Derived from `resolvers` rather than mirrored into a second stored
+    /// property so the two can never desync (#183).
+    var pendingResolveCount: Int { resolvers.count }
+
     /// Cap on concurrent resolvers + emitted services. A hostile peer on
     /// the LAN can flood the multicast group with unique `_majortom._tcp`
     /// names; without a cap each name opens an `NWConnection` and a chip
@@ -37,11 +53,21 @@ final class BonjourBrowser {
     /// realistic deployment (home LAN typically has 1, lab setups <5).
     private static let maxServices = 16
 
+    /// Hard bound on a single resolve's TCP handshake. Without it a peer that
+    /// black-holes SYNs to `:9090` keeps `pendingResolveCount` above zero for
+    /// the platform default (tens of seconds), which would pin
+    /// `RelayURLResolver`'s adaptive window at its ceiling on every connect.
+    /// 3s is far above a real LAN handshake (single-digit ms).
+    private static let resolveConnectTimeoutSeconds = 3
+
     private var browser: NWBrowser?
     private var resolvers: [String: NWConnection] = [:]
 
+    private let clock = ContinuousClock()
+
     func start() {
         guard browser == nil else { return }
+        discoveryLog.info("browser starting")
         let descriptor = NWBrowser.Descriptor.bonjour(type: "_majortom._tcp", domain: nil)
         let params = NWParameters()
         params.includePeerToPeer = false
@@ -54,8 +80,20 @@ final class BonjourBrowser {
         }
         browser.stateUpdateHandler = { [weak self] state in
             Task { @MainActor [weak self] in
-                if case .failed = state {
+                switch state {
+                case .ready:
+                    discoveryLog.info("browser ready")
+                case .waiting(let error):
+                    // The tell-tale for a denied/undetermined Local Network
+                    // permission — worth its own line in the #183 timing pass.
+                    discoveryLog.notice("browser waiting: \(error.localizedDescription, privacy: .public)")
+                case .failed(let error):
+                    discoveryLog.error("browser failed: \(error.localizedDescription, privacy: .public)")
                     self?.isBrowsing = false
+                case .cancelled:
+                    discoveryLog.info("browser cancelled")
+                default:
+                    break
                 }
             }
         }
@@ -65,6 +103,12 @@ final class BonjourBrowser {
     }
 
     func stop() {
+        // Log only when there was something to tear down, but ALWAYS run the
+        // teardown below — an early return here could strand a `services` entry
+        // appended by a resolver callback that landed after a previous `stop()`.
+        if browser != nil || !resolvers.isEmpty {
+            discoveryLog.info("browser stopping (\(self.services.count, privacy: .public) discovered, \(self.resolvers.count, privacy: .public) resolving)")
+        }
         browser?.cancel()
         browser = nil
         for conn in resolvers.values { conn.cancel() }
@@ -75,6 +119,7 @@ final class BonjourBrowser {
 
     private func handleResults(_ results: Set<NWBrowser.Result>) {
         let activeNames = Set(results.compactMap(Self.serviceName(from:)))
+        discoveryLog.info("browse results: \(activeNames.count, privacy: .public) advertised, \(self.services.count, privacy: .public) resolved, \(self.resolvers.count, privacy: .public) resolving")
 
         // Drop services that no longer appear in the browse results.
         services.removeAll { !activeNames.contains($0.id) }
@@ -97,30 +142,76 @@ final class BonjourBrowser {
     private func startResolve(for result: NWBrowser.Result, name: String, fingerprint: String?) {
         let params = NWParameters.tcp
         params.prohibitedInterfaceTypes = [.cellular]
+        if let tcp = params.defaultProtocolStack.transportProtocol as? NWProtocolTCP.Options {
+            tcp.connectionTimeout = Self.resolveConnectTimeoutSeconds
+        }
         let conn = NWConnection(to: result.endpoint, using: params)
+        let startedAt = clock.now
         resolvers[name] = conn
+        discoveryLog.info("resolve start \(name, privacy: .public) (fp \(Self.shortFingerprint(fingerprint), privacy: .public))")
 
         conn.stateUpdateHandler = { [weak self] state in
             Task { @MainActor [weak self] in
                 guard let self else { return }
+                let elapsed = Self.elapsedMS(from: startedAt, clock: self.clock)
                 switch state {
                 case .ready:
+                    // State callbacks hop through a `Task`, so a `stop()` or a
+                    // browse-result eviction can land first. If this resolver is
+                    // no longer the registered one, don't resurrect a service
+                    // that was torn down — just release the connection.
+                    guard self.resolvers[name] === conn else {
+                        conn.cancel()
+                        return
+                    }
                     if let address = Self.address(from: conn.currentPath?.remoteEndpoint) {
+                        discoveryLog.info("resolve ready \(name, privacy: .public) → \(address, privacy: .public) in \(elapsed, privacy: .public)ms")
                         let entry = DiscoveredService(id: name, displayName: name, address: address, fingerprint: fingerprint)
                         if !self.services.contains(entry) {
                             self.services.append(entry)
                         }
+                    } else {
+                        discoveryLog.notice("resolve ready \(name, privacy: .public) but no usable host:port in \(elapsed, privacy: .public)ms")
                     }
                     conn.cancel()
-                    self.resolvers.removeValue(forKey: name)
-                case .failed, .cancelled:
-                    self.resolvers.removeValue(forKey: name)
+                    self.clearResolver(name, ifIdenticalTo: conn)
+                case .failed(let error):
+                    discoveryLog.notice("resolve failed \(name, privacy: .public) after \(elapsed, privacy: .public)ms: \(error.localizedDescription, privacy: .public)")
+                    self.clearResolver(name, ifIdenticalTo: conn)
+                case .cancelled:
+                    self.clearResolver(name, ifIdenticalTo: conn)
                 default:
                     break
                 }
             }
         }
         conn.start(queue: .main)
+    }
+
+    /// Drop a finished resolver, but only if the slot still holds *this*
+    /// connection. `.ready` cancels the connection, so a `.cancelled` callback
+    /// always trails it; without the identity check that trailing callback
+    /// would evict a fresh resolver started for the same service name in
+    /// between (service flap), silently zeroing `pendingResolveCount`.
+    private func clearResolver(_ name: String, ifIdenticalTo conn: NWConnection) {
+        guard resolvers[name] === conn else { return }
+        resolvers.removeValue(forKey: name)
+    }
+
+    /// Whole milliseconds since `start` — the unit every discovery/resolve log
+    /// line reports so an on-device pass can be read without arithmetic.
+    static func elapsedMS(from start: ContinuousClock.Instant, clock: ContinuousClock) -> Int {
+        let elapsed = start.duration(to: clock.now)
+        let (seconds, attoseconds) = elapsed.components
+        return Int(seconds * 1_000 + attoseconds / 1_000_000_000_000_000)
+    }
+
+    /// First 8 chars of a relay fingerprint for log correlation. The
+    /// fingerprint is public data (plaintext mDNS TXT), but a prefix is
+    /// enough to correlate lines and keeps them short.
+    static func shortFingerprint(_ fingerprint: String?) -> String {
+        guard let fingerprint, !fingerprint.isEmpty else { return "none" }
+        return String(fingerprint.prefix(8))
     }
 
     private static func serviceName(from result: NWBrowser.Result) -> String? {

--- a/ios/MajorTom/Core/Services/RelayURLResolver.swift
+++ b/ios/MajorTom/Core/Services/RelayURLResolver.swift
@@ -1,4 +1,11 @@
 import Foundation
+import OSLog
+
+/// Connect-time LAN-vs-tunnel decisions land under `com.majortom.app` /
+/// `resolve`. Only addresses, fingerprint prefixes (public mDNS data) and
+/// elapsed milliseconds are emitted — never the session cookie, the pinned
+/// key, a nonce or a signature.
+private let resolveLog = Logger(subsystem: "com.majortom.app", category: "resolve")
 
 /// Resolves the best relay base URL to connect to *at connect time*,
 /// preferring a Bonjour-discovered LAN host over the frozen `auth.serverURL`
@@ -55,31 +62,75 @@ final class RelayURLResolver {
         return auth.serverURL
     }
 
+    /// How long we wait for Bonjour to show *any* sign of a local responder
+    /// before giving up on the LAN. Sized for the cellular / remote case: with
+    /// nothing advertising `_majortom._tcp` this is the entire cost added to
+    /// connect (down from the old flat 2s window). Deliberately NOT gated on
+    /// `NetworkPathMonitor.reachability` — that starts at `.offline` until
+    /// `NWPathMonitor` delivers its first update, so a launch-time check would
+    /// skip the LAN exactly when we most want it.
+    private static let discoveryGrace: Duration = .seconds(1)
+
+    /// Hard ceiling on the LAN window. Only reachable when a responder is
+    /// actually mid-resolve or mid-challenge — the grace window ends the wait
+    /// otherwise. Sized to cover mDNS browse + TCP handshake + one challenge
+    /// round-trip on a slow/busy Wi-Fi network.
+    private static let maxWait: Duration = .seconds(4)
+
+    /// Re-check cadence while the window is open.
+    private static let pollInterval: Duration = .milliseconds(150)
+
     /// Resolve preferring the LAN, but only after proving a discovered host is
-    /// the relay we paired with. Gives Bonjour a brief window to answer, then
-    /// for each discovered host fast-filters on the advertised fingerprint and
-    /// challenges it to sign a fresh nonce (`RelayIdentityVerifier`). The first
-    /// host that returns a valid signature against the pinned key is cached and
-    /// returned; otherwise we fall back to the tunnel. With no pinned identity
-    /// (paired against a relay that predates `/identity`) we never trust a LAN
-    /// host and always return the tunnel. Idempotently starts discovery.
-    func resolvePreferringLAN(timeout: Duration = .seconds(2)) async -> String {
+    /// the relay we paired with. Gives Bonjour a window to answer, then for each
+    /// discovered host fast-filters on the advertised fingerprint and challenges
+    /// it to sign a fresh nonce (`RelayIdentityVerifier`). The first host that
+    /// returns a valid signature against the pinned key is cached and returned;
+    /// otherwise we fall back to the tunnel. With no pinned identity (paired
+    /// against a relay that predates `/identity`) we never trust a LAN host and
+    /// always return the tunnel. Idempotently starts discovery.
+    ///
+    /// **Timing policy (#183).** The old flat 2s window routinely expired before
+    /// `BonjourBrowser` had finished its discover → TCP-handshake → `.ready`
+    /// pipeline, so the LAN never won on Wi-Fi. It is replaced by a window that
+    /// is *short when nothing is there* and *patient when something is*:
+    ///
+    /// - `discoveryGrace` (1s): if nothing local has answered by then — nothing
+    ///   discovered, nothing mid-resolve — return the tunnel. Cellular and
+    ///   remote users pay 1s instead of the old 2s.
+    /// - Extend past the grace window only while `browser.pendingResolveCount`
+    ///   is non-zero, i.e. a discovered responder is genuinely mid-handshake.
+    ///   `BonjourBrowser` caps each handshake at 3s, so a black-holed advertiser
+    ///   cannot hold the window open indefinitely.
+    /// - `maxWait` (4s) is a hard ceiling: no *new* challenge starts after it,
+    ///   which also bounds the old worst case where up to 16 discovered hosts
+    ///   could each burn a 2s challenge timeout serially inside one pass.
+    ///
+    /// A challenge already in flight is allowed to finish (it is the payoff),
+    /// so the absolute worst case is `maxWait` + one challenge timeout.
+    func resolvePreferringLAN() async -> String {
+        let clock = ContinuousClock()
+        let started = clock.now
+
         // Re-use a still-advertised verified host without re-challenging.
         if let verified = verifiedLANAddress,
            browser.services.contains(where: { $0.address == verified }) {
+            resolveLog.info("resolve → LAN \(verified, privacy: .public) (cached, verified this session)")
             return verified
         }
         verifiedLANAddress = nil
 
         guard let pinned = KeychainService.load(.relayPublicKey),
               let pinnedRaw = RelayIdentityVerifier.data(fromBase64url: pinned) else {
+            resolveLog.notice("resolve → tunnel: no pinned relay identity (paired pre-/identity)")
             return auth.serverURL
         }
         let expectedFingerprint = RelayIdentityVerifier.fingerprint(forRawPublicKey: pinnedRaw)
 
         browser.start()
-        let clock = ContinuousClock()
-        let deadline = clock.now.advanced(by: timeout)
+        resolveLog.info("resolve start: \(self.browser.services.count, privacy: .public) warm, \(self.browser.pendingResolveCount, privacy: .public) resolving, pinned fp \(BonjourBrowser.shortFingerprint(expectedFingerprint), privacy: .public)")
+
+        let graceDeadline = started.advanced(by: Self.discoveryGrace)
+        let ceiling = started.advanced(by: Self.maxWait)
         var challenged: Set<String> = []
 
         while true {
@@ -87,20 +138,48 @@ final class RelayURLResolver {
             // during an await are picked up on the next outer pass. `challenged`
             // prevents re-issuing a challenge to the same address.
             for service in browser.services where !challenged.contains(service.address) {
+                // Don't *start* a new challenge past the ceiling — each one can
+                // burn its own HTTP timeout, so an unbounded pass over many
+                // discovered hosts would stall the connect path.
+                if clock.now >= ceiling { break }
                 challenged.insert(service.address)
                 // A mismatched advertised fingerprint can't be our relay — skip
                 // the round-trip. A *missing* fingerprint is still challenged;
                 // the signature, not the fingerprint, is the trust anchor.
-                if let fp = service.fingerprint, fp != expectedFingerprint { continue }
+                if let fp = service.fingerprint, fp != expectedFingerprint {
+                    resolveLog.notice("skip \(service.address, privacy: .public): advertised fp \(BonjourBrowser.shortFingerprint(fp), privacy: .public) ≠ pinned")
+                    continue
+                }
                 let base = AuthService.normalizeBaseURL(service.address)
-                if await RelayIdentityVerifier.challenge(baseURL: base, pinnedPublicKeyBase64url: pinned) {
+                let challengeStart = clock.now
+                let verified = await RelayIdentityVerifier.challenge(baseURL: base, pinnedPublicKeyBase64url: pinned)
+                resolveLog.info("challenge \(service.address, privacy: .public) → \(verified ? "VERIFIED" : "rejected", privacy: .public) in \(BonjourBrowser.elapsedMS(from: challengeStart, clock: clock), privacy: .public)ms")
+                if verified {
                     verifiedLANAddress = service.address
+                    resolveLog.info("resolve → LAN \(service.address, privacy: .public) in \(BonjourBrowser.elapsedMS(from: started, clock: clock), privacy: .public)ms")
                     return service.address
                 }
             }
-            if clock.now >= deadline { break }
+
+            let now = clock.now
+            if now >= ceiling {
+                resolveLog.notice("resolve → tunnel: hit \(Self.maxWait.description, privacy: .public) ceiling after \(challenged.count, privacy: .public) challenge(s)")
+                break
+            }
+            // Hold the window open past the grace period only while a discovered
+            // responder is still mid-handshake. Nothing pending == nothing local
+            // is coming, so cellular/remote falls through immediately.
+            if now >= graceDeadline && browser.pendingResolveCount == 0 {
+                resolveLog.info("resolve → tunnel: no local responder after \(BonjourBrowser.elapsedMS(from: started, clock: clock), privacy: .public)ms (\(challenged.count, privacy: .public) challenged)")
+                break
+            }
             // Break (don't busy-spin) if the task is cancelled mid-wait.
-            do { try await Task.sleep(for: .milliseconds(150)) } catch { break }
+            do {
+                try await Task.sleep(for: Self.pollInterval)
+            } catch {
+                resolveLog.notice("resolve → tunnel: cancelled after \(BonjourBrowser.elapsedMS(from: started, clock: clock), privacy: .public)ms")
+                break
+            }
         }
         return auth.serverURL
     }

--- a/ios/MajorTom/Core/Services/RelayURLResolver.swift
+++ b/ios/MajorTom/Core/Services/RelayURLResolver.swift
@@ -63,6 +63,19 @@ final class RelayURLResolver {
     /// mutate it.
     @ObservationIgnored private var verifiedLAN: VerifiedLANHost?
 
+    /// The resolve pass currently in flight, if any.
+    ///
+    /// `resolvePreferringLAN` now has two independent triggers — the
+    /// `auth.isPaired` connect path and the scenePhase `.active` re-resolve —
+    /// and on a cold launch of an already-paired device both fire within
+    /// milliseconds of each other. Overlapping calls are therefore routine, not
+    /// exotic. Two passes would each issue their own `/identity/challenge`
+    /// round-trip to the same host: correct (nothing writes `verifiedLAN`
+    /// without a signature that verified against the pinned key, and the two
+    /// passes can only agree), but a wasted nonce round-trip per host and a log
+    /// that reads like a double-connect. Joiners await this task instead.
+    @ObservationIgnored private var inFlightResolve: Task<String, Never>?
+
     /// THE single gate for reusing a prior proof. Returns an address only when
     /// every part of the trust context still holds — same pinned key, same
     /// browse session, host still advertised — and drops the entry otherwise, so
@@ -91,7 +104,21 @@ final class RelayURLResolver {
     /// changes in a way the bindings above cannot see from the inside — currently
     /// app backgrounding, after which the device may return on a different
     /// network with an attacker advertising the same `host:port` string.
+    ///
+    /// Pairs with the scenePhase `.active` re-resolve in `MajorTomApp`: dropping
+    /// the proof with no trigger to re-earn it would pin the process to the
+    /// tunnel for the rest of its life, since `bestRelayURL` is synchronous and
+    /// cannot challenge.
     func invalidateVerifiedLANHost() {
+        // Cancel any pass still in flight, not just the cached entry. A resolve
+        // that started before backgrounding captured the pre-`stop()`
+        // `BonjourBrowser.generation`, so whatever it proves is already unusable
+        // by the time it lands — and the foreground re-resolve would *join* it
+        // (see `inFlightResolve`) and inherit that dead answer instead of
+        // opening a fresh pass against the new browse session. Cancellation is
+        // fail-closed: `performResolve` breaks out and returns the tunnel.
+        inFlightResolve?.cancel()
+        inFlightResolve = nil
         guard verifiedLAN != nil else { return }
         resolveLog.info("cached LAN host invalidated (app backgrounded)")
         verifiedLAN = nil
@@ -200,7 +227,26 @@ final class RelayURLResolver {
     ///
     /// A challenge already in flight is allowed to finish (it is the payoff),
     /// so the absolute worst case is `maxWait` + one challenge timeout.
+    ///
+    /// **Idempotent under concurrency.** Overlapping callers share a single pass
+    /// (`inFlightResolve`) rather than each opening their own — see that
+    /// property for why overlap is now the normal cold-launch shape.
     func resolvePreferringLAN() async -> String {
+        if let inFlight = inFlightResolve {
+            resolveLog.info("resolve joined a pass already in flight")
+            return await inFlight.value
+        }
+        let pass = Task { await self.performResolve() }
+        inFlightResolve = pass
+        let result = await pass.value
+        // Only the caller that opened the pass clears it, and only if it is
+        // still the registered one — `invalidateVerifiedLANHost` may have
+        // cancelled and replaced/cleared it while we were awaiting.
+        if inFlightResolve == pass { inFlightResolve = nil }
+        return result
+    }
+
+    private func performResolve() async -> String {
         let clock = ContinuousClock()
         let started = clock.now
 
@@ -263,6 +309,22 @@ final class RelayURLResolver {
                 let verified = await RelayIdentityVerifier.challenge(baseURL: base, pinnedPublicKeyBase64url: pinned)
                 resolveLog.info("challenge \(service.address, privacy: .public) → \(verified ? "VERIFIED" : "rejected", privacy: .public) in \(BonjourBrowser.elapsedMS(from: challengeStart, clock: clock), privacy: .public)ms")
                 if verified {
+                    // Cancellation is cooperative, so a challenge that was
+                    // already in flight when `invalidateVerifiedLANHost()` ran
+                    // resumes *after* it — and would otherwise write a cache
+                    // entry over an invalidation that already happened, and hand
+                    // a LAN address to a caller (or a joiner) that must fail
+                    // closed. The signature itself was genuine; the trust context
+                    // it was earned in is the thing that just went away.
+                    //
+                    // The `browserGeneration` binding would also catch this the
+                    // next time the browser restarts, but that is a downstream
+                    // guard for a *later* read. This is the one that keeps the
+                    // return value of this call honest.
+                    if Task.isCancelled {
+                        resolveLog.notice("resolve → tunnel: \(service.address, privacy: .public) verified but the pass was cancelled mid-challenge")
+                        return auth.serverURL
+                    }
                     verifiedLAN = VerifiedLANHost(
                         address: service.address,
                         pinnedKey: pinned,

--- a/ios/MajorTom/Core/Services/RelayURLResolver.swift
+++ b/ios/MajorTom/Core/Services/RelayURLResolver.swift
@@ -33,10 +33,69 @@ final class RelayURLResolver {
     private let auth: AuthService
     private let browser: BonjourBrowser
 
-    /// A LAN address proven THIS SESSION to belong to the pinned relay identity
-    /// via challenge-response. Only this — never an unverified mDNS responder —
-    /// is handed to the cookie-bearing connections.
-    private var verifiedLANAddress: String?
+    /// A LAN address proven to belong to the pinned relay identity via
+    /// challenge-response, **bound to the trust context it was proven in**.
+    /// Only this — never an unverified mDNS responder — is handed to the
+    /// cookie-bearing connections.
+    ///
+    /// The address alone is not a safe cache key: it is a forgeable string
+    /// (`192.168.1.x:9090`, or a `.local` hostname an attacker can adopt), so a
+    /// bare address cache would let a hostile responder on a *different* network
+    /// inherit a proof issued on the network we verified at home. The bindings
+    /// below are what make that impossible.
+    private struct VerifiedLANHost {
+        /// The `host:port` that signed our nonce.
+        let address: String
+        /// The pinned relay public key the signature was verified against.
+        /// Unpair/re-pair rewrites `relay_public_key`, so a proof issued under
+        /// relay A's key can never be reused for relay B — no caller has to
+        /// remember to invalidate.
+        let pinnedKey: String
+        /// `BonjourBrowser.generation` at verification time. Any `stop()`/
+        /// `start()` cycle — background→foreground being the important one, since
+        /// that's the boundary across which the device can wake on a completely
+        /// different LAN — bumps it and voids the proof.
+        let browserGeneration: Int
+    }
+
+    /// Deliberately not observed: this is a security cache read from
+    /// `bestRelayURL` on the connect path, not view state, and self-healing reads
+    /// mutate it.
+    @ObservationIgnored private var verifiedLAN: VerifiedLANHost?
+
+    /// THE single gate for reusing a prior proof. Returns an address only when
+    /// every part of the trust context still holds — same pinned key, same
+    /// browse session, host still advertised — and drops the entry otherwise, so
+    /// both callers fail closed to the tunnel. No path in this type returns a LAN
+    /// address without either passing through here or completing a fresh
+    /// challenge against the currently-pinned key.
+    private var reusableVerifiedLANAddress: String? {
+        guard let cached = verifiedLAN else { return nil }
+        guard let pinned = KeychainService.load(.relayPublicKey), pinned == cached.pinnedKey else {
+            resolveLog.notice("cached LAN host dropped: pinned relay identity changed")
+            verifiedLAN = nil
+            return nil
+        }
+        guard cached.browserGeneration == browser.generation else {
+            resolveLog.notice("cached LAN host dropped: discovery restarted (possible network change)")
+            verifiedLAN = nil
+            return nil
+        }
+        // Not a trust failure — a service can flap — so keep the entry and let a
+        // later browse result make it usable again.
+        guard browser.services.contains(where: { $0.address == cached.address }) else { return nil }
+        return cached.address
+    }
+
+    /// Drop any cached LAN proof. Called from the app when the trust context
+    /// changes in a way the bindings above cannot see from the inside — currently
+    /// app backgrounding, after which the device may return on a different
+    /// network with an attacker advertising the same `host:port` string.
+    func invalidateVerifiedLANHost() {
+        guard verifiedLAN != nil else { return }
+        resolveLog.info("cached LAN host invalidated (app backgrounded)")
+        verifiedLAN = nil
+    }
 
     init(auth: AuthService, browser: BonjourBrowser) {
         self.auth = auth
@@ -49,27 +108,38 @@ final class RelayURLResolver {
     }
 
     /// Best relay base URL for a *synchronous* caller (e.g. the terminal
-    /// building its `/shell` URL): a LAN host we already verified this session
-    /// AND that is still being advertised, else the frozen `auth.serverURL`
-    /// (tunnel). Never returns an unverified host — verification happens only in
-    /// the async `resolvePreferringLAN`. Returned in the same raw `host[:port]`
-    /// form as `auth.serverURL`, so callers keep normalizing via `AuthService`.
+    /// building its `/shell` URL): a LAN host whose proof is still bound to the
+    /// current trust context (see `reusableVerifiedLANAddress`), else the frozen
+    /// `auth.serverURL` (tunnel). Never returns an unverified host —
+    /// verification happens only in the async `resolvePreferringLAN`. Returned in
+    /// the same raw `host[:port]` form as `auth.serverURL`, so callers keep
+    /// normalizing via `AuthService`.
     var bestRelayURL: String {
-        if let verified = verifiedLANAddress,
-           browser.services.contains(where: { $0.address == verified }) {
-            return verified
-        }
-        return auth.serverURL
+        reusableVerifiedLANAddress ?? auth.serverURL
     }
 
-    /// How long we wait for Bonjour to show *any* sign of a local responder
-    /// before giving up on the LAN. Sized for the cellular / remote case: with
-    /// nothing advertising `_majortom._tcp` this is the entire cost added to
-    /// connect (down from the old flat 2s window). Deliberately NOT gated on
-    /// `NetworkPathMonitor.reachability` — that starts at `.offline` until
-    /// `NWPathMonitor` delivers its first update, so a launch-time check would
-    /// skip the LAN exactly when we most want it.
-    private static let discoveryGrace: Duration = .seconds(1)
+    /// How long Bonjour gets to show *any* sign of a local responder before we
+    /// give up on the LAN — measured from the instant the **browser** started,
+    /// not from the instant this resolve started (`BonjourBrowser.startedAt`).
+    ///
+    /// Anchoring at resolve start is what makes the window a straight tax: the
+    /// browser and the resolve both begin within milliseconds of each other on a
+    /// cold launch of an already-paired device, so the whole discover → TCP
+    /// handshake → `.ready` pipeline has to fit inside it. Anchoring at browser
+    /// start means the pre-warm actually counts — by sign-in time the browser has
+    /// usually been running for seconds, so warm services are challenged
+    /// immediately and a cellular device pays only `discoveryGraceFloor`.
+    ///
+    /// Deliberately NOT gated on `NetworkPathMonitor.reachability` — that starts
+    /// at `.offline` until `NWPathMonitor` delivers its first update, so a
+    /// launch-time check would skip the LAN exactly when we most want it.
+    private static let discoveryGrace: Duration = .seconds(2)
+
+    /// Minimum wait measured from *this* resolve's start, so a resolve that
+    /// begins while the browser is still coming up isn't cut off before the first
+    /// poll. Also the entire LAN cost for a device whose browser has been warm
+    /// and empty for longer than `discoveryGrace` (cellular / remote).
+    private static let discoveryGraceFloor: Duration = .milliseconds(250)
 
     /// Hard ceiling on the LAN window. Only reachable when a responder is
     /// actually mid-resolve or mid-challenge — the grace window ends the wait
@@ -89,21 +159,44 @@ final class RelayURLResolver {
     /// against a relay that predates `/identity`) we never trust a LAN host and
     /// always return the tunnel. Idempotently starts discovery.
     ///
-    /// **Timing policy (#183).** The old flat 2s window routinely expired before
-    /// `BonjourBrowser` had finished its discover → TCP-handshake → `.ready`
-    /// pipeline, so the LAN never won on Wi-Fi. It is replaced by a window that
-    /// is *short when nothing is there* and *patient when something is*:
+    /// **Timing policy (#183).** The old flat 2s window was measured from the
+    /// resolve's own start, and the browser started at that same instant, so the
+    /// whole discover → TCP-handshake → `.ready` pipeline had to fit inside it.
+    /// The window is now *anchored at browser start* and *short when nothing is
+    /// there, patient when something is*:
     ///
-    /// - `discoveryGrace` (1s): if nothing local has answered by then — nothing
-    ///   discovered, nothing mid-resolve — return the tunnel. Cellular and
-    ///   remote users pay 1s instead of the old 2s.
+    /// - `discoveryGrace` (2s **from `browser.startedAt`**): if nothing local has
+    ///   answered by then — nothing discovered, nothing mid-resolve — return the
+    ///   tunnel. Because the browser is started when the UI scene appears, this
+    ///   is mostly spent *before* a resolve even begins.
+    /// - `discoveryGraceFloor` (250ms from this resolve's start) keeps a resolve
+    ///   that fires while the browser is still coming up from being cut off, and
+    ///   is the whole LAN cost once the browser has been warm and empty.
     /// - Extend past the grace window only while `browser.pendingResolveCount`
     ///   is non-zero, i.e. a discovered responder is genuinely mid-handshake.
-    ///   `BonjourBrowser` caps each handshake at 3s, so a black-holed advertiser
-    ///   cannot hold the window open indefinitely.
-    /// - `maxWait` (4s) is a hard ceiling: no *new* challenge starts after it,
-    ///   which also bounds the old worst case where up to 16 discovered hosts
-    ///   could each burn a 2s challenge timeout serially inside one pass.
+    ///   `BonjourBrowser` caps each resolve at 3s (TCP timeout + wall-clock
+    ///   watchdog), so a black-holed or path-less advertiser cannot hold the
+    ///   window open indefinitely.
+    /// - `maxWait` (4s from this resolve's start) is a hard ceiling: no *new*
+    ///   challenge starts after it, which also bounds the old worst case where up
+    ///   to 16 discovered hosts could each burn a 2s challenge timeout serially
+    ///   inside one pass.
+    ///
+    /// Resulting cost, versus `main`'s flat 2s-from-resolve-start window:
+    ///
+    /// | Case | `main` | now |
+    /// |---|---|---|
+    /// | cold launch already paired, relay on LAN | 2s of browse time, all of it inside the connect wait | ~2s of browse time starting at scene appear, ~1.95s of connect wait |
+    /// | fresh sign-in (browser warm for seconds) | 2s from a cold browser | warm services challenged on the first pass — no wait at all |
+    /// | any later resolve in a warm process | 2s | ~250ms when nothing is on the LAN |
+    /// | cellular, cold launch | 2s | ~1.95s — unchanged, because a cold browser is indistinguishable from a slow one without a transport signal |
+    /// | cellular, after warm-up | 2s | ~250ms |
+    ///
+    /// Cutting the cold-launch cellular case needs a reachability gate, which is
+    /// *not* the naive "skip the LAN when `.cellular`" that was rejected above
+    /// (`NetworkPathMonitor` starts at `.offline`); it has to be an early *break*
+    /// once reachability has positively reported `.cellular`. Deferred until the
+    /// on-device instrumentation says what the real numbers are.
     ///
     /// A challenge already in flight is allowed to finish (it is the payoff),
     /// so the absolute worst case is `maxWait` + one challenge timeout.
@@ -111,13 +204,13 @@ final class RelayURLResolver {
         let clock = ContinuousClock()
         let started = clock.now
 
-        // Re-use a still-advertised verified host without re-challenging.
-        if let verified = verifiedLANAddress,
-           browser.services.contains(where: { $0.address == verified }) {
-            resolveLog.info("resolve → LAN \(verified, privacy: .public) (cached, verified this session)")
-            return verified
+        // Re-use a proof that is still bound to the current pinned key + browse
+        // session, without re-challenging.
+        if let cached = reusableVerifiedLANAddress {
+            resolveLog.info("resolve → LAN \(cached, privacy: .public) (cached, still bound to the pinned identity)")
+            return cached
         }
-        verifiedLANAddress = nil
+        verifiedLAN = nil
 
         guard let pinned = KeychainService.load(.relayPublicKey),
               let pinnedRaw = RelayIdentityVerifier.data(fromBase64url: pinned) else {
@@ -129,8 +222,23 @@ final class RelayURLResolver {
         browser.start()
         resolveLog.info("resolve start: \(self.browser.services.count, privacy: .public) warm, \(self.browser.pendingResolveCount, privacy: .public) resolving, pinned fp \(BonjourBrowser.shortFingerprint(expectedFingerprint), privacy: .public)")
 
-        let graceDeadline = started.advanced(by: Self.discoveryGrace)
+        // Capture the browse session BEFORE any challenge. If discovery restarts
+        // mid-loop (a `.failed` browser tears itself down and rebuilds), a proof
+        // earned against a service discovered in the old session must not be
+        // cached under the new one — binding the stale generation makes the entry
+        // immediately unusable, i.e. fail closed.
+        let browseGeneration = browser.generation
+
         let ceiling = started.advanced(by: Self.maxWait)
+        // Anchored at browser start (see `discoveryGrace`), floored relative to
+        // this resolve, and clamped under the ceiling so the two can never
+        // invert.
+        let browserStart = browser.startedAt ?? started
+        let graceDeadline = min(
+            max(browserStart.advanced(by: Self.discoveryGrace),
+                started.advanced(by: Self.discoveryGraceFloor)),
+            ceiling
+        )
         var challenged: Set<String> = []
 
         while true {
@@ -155,7 +263,11 @@ final class RelayURLResolver {
                 let verified = await RelayIdentityVerifier.challenge(baseURL: base, pinnedPublicKeyBase64url: pinned)
                 resolveLog.info("challenge \(service.address, privacy: .public) → \(verified ? "VERIFIED" : "rejected", privacy: .public) in \(BonjourBrowser.elapsedMS(from: challengeStart, clock: clock), privacy: .public)ms")
                 if verified {
-                    verifiedLANAddress = service.address
+                    verifiedLAN = VerifiedLANHost(
+                        address: service.address,
+                        pinnedKey: pinned,
+                        browserGeneration: browseGeneration
+                    )
                     resolveLog.info("resolve → LAN \(service.address, privacy: .public) in \(BonjourBrowser.elapsedMS(from: started, clock: clock), privacy: .public)ms")
                     return service.address
                 }

--- a/ios/MajorTom/Features/Pairing/ViewModels/PairingViewModel.swift
+++ b/ios/MajorTom/Features/Pairing/ViewModels/PairingViewModel.swift
@@ -93,14 +93,13 @@ final class PairingViewModel {
     /// view appear. The pairing UI no longer surfaces the discovered
     /// services, but they still drive `currentRelayURL` so an on-LAN
     /// relay is preferred over the tunnel.
+    ///
+    /// There is no matching `stop` — the browser is the app-level one and
+    /// `MajorTomApp`'s scenePhase handler owns its teardown. Stopping it when
+    /// this view disappears would wipe the discovery cache at the exact moment
+    /// pairing succeeds and `RelayURLResolver` needs it (#183).
     func startDiscovery() {
         browser.start()
-    }
-
-    /// Stop mDNS discovery and tear down active resolvers. Called on
-    /// view disappear.
-    func stopDiscovery() {
-        browser.stop()
     }
 
     /// Fetch auth methods from the relay to adapt the login UI.

--- a/ios/MajorTom/Features/Pairing/ViewModels/PairingViewModel.swift
+++ b/ios/MajorTom/Features/Pairing/ViewModels/PairingViewModel.swift
@@ -3,10 +3,11 @@ import Foundation
 // MARK: - Server Presets
 
 /// Relay URL targets picked from the device's current reachability.
-/// LAN deliberately falls through to the public tunnel — Bonjour
-/// discovery (see `currentRelayURL`) takes precedence when an mDNS
-/// broadcast is visible, so the tunnel is only used as a safety net
-/// when Bonjour can't see the relay (mDNS blocked, Mac asleep).
+/// LAN deliberately falls through to the public tunnel: pre-pairing there is no
+/// pinned relay identity to challenge a discovered host against, so an mDNS
+/// responder can never be trusted here. LAN preference is applied *after*
+/// pairing, by `RelayURLResolver`, where the Ed25519 challenge-response gate
+/// exists. See `currentRelayURL`.
 enum ServerPreset {
     case cloudflare
     case tailscale
@@ -46,15 +47,20 @@ final class PairingViewModel {
     private let browser: BonjourBrowser
     private let googleOAuth: GoogleOAuthService
 
+    /// `browser` is **required** and must be the app-level `BonjourBrowser`.
+    /// A private instance would warm a cache `RelayURLResolver` never reads,
+    /// silently reintroducing #183 with no compile error — and, since this type
+    /// no longer has a `stopDiscovery`, would browse with no teardown path at
+    /// all. Making it non-optional makes that mistake unrepresentable.
     init(
         auth: AuthService,
+        browser: BonjourBrowser,
         network: NetworkPathMonitor? = nil,
-        browser: BonjourBrowser? = nil,
         googleOAuth: GoogleOAuthService? = nil
     ) {
         self.auth = auth
+        self.browser = browser
         self.network = network ?? NetworkPathMonitor()
-        self.browser = browser ?? BonjourBrowser()
         self.googleOAuth = googleOAuth ?? GoogleOAuthService()
     }
 
@@ -75,29 +81,37 @@ final class PairingViewModel {
         (authMethods?.google ?? false) && (googleIOSClientID?.isEmpty == false)
     }
 
-    /// Resolve the relay URL at call-time:
-    /// 1. First Bonjour-discovered service if any (lowest latency on LAN).
-    /// 2. Reachability-driven preset (Tailscale on VPN, tunnel otherwise).
-    /// 3. Tunnel hostname as a final safety net so signin never has nothing to hit.
+    /// Resolve the relay URL for the *pre-pairing* flow:
+    /// 1. Reachability-driven preset (Tailscale on VPN, tunnel otherwise).
+    /// 2. Tunnel hostname as a final safety net so signin never has nothing to hit.
+    ///
+    /// SECURITY: deliberately **not** Bonjour-derived. Before pairing there is no
+    /// pinned relay identity, so `RelayIdentityVerifier` cannot challenge a
+    /// discovered host and any LAN peer advertising `_majortom._tcp` could be the
+    /// first responder — it would serve `/auth/methods`, hand back *its own*
+    /// Google `iosClientId`, and receive the resulting ID token (which
+    /// `signInWithGoogle` POSTs to this same host after freezing it into
+    /// `auth.serverURL`). Sharing the app-level browser (#183) keeps
+    /// `browser.services` warm by the time this view runs, which is exactly what
+    /// made that first-responder shortcut reachable. LAN preference belongs after
+    /// pairing, in `RelayURLResolver`, where the challenge-response gate exists.
     var currentRelayURL: String {
-        if let discovered = browser.services.first {
-            return discovered.address
-        }
         if let preset = ServerPreset(reachability: network.reachability) {
             return preset.address
         }
         return Secrets.tunnelURL
     }
 
-    /// Start mDNS discovery. Idempotent — safe to call repeatedly on
-    /// view appear. The pairing UI no longer surfaces the discovered
-    /// services, but they still drive `currentRelayURL` so an on-LAN
-    /// relay is preferred over the tunnel.
+    /// Start mDNS discovery. Idempotent — safe to call repeatedly on view appear.
+    /// Nothing in the pairing flow *consumes* discovery (see `currentRelayURL`);
+    /// this exists purely to guarantee the app-level browser is warm before
+    /// sign-in flips `isPaired`, since that transition is what fires the first
+    /// `RelayURLResolver.resolvePreferringLAN` (#183).
     ///
     /// There is no matching `stop` — the browser is the app-level one and
     /// `MajorTomApp`'s scenePhase handler owns its teardown. Stopping it when
     /// this view disappears would wipe the discovery cache at the exact moment
-    /// pairing succeeds and `RelayURLResolver` needs it (#183).
+    /// pairing succeeds and `RelayURLResolver` needs it.
     func startDiscovery() {
         browser.start()
     }

--- a/ios/MajorTom/Features/Pairing/Views/PairingView.swift
+++ b/ios/MajorTom/Features/Pairing/Views/PairingView.swift
@@ -62,12 +62,15 @@ struct PairingView: View {
         .background(MajorTomTheme.Colors.background)
         .animation(.easeInOut(duration: 0.2), value: viewModel.authState)
         .task {
-            // Bonjour browses silently so LAN-resolved URLs are preferred
-            // over the tunnel when the relay is on the same network. Idempotent
-            // — the app already started this browser at launch. Deliberately
-            // NOT stopped on disappear: this view disappears the moment pairing
-            // succeeds, which is precisely when `resolvePreferringLAN` needs the
-            // warm cache (#183). The app's scenePhase handler owns teardown.
+            // Warm the app-level browser so `resolvePreferringLAN` has a
+            // populated cache the instant sign-in flips `isPaired` (#183).
+            // Idempotent — the app already started it when the scene appeared.
+            // Discovery does NOT influence which host this view talks to (see
+            // `PairingViewModel.currentRelayURL`): pre-pairing there is no pinned
+            // identity to challenge a responder against. Deliberately NOT stopped
+            // on disappear — this view disappears the moment pairing succeeds,
+            // which is precisely when the resolver needs the warm cache. The
+            // app's scenePhase handler owns teardown.
             viewModel.startDiscovery()
             await viewModel.fetchAuthMethods()
         }

--- a/ios/MajorTom/Features/Pairing/Views/PairingView.swift
+++ b/ios/MajorTom/Features/Pairing/Views/PairingView.swift
@@ -3,8 +3,12 @@ import SwiftUI
 struct PairingView: View {
     @State private var viewModel: PairingViewModel
 
-    init(auth: AuthService) {
-        _viewModel = State(initialValue: PairingViewModel(auth: auth))
+    /// `browser` is the app-level `BonjourBrowser` (see `MajorTomApp`). Sharing
+    /// it means the cache warmed while the user signs in is the same one
+    /// `RelayURLResolver` reads the instant pairing completes (#183); its
+    /// lifecycle is owned by the app's scenePhase handler, not by this view.
+    init(auth: AuthService, browser: BonjourBrowser) {
+        _viewModel = State(initialValue: PairingViewModel(auth: auth, browser: browser))
     }
 
     var body: some View {
@@ -59,12 +63,13 @@ struct PairingView: View {
         .animation(.easeInOut(duration: 0.2), value: viewModel.authState)
         .task {
             // Bonjour browses silently so LAN-resolved URLs are preferred
-            // over the tunnel when the relay is on the same network.
+            // over the tunnel when the relay is on the same network. Idempotent
+            // — the app already started this browser at launch. Deliberately
+            // NOT stopped on disappear: this view disappears the moment pairing
+            // succeeds, which is precisely when `resolvePreferringLAN` needs the
+            // warm cache (#183). The app's scenePhase handler owns teardown.
             viewModel.startDiscovery()
             await viewModel.fetchAuthMethods()
-        }
-        .onDisappear {
-            viewModel.stopDiscovery()
         }
     }
 
@@ -130,5 +135,5 @@ struct PairingView: View {
 }
 
 #Preview {
-    PairingView(auth: AuthService())
+    PairingView(auth: AuthService(), browser: BonjourBrowser())
 }


### PR DESCRIPTION
## Root cause

`RelayURLResolver.resolvePreferringLAN` called `browser.start()` and *then* began a flat 2s wait — but `BonjourBrowser.startResolve` only appends a service to `services` after opening an `NWConnection` and reaching `.ready`, i.e. after a full TCP handshake to `:9090`. On a fresh sign-in both the browser start and the resolve fire off the same `isPaired` transition, so the whole discover → resolve → `.ready` → append pipeline had to complete inside a window that started at the same instant. It usually didn't: the resolver timed out, returned the tunnel, and nothing re-resolved afterwards. That matches the field evidence in #183 — **zero** `POST /identity/challenge` requests ever reached the relay.

Confirmed *not* the cause (per the issue): the relay advertises correctly with a matching TXT `fp`, and the key is pinned before `.paired` flips, so the pin/connect ordering is fine.

---

## What changed

### 1. Discovery lifecycle

- The app-level `BonjourBrowser` is started from the root view's `.onAppear` — **not** from `MajorTomApp.init()`. `init()` runs on scene-less launches too: `FleetStatusIntent`, `SessionSummaryIntent` and `ToggleGodModeIntent` all ship `openAppWhenRun = false` (Siri/Shortcuts launches the process in the background to `perform()`), and `WatchConnectivityService`'s `sendMessage`/`transferUserInfo` wakes the iOS counterpart. In those launches no scene connects, `.onChange(of: scenePhase)` is never installed, and `bonjour.stop()` never runs — so `init()` would browse mDNS and open `:9090` TCP resolves fully off-screen, where the Local Network permission can't even be prompted for. `.onAppear` runs only when a scene is connected, which is exactly the gate we want.
- Racing the `isPaired` handler is now harmless: `resolvePreferringLAN` starts the browser itself if needed, and its grace window is measured from `BonjourBrowser.startedAt` rather than from its own start (see §2). Whichever fires first, the LAN gets a full window.
- The scenePhase `.active` restart is no longer gated on `auth.isPaired` — an *unpaired* device is precisely the one that needs a warm cache, because sign-in completing is what triggers the first resolve.
- `PairingView` takes the app-level browser instead of constructing a second one, and no longer stops it on disappear (that view disappears the instant pairing succeeds, which is exactly when the resolver needs the cache). `PairingViewModel.stopDiscovery()` is removed; teardown belongs to the scenePhase handler.
- **`.failed` recovery.** A failed `NWBrowser` used to leave `browser` non-nil while flipping `isBrowsing = false`, so `start()`'s `guard browser == nil` became a permanent no-op — discovery stayed dead for the whole process and every resolve silently rode the tunnel (#183, reproduced permanently for that launch). Since this PR makes idempotent `start()` the *sole* recovery mechanism, `.failed` now tears the browser down completely so a later `start()` can build a fresh one.

### 2. Timing policy (the numbers, and why)

The grace window is now anchored at **browser start**, not at resolve start.

| Knob | Value | Rationale |
|---|---|---|
| `discoveryGrace` | **2s from `BonjourBrowser.startedAt`** | Budget for *any* sign of a local responder. Anchoring at resolve start made the window a straight tax: on a cold launch of an already-paired device the browser and the resolve begin within milliseconds of each other, so the entire discover → handshake → `.ready` pipeline had to fit inside it. Anchoring at browser start is what makes the pre-warm actually count. |
| `discoveryGraceFloor` | **250ms from resolve start** | Keeps a resolve that fires while the browser is still coming up from being cut off before the first poll, and is the whole LAN cost once the browser has been warm and empty. |
| extension condition | `browser.pendingResolveCount > 0` | Hold the window open past the grace period **only** while a discovered responder is genuinely mid-handshake. No local responder → count stays 0 → immediate fallthrough. |
| `maxWait` (ceiling) | **4s from resolve start** | Hard stop, also clamps the grace deadline so the two can never invert. Only reachable when something local is actually resolving/being challenged. |
| resolve deadline | **3s** | Applied as `NWProtocolTCP.Options.connectionTimeout` **and** as a wall-clock watchdog — see §3. |
| `pollInterval` | 150ms | Unchanged. |

Resulting cost, versus `main`'s flat 2s-from-resolve-start window:

| Case | `main` | this PR |
|---|---|---|
| cold launch already paired, relay on LAN | 2s of browse time, all inside the connect wait | ~2s of browse time starting at scene appear, ~1.95s of connect wait |
| fresh sign-in (browser warm for seconds) | 2s from a cold browser | warm services challenged on the first pass — **no wait at all** |
| any later resolve in a warm process | 2s | ~250ms when nothing is on the LAN |
| cellular, cold launch | 2s | ~1.95s — **unchanged**, see below |
| cellular, after warm-up | 2s | ~250ms |

**Correction to an earlier revision of this PR.** A previous commit used a flat 1s grace measured from resolve start. That was a regression risk, not a win: on a cold launch of an already-paired device the pre-warm bought only the ~50ms of SwiftUI body evaluation + `requestPermission()`, while the budget was halved — so a browse delivery landing anywhere in **(1.05s, 2.05s)** (busy Wi-Fi, mDNS retry) would fall back to the tunnel where `main` would have caught it. That is exactly the band #183 is unresolved about. The `pendingResolveCount` extension didn't help, because it only engages once a browse result has *already* arrived.

**Not fixed here:** cold-launch on cellular still pays ~1.95s, because a cold browser is indistinguishable from a slow one without a transport signal. The naive "skip the LAN when `NetworkPathMonitor.reachability == .cellular`" remains rejected — reachability starts at `.offline` until `NWPathMonitor` delivers its first update. The safe shape is an early *break* once reachability has **positively** reported `.cellular`; deferred to #196 until the instrumentation below gives real numbers.

### 3. Resolver bounds

`connectionTimeout` bounds the TCP handshake, but **not** `.waiting` and **not** the mDNS/DNS resolution phase of a `.service` endpoint. An `NWConnection` with no viable path parks in `.waiting` indefinitely — easy to hit, since `prohibitedInterfaceTypes = [.cellular]` means dropping Wi-Fi mid-resolve leaves no path at all. `default: break` never cleared it, browse-result eviction couldn't fire (no result change), so `resolvers` kept the entry, `pendingResolveCount` stayed at 1, the grace break never fired, and the *next* connect stalled the full 4s ceiling — 4× the cost, in exactly the cellular case this PR optimises.

Two fixes:
- **A per-resolver wall-clock watchdog** at the same 3s deadline. Chosen over cancelling on `.waiting` so a transient `ECONNREFUSED` can still recover, while the slot is still guaranteed to be freed. `.waiting` is logged.
- **`.failed` resolvers are cancelled before being dropped.** The state handler closure captures `conn`, and `NWConnection` retains its `stateUpdateHandler` until `.cancelled` — so dropping the dictionary reference left the connection and handler alive forever. With a relay asleep behind a Bonjour sleep proxy (still advertised, SYNs unanswered) that was one leaked `NWConnection` per mDNS TTL refresh.

Both browser handlers also now guard on browser identity. `browseResultsChangedHandler` hops through a `Task`; one queued before a `stop()` would call `startResolve` while `browser == nil`, registering a resolver that browse-result eviction can never reach — and whose name the next browser then skips (`resolvers[name] != nil`), so the service never re-resolves and every connect falls back to the tunnel for the rest of the session.

### 4. Instrumentation

Two `os_log` categories under subsystem `com.majortom.app`:

- **`discovery`** (`BonjourBrowser`): `browser starting` / `ready` / `waiting: …` / `failed: …`, browse-result counts (advertised / resolved / resolving), `resolve start <name> (fp <prefix>)`, `resolve ready <name> → <addr> in <N>ms`, `resolve waiting <name> …`, `resolve failed <name> after <N>ms: <error>`, `resolve watchdog <name>: cancelling after 3s`, `browser stopping (…)`.
- **`resolve`** (`RelayURLResolver`): `resolve start: <n> warm, <n> resolving, pinned fp <prefix>`, `skip <addr>: advertised fp <prefix> ≠ pinned`, `challenge <addr> → VERIFIED|rejected in <N>ms`, `cached LAN host dropped: …` / `invalidated (app backgrounded)`, and exactly one terminal line naming the winning branch — `resolve → LAN <addr> in <N>ms` or `resolve → tunnel: <reason> after <N>ms`.

**Nothing sensitive is logged**: hostnames, `host:port` addresses, elapsed ms, and 8-char prefixes of the *public* mDNS fingerprint only — never the pinned key, a nonce, a signature, or the session cookie. `browser waiting: …` is included deliberately: it's the tell-tale for a denied/undetermined Local Network permission, which would look identical to a timing failure from the outside.

### 5. Background→foreground re-resolve (round 2)

The `.background` invalidation in §Security below shipped, in the first fix commit, **without a trigger to re-earn the proof it dropped** — a self-inflicted regression caught in round-2 verification.

`resolvePreferringLAN` had exactly one call site: the `auth.isPaired` transition. That does not fire on foreground, and `bestRelayURL` is synchronous so it cannot challenge. So after the first background round-trip `verifiedLAN` stayed nil for the rest of the process:

> Cold launch at home, LAN verified, terminal on `192.168.1.x:9090`. Press home. Return 10 seconds later on the same Wi-Fi. Open a new terminal tab → `wss://<tunnel>/shell/…`, and so does every tab after it.

On a phone that round-trip happens within minutes of every launch, so **#183's headline symptom returned for the dominant usage pattern** — this PR would have fixed its own bug only for the first foreground session. It is precisely the failure mode the §Security residual names as the reason not to invalidate on `NWPath` change ("aggressive invalidation with no re-resolve trigger degrades to permanent-tunnel"), shipped for the `.background` case.

| Change | Why |
|---|---|
| `MajorTomApp` re-resolves in the scenePhase `.active` branch when paired, after `bonjour.start()` | The missing half of the pair. Ordered after `start()` so the new browse generation is already in place. **Fire-and-forget** — nothing awaits it, so it cannot stall the UI or the connect path; a tab opened before it lands gets the tunnel for that one connection and the next gets the LAN. Graceful, not permanent. |
| `resolvePreferringLAN` is single-flight (`inFlightResolve`) | Cold launch now fires both triggers within milliseconds, so overlap is the normal shape, not exotic. Joiners share one pass instead of each issuing their own `/identity/challenge` to the same host. Makes the idempotency claim real rather than assumed — and makes adding further triggers (#196) cheap. |
| `invalidateVerifiedLANHost` cancels **and clears** the in-flight pass | A pass started before backgrounding captured the pre-`stop()` browser generation, so anything it proves is already unusable. Without clearing it, the foreground re-resolve would *join* that pass and inherit the dead answer instead of opening a fresh one against the new browse session. |
| `performResolve` re-checks `Task.isCancelled` before caching or returning a verified host | Cancellation is cooperative: a challenge already in flight when the invalidation ran resumes *after* it, and would otherwise write a cache entry over an invalidation that already happened. The `browserGeneration` binding catches this on the next read, but that is a downstream guard for a *later* read — this keeps the return value of the call itself honest. |

Fail-closed is preserved on every new exit: cancelled mid-challenge → tunnel; cancelled mid-sleep → tunnel; joiner on a cancelled pass → tunnel. The main WebSocket is deliberately **not** re-pointed on foreground — it keeps its own stored `serverURL` and reconnects there, which is unchanged from `main`. Converging the main socket onto a newly-verified LAN host is fix candidate 3 from #183 and stays in #196.

---

## Security

### The verified-LAN cache is now bound to its trust context

`verifiedLANAddress` was a **session-lifetime cache keyed on a forgeable address string**, never re-validated after the one-time challenge and never cleared. It was textually unchanged from `main`, but per #183 the challenge never fired in the field, so the cached-reuse branch was effectively dead code — **this PR promotes it to the hot path on every terminal connect**, which makes it load-bearing.

Two ways that bites:

- **Cross-network.** Verify relay A at home → cache `192.168.1.42:9090` (or the `.local` hostname — `address(from:)` prefers hostnames) → background (which clears `services` but *not* the cache) → foreground on a café LAN. `auth.isPaired` never changed, so `resolvePreferringLAN` never re-ran. An attacker advertising `_majortom._tcp` at a matching address string got `bestRelayURL` back **with no challenge** → `injectAuthCookie` wrote `mt-session` for that domain → the page dialled the attacker's `/shell` → session cookie harvested and replayable against the real relay.
- **Re-pair.** `AuthService.unpair()` deletes `relay_public_key` but holds no resolver reference, and the resolver is app-lifetime. Unpair → re-pair to relay B in the same foreground session, and the early return jumped clean over the fail-closed `guard let pinned = KeychainService.load(.relayPublicKey)` — so relay B's freshly issued cookie went to relay A, which never signed a nonce under B's key.

Fix — `VerifiedLANHost` records the proof **plus the context it was proven in**:

| Binding | Invalidated by |
|---|---|
| `pinnedKey` — the `relay_public_key` value the signature was verified against | unpair / re-pair to a different relay, **by construction** (no caller has to remember) |
| `browserGeneration` — `BonjourBrowser.generation` at verification time, captured *before* the challenge so a mid-loop discovery restart fails closed | any `stop()`/`start()` cycle, i.e. background→foreground |
| still-advertised check | service disappearing (non-destructive — a flap can recover) |

Plus an explicit `relayResolver.invalidateVerifiedLANHost()` in the `.background` branch alongside `bonjour.stop()`, since backgrounding is the boundary across which the device can wake on a completely different network.

`bestRelayURL` (sync) and `resolvePreferringLAN` (async) both route through one private gate, `reusableVerifiedLANAddress`, so **there is no path that returns a LAN address without either a fresh successful challenge or a cache entry proven to belong to the currently-pinned key.**

### Residual, tracked in #196

Two scenarios, both the same missing piece, both **pre-existing** rather than introduced here:

1. **Foreground network change.** Walking from home Wi-Fi onto another Wi-Fi network changes neither the pinned key nor the browser generation — and `NetworkPathMonitor` collapses `NWPath` into a 4-case `Reachability` where both are `.lan`, so nothing even fires.
2. **Stopped-advertising + hostname takeover.** Same LAN, app foregrounded: the real relay sleeps and stops advertising; an attacker claims the now-free `.local` hostname and advertises `_majortom._tcp`; `browser.services` repopulates with a byte-identical address string; the gate returns it with no re-challenge. Requires physical LAN presence plus the real relay vanishing.

Why not fixed here — two structural blockers, not judgement calls: `NetworkPathMonitor` has no path-identity signal that can see scenario 1 (needs new API plus tuning against how chatty `NWPathMonitor` is), and there is no app-level instance to observe — the only one lives inside `PairingViewModel`, which exists only pre-pairing. Both are new surface on a PR already touching a sensitive path, and the cellular half of #196 explicitly waits on numbers from this PR's instrumentation.

Note that the *original* reason #196 was blocked — "no re-resolve trigger exists" — **is now resolved by round 2 below**, which is what makes the remaining work tractable. Details posted on #196.

### Pairing no longer talks to an unverified mDNS responder

An earlier revision of this PR body claimed that sharing the browser with `PairingView` "does not widen the pre-existing TOFU window, because `fetchAuthMethods()` runs in the same runloop turn as `startDiscovery()`". **That was wrong.** It held on `main`, where `PairingViewModel` constructed its *own* browser (`browser ?? BonjourBrowser()`) started immediately before the fetch, so `services` couldn't have resolved anything yet. Post-change the browser has been running since the scene appeared, so by the time `PairingView.task` runs, `browser.services` may already be populated and `currentRelayURL` returned `browser.services.first` — an unverified responder.

The exposure: an unpaired device on a LAN with a hostile advertiser that resolves faster than the real relay. `/auth/methods` and `/auth/google/client-id` go to the attacker, who returns its own `iosClientId`; the user sees a Google consent screen for the attacker's OAuth client; and `signInWithGoogle` then calls `auth.saveServerURL(target)` and POSTs the resulting ID token **to the attacker's host**.

Fix: `PairingViewModel.currentRelayURL` no longer consults Bonjour at all. It is now reachability-preset → tunnel, which covers `fetchAuthMethods()`, the client-ID fetch, `reachable()` and `signInWithGoogle()` uniformly.

Rationale for going wider than just `fetchAuthMethods`: fixing only the metadata fetch would have left the ID-token POST pointed at the same unverified host — cosmetic. And the LAN shortcut has no compensating benefit here: **pre-pairing there is no pinned identity, so `RelayIdentityVerifier` structurally cannot challenge a discovered host.** LAN preference belongs *after* pairing, in `RelayURLResolver`, where the challenge gate exists.

**Correction — an earlier revision of this section claimed "no practical behaviour loss". That was wrong, and the reasoning behind it was a category error.**

#183 is about `RelayURLResolver.resolvePreferringLAN`'s 2s window. `currentRelayURL` has no window at all — it is a lazily-read computed property, and by the time the user taps "Sign in with Google", seconds after `.task` ran `startDiscovery()`, `browser.services` is populated and the Bonjour branch wins. The "it never won" evidence in `docs/HANDOFF-TERMINAL-LAN-CONNECT.md` also predates the `%en0` fix in PR #177, which is what made resolved addresses usable in the first place. So the branch was not dead code — it was a working LAN path, and removing it removes a real capability.

**What was actually lost.** `Secrets.tunnelURL` (or `Secrets.tailscaleAddress`) is now the only reachable pairing target, and `PairingView` has had no manual-URL field since PR #173. So iOS pairing is impossible in the tunnel-off deployment: fresh device, relay on `bash start.sh --local` (`start.sh:11`), same Wi-Fi, no Tailscale → `/auth/methods` transport-fails → `authMethods = nil` → `isGoogleEnabled == false` → **"Google sign-in not available"**, with a Retry button that can never succeed. `docs/HANDOFF-RELAY-OAUTH-RESTART.md` already described this trap as an mDNS-*miss* problem; it is now unconditional.

**Still the right trade.** The alternative is leaving a path where an unpaired device hands its Google ID token to an unauthenticated mDNS first-responder, which then gets its own key pinned — a full device takeover, silent, requiring only LAN presence. A broken `--local` dev workflow is a much smaller cost than that, and it is recoverable (Tailscale still works — the relay binds `0.0.0.0`, `relay/src/server.ts:59`) while a stolen pairing is not. **Do not revert this.**

Tracked as **#198**, cross-referenced from P2 in `docs/HANDOFF-RELAY-OAUTH-RESTART.md`, which this PR also updates to record that `--local` + iOS pairing is currently unsupported on plain Wi-Fi. Post-pairing LAN preference is unaffected.

### Invariants preserved

| Invariant | Status |
|---|---|
| Cookie only goes to a host that signed a fresh 32-byte nonce verified against the pinned Ed25519 key | **Strengthened.** `RelayIdentityVerifier.challenge` is called with the same arguments; the cached-reuse path is now bound to that same pinned key. |
| Fail-closed to the tunnel on any doubt | **Verified by inspection of every exit:** no pinned key → tunnel; key changed → cache dropped → tunnel; browser restarted → cache dropped → tunnel; ceiling hit → tunnel; grace expired with nothing pending → tunnel; task cancelled → tunnel; fp mismatch → `continue` (never returned). |
| TXT `fp` is a discovery fast-filter, never a trust decision | **Unchanged.** A *mismatched* fp still only skips a round-trip; a *missing* fp is still fully challenged. |
| Verification is not shortened | **Unchanged.** Nonce size, signed-byte construction, challenge HTTP timeout, and the DEBUG self-test are all untouched. |
| `bestRelayURL` (sync, terminal `/shell` path) can't return an unverified host | **Strengthened** — now shares the single gate with the async path. |
| A reused cache entry is *proven under the currently-pinned key and the current browse generation* | **New — and note the precise wording.** This is **not** the stronger claim that the host is still the host that proved it. `reusableVerifiedLANAddress` deliberately keeps the entry when a service stops being advertised (a flap should recover, and `bestRelayURL` is sync so it cannot re-challenge), so a *reappearing* byte-identical address string revives the proof rather than re-earning it. See the residual below. |
| Pre-pairing traffic never reaches an unauthenticated responder | **New.** |

---

## Architecture

`PairingViewModel.browser` is now **non-optional**. The old `browser: BonjourBrowser? = nil` / `?? BonjourBrowser()` let a caller get a private browser — and since `stopDiscovery()` was removed, that fallback instance would have had no teardown path at all, browsing forever while feeding a cache `RelayURLResolver` never reads (reintroducing #183 with no compile error). Making it non-optional makes that unrepresentable.

---

## Build

There is no iOS job in CI (`.github/workflows/ci.yml:169` has the `xcodebuild` step commented out — see #197), so the build claim below is the only gate. Built from an explicit project path into a dedicated derived-data dir, then verified that the shipped product actually contains the change:

```
xcodebuild -project <worktree>/ios/MajorTom.xcodeproj -scheme MajorTom \
  -destination 'generic/platform=iOS Simulator' \
  -derivedDataPath <worktree>/.build-verify build
...
** BUILD SUCCEEDED **
```

Provenance and inclusion, not just the exit code:

- `RelayURLResolver.d` records the compiled source as `<worktree>/ios/MajorTom/Core/Services/RelayURLResolver.swift` — this worktree, not another checkout's copy of `main`.
- The shipped `Major Tom.app/Major Tom.debug.dylib` contains the round-2 log strings: `resolve joined a pass already in flight` and `… verified but the pass was cancelled mid-challenge`.

---

## Deferred (filed)

- **#193** — a hostile advertiser can starve the 16-slot resolver pool (availability only; fails closed to the tunnel).
- **#194** — the `resolveDeadlineSeconds (3s) < maxWait (4s)` invariant is load-bearing but enforced only by prose across two files.
- **#195** — `BonjourBrowser.elapsedMS` / `.shortFingerprint` are misplaced on a discovery service.
- **#196** — LAN proof survives a foreground network change, and a reappearing address string revives a proof rather than re-earning it. The re-resolve trigger half is **done** in round 2; what remains is `NWPath` invalidation (blocked on `NetworkPathMonitor` having no path-identity signal and no app-level instance) plus the one-way still-advertised check. Also carries the cold-launch-cellular grace optimisation.
- **#198** — iOS pairing has no non-mDNS LAN target, so `start.sh --local` cannot pair a fresh device on plain Wi-Fi. Direct consequence of the pairing fix above; P2 in `docs/HANDOFF-RELAY-OAUTH-RESTART.md` is now the only path and does not exist.

---

## Device QA checklist (Sean)

Open **Console.app**, select your iPhone, filter `subsystem:com.majortom.app` (narrow with `category:discovery` or `category:resolve`). Every latency is in ms and each resolve ends with exactly one `resolve → …` line.

**Golden path**

1. **Wi-Fi, relay awake, cold launch already signed in — LAN should win.**
   - Expect `resolve → LAN <mac>.local:9090 in <N>ms` (not `→ tunnel`), preceded by `challenge <addr> → VERIFIED in <N>ms`. The relay log should show a `POST /identity/challenge` — it never has before.
   - Open Terminal, spawn a shell, confirm `/shell` connects and the PTY works over the LAN address.
   - **Note the `resolve ready … in <N>ms` value.** If it routinely creeps past ~1500ms the 2s grace is too tight — that number is the whole reason the instrumentation exists.
2. **Fresh sign-in.** Sign out, sign back in with Google. `resolve start:` should report ≥1 **warm** service (pre-warm working) and the LAN should win with no visible stall.
3. **Terminal reconnect.** With the LAN verified, switch tabs / reconnect. Should stay on the LAN address.

**Fallbacks (must be fast and clean)**

4. **Relay off / Mac asleep, Wi-Fi.** Expect `resolve → tunnel: no local responder after ~2000ms` on a cold launch and a normal connect. No stall, no spinner hang.
5. **Cellular, cold launch.** Wi-Fi off. Expect the same `no local responder` line at ~2000ms. (Cold-launch cellular is *not* faster than `main` — see #196.)
6. **Cellular, warm process.** Already launched on cellular, then sign out / sign in. Expect `no local responder after ~250ms` — noticeably snappier.

**Security regressions (the point of this round)**

7. **Cross-network cache invalidation.** Connect at home over the LAN (confirm `resolve → LAN`). Background the app, move to a different Wi-Fi network (phone hotspot is fine), foreground it. Expect `browser stopping` → `cached LAN host invalidated (app backgrounded)` → `browser starting`, and the next connect must **not** reuse the old LAN address — it should either re-challenge or go to the tunnel. **Never a `resolve → LAN` for the old address without a fresh `challenge … → VERIFIED` line.**
8. **Same-network background round-trip — the round-2 regression test.** This is the one that would have caught the bug described in §5. On the LAN with `resolve → LAN` confirmed, press home, wait ~10s, foreground the app **on the same Wi-Fi**. Expect `browser stopping` → `cached LAN host invalidated (app backgrounded)` → `browser starting` → a **fresh** `challenge … → VERIFIED` and `resolve → LAN`. Then open a NEW terminal tab and confirm it dials the LAN address, not `wss://<tunnel>/shell/…`. Repeat the background round-trip 2–3 times — every one should re-verify. A `resolve → tunnel` here, or a tunnel `/shell`, means the re-resolve trigger is not firing.
9. **Re-pair invalidation.** Signed in over the LAN → Settings → unpair → sign in again. The first resolve after re-pairing must show a fresh `challenge … → VERIFIED`, never `(cached, still bound to the pinned identity)`.
10. **Pairing goes over the tunnel.** Sign out and sign back in while on the same LAN as the relay. The relay's *tunnel* access log should show `/auth/methods` and `/auth/google/client-id`, not the LAN interface. Sign-in must still succeed normally.
11. **DEBUG identity self-test.** Debug build launch — `RelayIdentityVerifier.runSelfTest()` must still pass (no assertion trap).

**Red flags**

- `browser waiting: …` on every launch → Local Network permission problem, not timing. Check Settings → Major Tom → Local Network.
- `browser failed: …` → note whether a later foreground recovers (`browser starting` again). It should now; before this round it couldn't.
- `resolve → tunnel: hit 4.0 seconds ceiling` → something local answers TCP but not the challenge.
- `resolve watchdog <name>: cancelling after 3s` appearing routinely → a responder is stalling in `.waiting`; worth investigating which.
- `skip <addr>: advertised fp … ≠ pinned` → wrong relay identity (relay identity regenerated → needs a re-pair).
- `resolve joined a pass already in flight` appearing **more than once per foreground** → the single-flight dedup is not collapsing what it should; harmless but worth a look.
- `… verified but the pass was cancelled mid-challenge` → expected only if you background the app *during* a connect. Routine appearances mean something is cancelling resolves unexpectedly.

Fixes #183

🤖 Generated with [Claude Code](https://claude.com/claude-code)

