### PR TITLE
ci: add iOS simulator build job (closes #197)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,26 +152,151 @@ jobs:
   #       run: npm run build
 
   # =============================================================================
-  # iOS — Build (requires macOS runner)
-  # NOTE: Disabled until Xcode project exists. Enable when Phase 1 starts.
+  # Changed-path detection — gates the (expensive) macOS runner
+  #
+  # macOS runners bill at 10x Linux, so relay/docs-only PRs shouldn't pay for an
+  # Xcode build. This job is Linux-cheap and decides whether build-ios runs.
+  # Uses the PR files API rather than a git diff so no checkout/fetch-depth is
+  # needed, and no third-party action is pulled in.
+  #
+  # Pushes to main always build iOS — a merge commit is new code that no PR
+  # gate ever compiled.
   # =============================================================================
-  # build-ios:
-  #   name: Build (iOS)
-  #   runs-on: macos-14
-  #   steps:
-  #     - uses: actions/checkout@v4
+  changes:
+    name: Detect Changes
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      ios: ${{ steps.filter.outputs.ios }}
+    steps:
+      - name: Detect iOS-affecting changes
+        id: filter
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          EVENT_NAME: ${{ github.event_name }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          if [[ "$EVENT_NAME" != "pull_request" ]]; then
+            echo "Event is '$EVENT_NAME' (not a PR) — building iOS unconditionally."
+            echo "ios=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          FILES=$(gh api "repos/$REPO/pulls/$PR_NUMBER/files" --paginate --jq '.[].filename')
+          echo "Changed files:"
+          echo "$FILES"
+          # ios/** is the app itself. ci.yml is included so changes to THIS job
+          # are exercised by the PR that makes them. The iOS app has no other
+          # build inputs — no SPM packages, no generated sources from relay/web.
+          if grep -qE '^(ios/|\.github/workflows/ci\.yml$)' <<<"$FILES"; then
+            echo "iOS-affecting changes detected — build-ios will run."
+            echo "ios=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "No iOS-affecting changes — build-ios will be skipped."
+            echo "ios=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  # =============================================================================
+  # iOS — Build (requires macOS runner)
   #
-  #     - name: Select Xcode
-  #       run: sudo xcode-select -s /Applications/Xcode_15.2.app
+  # Simulator-only, unsigned. Never touches certificates, provisioning profiles
+  # or the Keychain, so it does not depend on any Apple Developer account.
   #
-  #     - name: Build
-  #       run: |
-  #         xcodebuild build \
-  #           -project ios/MajorTom.xcodeproj \
-  #           -scheme MajorTom \
-  #           -destination 'platform=iOS Simulator,name=iPhone 15' \
-  #           -configuration Debug \
-  #           CODE_SIGNING_ALLOWED=NO
+  # Scheme coverage:
+  #   MajorTom      -> app + MajorTomWidgets (a target dependency AND embedded
+  #                    in the app's "Embed Foundation Extensions" phase, so the
+  #                    one scheme compiles both)
+  #   MajorTomWatch -> watchOS app. NOT a dependency of MajorTom and NOT in any
+  #                    embed phase, so it only builds via its own scheme.
+  #
+  # No caching: the project has zero SPM/CocoaPods dependencies, and DerivedData
+  # restore/save for a ~2 min build costs more than it saves.
+  # =============================================================================
+  build-ios:
+    name: Build (iOS)
+    runs-on: macos-latest
+    needs: [changes]
+    if: needs.changes.outputs.ios == 'true'
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Select Xcode
+        # Pinned rather than tracking the runner image default (26.6), so CI
+        # compiles with the same toolchain as local dev. If a future image drops
+        # this version, the `ls` output names what is available.
+        run: |
+          set -euo pipefail
+          ls -d /Applications/Xcode*.app
+          sudo xcode-select -s /Applications/Xcode_26.5.app
+          xcodebuild -version
+
+      - name: Stage Secrets.swift from template
+        # ios/MajorTom/Core/Services/Secrets.swift is gitignored (it holds the
+        # real Cloudflare tunnel host + Tailscale address), so a fresh checkout
+        # doesn't have it and the build would fail to compile. The committed
+        # .example declares the same members with placeholder values, which is
+        # all a compile needs — this job never dials the relay.
+        #
+        # This also makes the template self-enforcing: add a field to the real
+        # Secrets.swift, reference it from app code, and forget to add it to the
+        # .example, and this job goes red on the PR that introduced the drift.
+        run: |
+          set -euo pipefail
+          SRC=ios/MajorTom/Core/Services/Secrets.swift.example
+          DST=ios/MajorTom/Core/Services/Secrets.swift
+          if [[ ! -f "$SRC" ]]; then
+            echo "::error file=$SRC::Missing Secrets template — iOS cannot be built in CI without it"
+            exit 1
+          fi
+          cp "$SRC" "$DST"
+          echo "Staged $DST from template (placeholder values only):"
+          cat "$DST"
+
+      - name: Build MajorTom (app + widgets, iOS Simulator)
+        run: |
+          set -euo pipefail
+          xcodebuild build \
+            -project ios/MajorTom.xcodeproj \
+            -scheme MajorTom \
+            -configuration Debug \
+            -destination 'generic/platform=iOS Simulator' \
+            -derivedDataPath "$RUNNER_TEMP/DerivedData" \
+            -quiet \
+            CODE_SIGNING_ALLOWED=NO \
+            CODE_SIGNING_REQUIRED=NO
+
+      - name: Build MajorTomWatch (watchOS Simulator)
+        run: |
+          set -euo pipefail
+          xcodebuild build \
+            -project ios/MajorTom.xcodeproj \
+            -scheme MajorTomWatch \
+            -configuration Debug \
+            -destination 'generic/platform=watchOS Simulator' \
+            -derivedDataPath "$RUNNER_TEMP/DerivedData" \
+            -quiet \
+            CODE_SIGNING_ALLOWED=NO \
+            CODE_SIGNING_REQUIRED=NO
+
+      - name: Verify build products
+        # A zero exit code proves xcodebuild ran, not that it produced anything.
+        # #197 was exactly this failure mode. Assert the products exist.
+        run: |
+          set -euo pipefail
+          APP="$RUNNER_TEMP/DerivedData/Build/Products/Debug-iphonesimulator/Major Tom.app"
+          WATCH_APP="$RUNNER_TEMP/DerivedData/Build/Products/Debug-watchsimulator/MajorTomWatch.app"
+          for product in "$APP/Major Tom" "$APP/PlugIns/MajorTomWidgets.appex" "$WATCH_APP/MajorTomWatch"; do
+            if [[ ! -e "$product" ]]; then
+              echo "::error::Expected build product missing: $product"
+              exit 1
+            fi
+            echo "OK: $product"
+          done
 
   # =============================================================================
   # Auto-Label PRs on CI Results
@@ -321,16 +446,31 @@ jobs:
   ci-success:
     name: CI Success
     runs-on: ubuntu-latest
-    needs: [lint-relay, typecheck-relay, test-relay, build-relay]
+    needs: [lint-relay, typecheck-relay, test-relay, build-relay, changes, build-ios]
     if: always()
     steps:
       - name: Check all jobs passed
+        env:
+          LINT_RELAY: ${{ needs.lint-relay.result }}
+          TYPECHECK_RELAY: ${{ needs.typecheck-relay.result }}
+          TEST_RELAY: ${{ needs.test-relay.result }}
+          BUILD_RELAY: ${{ needs.build-relay.result }}
+          CHANGES: ${{ needs.changes.result }}
+          BUILD_IOS: ${{ needs.build-ios.result }}
         run: |
-          if [[ "${{ needs.lint-relay.result }}" != "success" ]] || \
-             [[ "${{ needs.typecheck-relay.result }}" != "success" ]] || \
-             [[ "${{ needs.test-relay.result }}" != "success" ]] || \
-             [[ "${{ needs.build-relay.result }}" != "success" ]]; then
+          if [[ "$LINT_RELAY" != "success" ]] || \
+             [[ "$TYPECHECK_RELAY" != "success" ]] || \
+             [[ "$TEST_RELAY" != "success" ]] || \
+             [[ "$BUILD_RELAY" != "success" ]] || \
+             [[ "$CHANGES" != "success" ]]; then
             echo "One or more jobs failed"
             exit 1
           fi
-          echo "All CI checks passed!"
+          # build-ios is path-gated, so 'skipped' is a legitimate pass. The
+          # 'changes' check above closes the hole where a broken detector would
+          # silently skip the iOS gate.
+          if [[ "$BUILD_IOS" != "success" ]] && [[ "$BUILD_IOS" != "skipped" ]]; then
+            echo "iOS build failed (result: $BUILD_IOS)"
+            exit 1
+          fi
+          echo "All CI checks passed! (iOS: $BUILD_IOS)"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,8 @@ jobs:
   lint-relay:
     name: Lint (Relay)
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     defaults:
       run:
         working-directory: relay
@@ -46,6 +48,8 @@ jobs:
   typecheck-relay:
     name: Typecheck (Relay)
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     defaults:
       run:
         working-directory: relay
@@ -72,6 +76,8 @@ jobs:
     name: Test (Relay)
     runs-on: ubuntu-latest
     needs: [lint-relay, typecheck-relay]
+    permissions:
+      contents: read
     defaults:
       run:
         working-directory: relay
@@ -100,6 +106,8 @@ jobs:
     name: Build (Relay)
     runs-on: ubuntu-latest
     needs: [lint-relay, typecheck-relay]
+    permissions:
+      contents: read
     defaults:
       run:
         working-directory: relay
@@ -185,8 +193,24 @@ jobs:
             echo "ios=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          FILES=$(gh api "repos/$REPO/pulls/$PR_NUMBER/files" --paginate --jq '.[].filename')
-          echo "Changed files:"
+          # The PR files API is hard-capped at 3000 entries — `--paginate` does
+          # NOT lift it. Past that the list is silently truncated, so a large PR
+          # could hide its ios/ entries and skip the gate. Read the true count
+          # off the PR object and fail OPEN (build iOS) at the cap.
+          CHANGED_COUNT=$(gh api "repos/$REPO/pulls/$PR_NUMBER" --jq '.changed_files')
+          echo "PR reports $CHANGED_COUNT changed files."
+          if (( CHANGED_COUNT >= 3000 )); then
+            echo "At/over the 3000-file API cap — the file list may be truncated."
+            echo "Failing open: build-ios will run."
+            echo "ios=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          # `previous_filename` matters: a rename OUT of ios/ reports only the
+          # new path, so matching on .filename alone would miss a PR that moves
+          # the app (ios/ -> apps/ios/) and leaves the -project path below stale.
+          FILES=$(gh api "repos/$REPO/pulls/$PR_NUMBER/files" --paginate \
+            --jq '.[] | .filename, (.previous_filename // empty)')
+          echo "Changed files (including pre-rename paths):"
           echo "$FILES"
           # ios/** is the app itself. ci.yml is included so changes to THIS job
           # are exercised by the PR that makes them. The iOS app has no other
@@ -217,9 +241,17 @@ jobs:
   # =============================================================================
   build-ios:
     name: Build (iOS)
-    runs-on: macos-latest
+    # Pinned to the image, not the `macos-latest` alias. The alias resolves to
+    # macos-26-arm64 today; when GitHub rolls it forward to an image that no
+    # longer ships Xcode 26.5, `xcode-select -s` below exits 1 and every
+    # iOS-touching PR goes red on GitHub's schedule rather than ours. Pinning
+    # the image keeps the runner and the toolchain moving together.
+    runs-on: macos-26
     needs: [changes]
     if: needs.changes.outputs.ios == 'true'
+    # Measured job time is ~2 min. The 360-minute default would let a wedged
+    # xcodebuild/CoreSimulator hang for six hours with ci-success pending on it.
+    timeout-minutes: 30
     permissions:
       contents: read
     steps:
@@ -304,7 +336,13 @@ jobs:
   label-pr:
     name: Label PR
     runs-on: ubuntu-latest
-    needs: [lint-relay, typecheck-relay, test-relay, build-relay]
+    # `changes` + `build-ios` are in this list on purpose. Without them the job
+    # ran to completion before the (much slower) macOS build finished and wrote
+    # `CI Pass` on a PR whose iOS result did not exist yet — observed on this
+    # PR's own first run: Label PR completed 23:28:00, Build (iOS) 23:28:47.
+    # `main` has no branch protection, so the label IS the merge signal.
+    needs:
+      [lint-relay, typecheck-relay, test-relay, build-relay, changes, build-ios]
     if: always() && github.event_name == 'pull_request'
     steps:
       - name: Add Lint Failure label
@@ -382,8 +420,11 @@ jobs:
               name: 'Test Failure'
             });
 
+      # Covers both build jobs — an iOS compile failure is a build failure.
       - name: Add Build Failure label
-        if: needs.build-relay.result == 'failure'
+        if: |
+          needs.build-relay.result == 'failure' ||
+          needs.build-ios.result == 'failure'
         uses: actions/github-script@v7
         with:
           script: |
@@ -394,8 +435,12 @@ jobs:
               labels: ['Build Failure']
             });
 
+      # 'skipped' is a legitimate build-ios state (path-gated), so tolerate it.
       - name: Remove Build Failure label on success
-        if: needs.build-relay.result == 'success'
+        if: |
+          needs.build-relay.result == 'success' &&
+          (needs.build-ios.result == 'success' ||
+           needs.build-ios.result == 'skipped')
         uses: actions/github-script@v7
         continue-on-error: true
         with:
@@ -407,12 +452,19 @@ jobs:
               name: 'Build Failure'
             });
 
+      # Must stay logically identical to the ci-success gate below: every job
+      # green, `changes` green, and build-ios either green or legitimately
+      # skipped (skipped is only legitimate when the detector said ios=false).
       - name: Add CI Pass label
         if: |
           needs.lint-relay.result == 'success' &&
           needs.typecheck-relay.result == 'success' &&
           needs.test-relay.result == 'success' &&
-          needs.build-relay.result == 'success'
+          needs.build-relay.result == 'success' &&
+          needs.changes.result == 'success' &&
+          (needs.build-ios.result == 'success' ||
+            (needs.build-ios.result == 'skipped' &&
+             needs.changes.outputs.ios != 'true'))
         uses: actions/github-script@v7
         with:
           script: |
@@ -423,12 +475,19 @@ jobs:
               labels: ['CI Pass']
             });
 
+      # Exact negation of the add condition — written as `!(...)` so the two can
+      # never drift apart, and so non-'failure' bad states (cancelled, or an
+      # illegitimate skip) also strip a stale label instead of leaving it.
       - name: Remove CI Pass label on failure
         if: |
-          needs.lint-relay.result == 'failure' ||
-          needs.typecheck-relay.result == 'failure' ||
-          needs.test-relay.result == 'failure' ||
-          needs.build-relay.result == 'failure'
+          !(needs.lint-relay.result == 'success' &&
+            needs.typecheck-relay.result == 'success' &&
+            needs.test-relay.result == 'success' &&
+            needs.build-relay.result == 'success' &&
+            needs.changes.result == 'success' &&
+            (needs.build-ios.result == 'success' ||
+              (needs.build-ios.result == 'skipped' &&
+               needs.changes.outputs.ios != 'true')))
         uses: actions/github-script@v7
         continue-on-error: true
         with:
@@ -446,8 +505,11 @@ jobs:
   ci-success:
     name: CI Success
     runs-on: ubuntu-latest
-    needs: [lint-relay, typecheck-relay, test-relay, build-relay, changes, build-ios]
+    needs:
+      [lint-relay, typecheck-relay, test-relay, build-relay, changes, build-ios]
     if: always()
+    permissions:
+      contents: read
     steps:
       - name: Check all jobs passed
         env:
@@ -457,6 +519,7 @@ jobs:
           BUILD_RELAY: ${{ needs.build-relay.result }}
           CHANGES: ${{ needs.changes.result }}
           BUILD_IOS: ${{ needs.build-ios.result }}
+          IOS_CHANGED: ${{ needs.changes.outputs.ios }}
         run: |
           if [[ "$LINT_RELAY" != "success" ]] || \
              [[ "$TYPECHECK_RELAY" != "success" ]] || \
@@ -473,4 +536,12 @@ jobs:
             echo "iOS build failed (result: $BUILD_IOS)"
             exit 1
           fi
-          echo "All CI checks passed! (iOS: $BUILD_IOS)"
+          # ...and this closes the other half: a skip is only legitimate when
+          # the detector actually said ios=false. If build-ios's `if:` is ever
+          # edited so it skips while ios=true, the iOS gate would silently stop
+          # existing and every PR after that would still print "passed".
+          if [[ "$BUILD_IOS" == "skipped" ]] && [[ "$IOS_CHANGED" == "true" ]]; then
+            echo "::error::build-ios was skipped but the change detector reported iOS-affecting changes (ios=$IOS_CHANGED). The iOS gate is broken."
+            exit 1
+          fi
+          echo "All CI checks passed! (iOS: $BUILD_IOS, ios-changed: $IOS_CHANGED)"

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -48,7 +48,14 @@ jobs:
   preflight:
     name: Preflight (skip drafts/forks)
     runs-on: ubuntu-latest
+    # DORMANT — see the gate comment in claude.yml. This is the workflow that
+    # actually auto-fired on `pull_request: opened` and put four permanently-red
+    # checks on every PR. The specialist jobs below carry the same gate rather
+    # than relying on skip-propagation through `needs:`, because each has its
+    # own `if:` and a job with an explicit `if:` is not reliably skipped by a
+    # skipped dependency.
     if: |
+      vars.CLAUDE_REVIEWS_ENABLED == 'true' &&
       github.repository == 'seantokuzo/major-tom' &&
       (github.event_name == 'workflow_dispatch' ||
        github.event.pull_request.draft != true)
@@ -80,8 +87,9 @@ jobs:
     needs: preflight
     name: 🔒 Security specialist
     if: |
-      needs.preflight.outputs.specialists == 'all' ||
-      contains(needs.preflight.outputs.specialists, 'security')
+      vars.CLAUDE_REVIEWS_ENABLED == 'true' &&
+      (needs.preflight.outputs.specialists == 'all' ||
+       contains(needs.preflight.outputs.specialists, 'security'))
     runs-on: ubuntu-latest
     timeout-minutes: 25
     permissions:
@@ -185,8 +193,9 @@ jobs:
     needs: preflight
     name: 🏗️ Architecture specialist
     if: |
-      needs.preflight.outputs.specialists == 'all' ||
-      contains(needs.preflight.outputs.specialists, 'architecture')
+      vars.CLAUDE_REVIEWS_ENABLED == 'true' &&
+      (needs.preflight.outputs.specialists == 'all' ||
+       contains(needs.preflight.outputs.specialists, 'architecture'))
     runs-on: ubuntu-latest
     timeout-minutes: 25
     permissions:
@@ -295,8 +304,9 @@ jobs:
     needs: preflight
     name: ✅ Correctness specialist
     if: |
-      needs.preflight.outputs.specialists == 'all' ||
-      contains(needs.preflight.outputs.specialists, 'correctness')
+      vars.CLAUDE_REVIEWS_ENABLED == 'true' &&
+      (needs.preflight.outputs.specialists == 'all' ||
+       contains(needs.preflight.outputs.specialists, 'correctness'))
     runs-on: ubuntu-latest
     timeout-minutes: 25
     permissions:

--- a/.github/workflows/claude-deep-review.yml
+++ b/.github/workflows/claude-deep-review.yml
@@ -29,7 +29,11 @@ jobs:
   preflight:
     name: Preflight
     runs-on: ubuntu-latest
+    # DORMANT — see the gate comment in claude.yml. Every downstream job here
+    # is `needs: preflight` with no independent `if:`, so gating preflight
+    # skips the whole graph cleanly.
     if: |
+      vars.CLAUDE_REVIEWS_ENABLED == 'true' &&
       github.repository == 'seantokuzo/major-tom' &&
       (github.event_name == 'workflow_dispatch' ||
        (github.event_name == 'pull_request' &&

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -36,7 +36,13 @@ jobs:
     name: Claude
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    # DORMANT: the Claude GitHub App is not installed on this repo, so
+    # claude-code-action fails at token exchange with
+    # "401 - Claude Code is not installed on this repository".
+    # Gated off so a stray mention no-ops (skipped) instead of going red.
+    # Re-enable by setting repo variable CLAUDE_REVIEWS_ENABLED=true.
     if: |
+      vars.CLAUDE_REVIEWS_ENABLED == 'true' &&
       github.repository == 'seantokuzo/major-tom' &&
       (
         github.event_name == 'workflow_dispatch' ||

--- a/ios/MajorTom/Core/Services/FeatureFlags.swift
+++ b/ios/MajorTom/Core/Services/FeatureFlags.swift
@@ -12,10 +12,3 @@ import Foundation
 enum FeatureFlags {
     // No active flags.
 }
-
-// TEMPORARY — deliberate compile error to prove the CI iOS gate can go RED.
-// This commit is reverted immediately after the red run is observed.
-// See PR #202.
-enum RedPathProof {
-    static let deliberatelyBroken: Int = "this is not an Int"
-}

--- a/ios/MajorTom/Core/Services/FeatureFlags.swift
+++ b/ios/MajorTom/Core/Services/FeatureFlags.swift
@@ -12,3 +12,10 @@ import Foundation
 enum FeatureFlags {
     // No active flags.
 }
+
+// TEMPORARY — deliberate compile error to prove the CI iOS gate can go RED.
+// This commit is reverted immediately after the red run is observed.
+// See PR #202.
+enum RedPathProof {
+    static let deliberatelyBroken: Int = "this is not an Int"
+}

--- a/ios/MajorTom/Core/Services/Secrets.swift.example
+++ b/ios/MajorTom/Core/Services/Secrets.swift.example
@@ -2,6 +2,11 @@ import Foundation
 
 /// Copy this file to `Secrets.swift` and fill in your relay's URLs.
 /// `Secrets.swift` is gitignored so your real URLs never reach GitHub.
+///
+/// KEEP THIS IN SYNC with your local `Secrets.swift`. CI has no `Secrets.swift`,
+/// so `.github/workflows/ci.yml` copies THIS file over it before building iOS.
+/// Add a member to `Secrets.swift`, reference it from app code, and forget to
+/// add it here, and the `Build (iOS)` job goes red on that PR.
 enum Secrets {
     /// Public Cloudflare tunnel hostname for off-LAN access.
     static let tunnelURL = "your-tunnel.example.com"


### PR DESCRIPTION
Closes #197

CI covered relay only — nothing compiled the iOS app, the widget extension, or the watch target. The `build-ios` job in `ci.yml` had been commented out since Phase 0 with the note *"Disabled until Xcode project exists"*; the Xcode project has existed for months.

The concrete cost, from #197: on PR #185 an agent reported a green `build_sim`, but that build had compiled **a different worktree's copy of `main`** — its DerivedData `WorkspacePath` pointed elsewhere and the built `terminal.html` still held the pre-fix code. Nothing caught it. The PR could have merged on a green build of code it did not contain.

---

## The Secrets problem, and the decision

`ios/MajorTom/Core/Services/Secrets.swift` is gitignored (`.gitignore:22`) — it holds the real Cloudflare tunnel host and Tailscale address. It is an explicit `PBXFileReference` in the pbxproj, so a fresh CI checkout doesn't just miss a value, it fails to compile.

**Chosen: CI copies `Secrets.swift.example` → `Secrets.swift` before building.**

Verified rather than assumed. Every `Secrets.` reference in the iOS tree:

| Reference | Member | Used as |
|---|---|---|
| `Core/Services/AuthService.swift:28` | `tunnelURL` | `var serverURL: String = …` |
| `Features/Pairing/ViewModels/PairingViewModel.swift:17` | `tunnelURL` | `String` return |
| `Features/Pairing/ViewModels/PairingViewModel.swift:18` | `tailscaleAddress` | `String` return |
| `Features/Pairing/ViewModels/PairingViewModel.swift:102` | `tunnelURL` | `String` return |

Four references, two members, both plain `static let` `String` constants. The `.example` declares exactly those two with the same names and types. Nothing force-unwraps them, nothing parses them into a `URL` at type-init, and no member is validated at compile time — so placeholder values compile identically to real ones. **The build never dials the relay**, so a placeholder host is not just acceptable, it's correct.

**Why not GitHub Actions secrets (option 2):** it would move the private tunnel hostname and Tailscale IP into repo secrets — a real increase in exposure surface on a **public** repo, where anyone who can land a workflow change can exfiltrate a secret — in exchange for zero compile benefit. Faithfulness to production values buys nothing when the job only type-checks and links.

**Why not refactor to non-compile-time values (option 3):** out of scope, and it would push a build-time guarantee into runtime for no gain.

### Drift enforcement

This is enforced **by construction**, not by convention. CI compiles against `Secrets.swift.example`. Add a member to the real `Secrets.swift`, reference it from app code, and forget to add it to the example → `Build (iOS)` fails on the PR that introduced the drift, with a plain `type 'Secrets' has no member 'x'` error. The drift can't reach `main`.

The example file's header comment now says this explicitly, so the next person to add a field is told before they hit it. No separate lint rule needed — the build *is* the check.

---

## Targets covered

Investigated the pbxproj rather than trusting the scheme names:

| Target | Covered by | How |
|---|---|---|
| `MajorTom` | `MajorTom` scheme | directly |
| `MajorTomWidgets` | `MajorTom` scheme | it's a `PBXTargetDependency` of `MajorTom` **and** in its `Embed Foundation Extensions` phase — one invocation compiles both |
| `MajorTomWatch` | its own scheme | `SDKROOT = watchos`, no `dependencies`, not in any embed phase. It genuinely only builds via `-scheme MajorTomWatch` against a watchOS simulator destination. |

Both builds run as **steps in one job**, not two jobs — the macOS runner spins up, checks out, and selects Xcode once. Two jobs would double the fixed overhead for one extra small target.

There are no shared schemes on disk (`xcshareddata/xcschemes/` doesn't exist; only `xcschememanagement.plist` is tracked). Confirmed `xcodebuild` synthesizes all three schemes from the pbxproj without writing anything — `xcodebuild -list` on a checkout with no `.xcscheme` files lists `MajorTom`, `MajorTomWatch`, `MajorTomWidgets` and leaves the tree clean. So `-scheme` works on a fresh CI checkout with no extra setup.

---

## Runner cost and duration

`macos-latest` currently resolves to **macOS 26 arm64**. **This repo is public, so standard GitHub-hosted runners — macOS included — are free.** The direct cost of this job is **$0**.

Stating the number anyway in case the repo ever goes private: macOS arm64 standard runners bill at **10x** Linux ($0.08/min vs $0.008/min). At an estimated 5–8 min/run that's **~$0.40–0.65 per run**.

Duration: the full clean `MajorTom` build takes **1m29s–1m37s locally** (M-series, cold DerivedData, both `arm64` and `x86_64` simulator slices). GitHub's 3-core standard runner is slower; expect **~4–7 min** for checkout + Xcode select + both builds. Actual measured CI time is in the comment below.

Worth knowing where the time goes: the build is dominated by asset catalog compilation, not Swift. `Assets.car` is **31 MB**. I tested `ONLY_ACTIVE_ARCH=YES` to drop the x86_64 slice — it saved 8 seconds (1m37 → 1m29) and didn't actually restrict the archs, so it's not in the workflow.

### Path gating — recommendation, and what I did

**Recommendation: gate it. Implemented, and it's a two-line removal if you disagree.**

A `changes` job (ubuntu, seconds) reads the PR's changed files via the GitHub API and sets `ios=true|false`; `build-ios` runs only when true. Relay-only and docs-only PRs cost **zero macOS minutes** and finish faster.

The gate is `ios/**` plus `.github/workflows/ci.yml`. That's exhaustive for this project — the iOS app has **no SPM packages, no CocoaPods, and no generated sources from relay or web** (verified: zero `XCRemoteSwiftPackageReference` entries in the pbxproj, no `Package.swift` / `Package.resolved` anywhere in `ios/`). There is no iOS-affecting change that lands outside those paths. Including `ci.yml` means any future edit to this job is exercised by the PR making it — including this one.

Pushes to `main` always build iOS regardless of paths, since a merge commit is new code that no PR gate ever compiled.

Deliberate design choice: the API-based detector is used instead of a workflow-level `paths:` filter (which can't gate a single job) and instead of `dorny/paths-filter` (a third-party action, and this repo's review priorities require SHA-pinning any such dependency — not worth the supply-chain surface for ten lines of `gh api`). It needs no checkout and no `fetch-depth: 0`, which matters given the repo's 31 MB of assets.

### Caching — deliberately none

No SPM or CocoaPods dependencies exist, so there is nothing to cache there. DerivedData caching was considered and rejected: the cache would be multi-GB, Xcode invalidates it on toolchain or path changes, and restore+save would plausibly cost more wall-clock than the ~2 min build it's meant to shorten. Adding it would be complexity for a likely negative return.

---

## Signing and toolchain

- Simulator destinations only (`generic/platform=iOS Simulator`, `generic/platform=watchOS Simulator`), with `CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO`. **Never touches certificates, provisioning profiles, or the Keychain.** Does not depend on Sean's Apple account — relevant given the free-team certs that rotate every 7 days.
- Xcode pinned via `sudo xcode-select -s /Applications/Xcode_26.5.app`. **No third-party action**, so nothing to SHA-pin. 26.5 is on the `macos-26-arm64` image and is the exact build (17F42) used locally, so CI and local dev compile with the same toolchain rather than drifting onto the image default (26.6). The step `ls -d /Applications/Xcode*.app` first, so if a future image drops 26.5 the failure names what's actually available instead of just erroring.
- Job-level `permissions:` narrowed per job — `changes` gets `pull-requests: read`, `build-ios` gets `contents: read` only.
- The `ci-success` `run:` block was converted from `${{ }}` interpolation directly into shell to `env:` variables — same pattern the new jobs use, and the repo's standing Actions-safety priority.

---

## Local verification evidence

Run from this branch's worktree, with `Secrets.swift` staged from the example exactly as CI does, into a dedicated `-derivedDataPath`.

**1. Build succeeds**

```
xcodebuild build -project <worktree>/ios/MajorTom.xcodeproj -scheme MajorTom \
  -configuration Debug -destination 'generic/platform=iOS Simulator' \
  -derivedDataPath <worktree>/.build/ci-final -quiet \
  CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO
```

`** BUILD SUCCEEDED **`, exit 0, `grep -c "error:"` over the full log → **0**. (Note for future readers: `-quiet` suppresses the `** BUILD SUCCEEDED **` banner; the exit code and the product assertion are the real signal, which is why the workflow has an explicit verify step.)

**2. The product contains *this* worktree's code — the #197 check**

- Provenance: **370** `.d` dependency files record source paths inside this worktree. **0** point at any other checkout (`grep -rl "major-tom/ios/MajorTom" --include="*.d"` → 0).
- Inclusion: `strings 'Major Tom.app/Major Tom.debug.dylib'` contains `your-tunnel.example.com` **1** time and `seantokuzodevtunnel` **0** times — proving the staged template is what actually compiled in, not a stale artifact or a leaked real secret. (Grepped the dylib, not the 73 KB `Major Tom` stub.)

**3. Products exist**

```
Major Tom.app/Major Tom                                 73,112 bytes
Major Tom.app/PlugIns/MajorTomWidgets.appex/            (MajorTomWidgets + .debug.dylib)
```

The `.appex` is independent confirmation that the widget extension really does build under the `MajorTom` scheme.

**4. YAML**

`actionlint 1.7.12` → clean, no findings.

---

## Explicitly out of scope

- **The watch build is verified on CI, not locally.** This Mac has the `watchsimulator26.5` SDK stub but not the watchOS 26.5 platform installed, so `xcodebuild` rejects every watchOS destination locally (`watchOS 26.5 is not installed`). The runner image does have it. This is the one step whose first real execution is the CI run on this PR — see the status comment below.
- ~~**`label-pr` not touched.**~~ **Struck in review round 1 — this was the blocking defect.** Leaving `label-pr` relay-scoped meant it wrote a green `CI Pass` before the iOS result existed. Fixed in `6a93502`; see the review round section below.
- **No tests run** — only compilation. There is no iOS test target in the project, so `xcodebuild test` has nothing to execute. This job answers "does it build", which is precisely the gap #197 identified.
- **`vscode-extension` job left commented out** — still unscaffolded, unrelated to this issue.
- **Warnings not gated.** The build emits Swift 6 `Sendable` warnings (e.g. `NotificationService.swift:313`). Turning those into errors is a real cleanup task, but failing CI on them today would block every PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

# Review round 1 — dispositions

Two independent specialists (security, correctness) both returned `fix-then-ship` and independently found the same blocking defect. All nine `fix-now` items applied across three commits.

| # | Finding | Disposition | Commit |
|---|---|---|---|
| 1 | **BLOCKING** — `label-pr` emits green `CI Pass` for a red iOS build | fixed | `6a93502` |
| 2 | `ci-success` accepts `build-ios == skipped` without cross-checking `changes.outputs.ios` | fixed | `6a93502` |
| 3 | PR files API caps at 3000 entries — truncation failed OPEN into a false `ios=false` | fixed | `6a93502` |
| 4 | Renames out of `ios/` skipped the gate (`previous_filename` dropped) | fixed | `6a93502` |
| 5 | Floating `macos-latest` + hard-pinned Xcode 26.5 | fixed | `6a93502` |
| 6 | No `timeout-minutes` on `build-ios` (360-minute default) | fixed | `6a93502` |
| 7 | Five jobs inherited `pull-requests: write` they don't need | fixed | `6a93502` |
| 8 | Dormant `claude-*.yml` workflows auto-failing on every PR | fixed | `2133268` |
| 9 | Stray committed gitlinks under `.claude/worktrees/` | fixed | `e0d7e90` |
| D1 | Action SHA-pinning policy | deferred | #203 |
| D2 | Real Tailscale address in two committed docs | deferred | #204 |
| D3 | `claude-code-review.yml` preflight doesn't actually skip forks | deferred | #205 |

## The blocking defect

`ci-success` gained `changes` + `build-ios` in its `needs`; `label-pr` did not. Its `needs` stayed relay-only, so it ran to completion before the (much slower) macOS job and wrote `CI Pass` on a PR whose iOS result did not yet exist.

Confirmed on this PR's own first run (`c66c37c`, run 30723340784):

```
Label PR     completed 23:28:00
Build (iOS)  completed 23:28:47   <-- 47s AFTER the label was written
```

This is not cosmetic. `main` has **no branch protection** — `GET /repos/seantokuzo/major-tom/branches/main/protection` returns 404 and the sole ruleset is `enforcement: disabled` — so the label and the checks list *are* the merge gate for the autonomous loop, and the label is the first field of `gh pr view`. A PR whose thesis is "a gate that manufactures false confidence is worse than no gate" cannot leave a false-green label behind it.

`label-pr` now `needs` all six jobs. `CI Pass` mirrors the `ci-success` gate exactly, and the removal condition is written as `!(add condition)` so the two can never drift and so cancelled / illegitimately-skipped states strip a stale label instead of leaving it.

**The out-of-scope note in the original body — "`label-pr` not touched" — was wrong and has been struck.** The stated reason (skipped `build-ios` would confuse `== 'success'` conditions) was a solvable problem, not a reason to leave the merge signal lying.

---

# CI evidence — the gate works, and it can go red

## Green path — run [30724261200](https://github.com/seantokuzo/major-tom/actions/runs/30724261200) (`e0d7e90`) → **success**

```
Detect Changes  success   23:55:39 -> 23:55:44
Build (iOS)     success   23:55:46 -> 23:57:28
Label PR        success   23:57:32 -> 23:57:37   <-- now STARTS after iOS ends
CI Success      success   23:57:37 -> 23:57:39
```

- `runs-on: macos-26` resolved to image `macos-26-arm64`; `Xcode 26.5 / Build version 17F42` selected. **The pinned label is valid** — also confirmed against `actions/runner-images` and actionlint's known-label set (actionlint *does* validate runner labels; a bogus `macos-99-bogus` is rejected, `macos-26` is not).
- All three build products verified present, including `MajorTomWidgets.appex` and the watch app.
- New detector output: `PR reports 7 changed files.` → `iOS-affecting changes detected`.
- New cross-check output: `All CI checks passed! (iOS: success, ios-changed: true)`.
- **Submodule warnings: 5 → 0.** The old run logged `fatal: No url found for submodule path …` five times; this run logs zero.

## Dormant-workflow gate — run [30724359526](https://github.com/seantokuzo/major-tom/actions/runs/30724359526) → **skipped**

Exercised the real auto-fire path (`gh pr ready --undo` then `gh pr ready`, firing `pull_request: ready_for_review`), not just a dispatch:

| Check | Before (`c66c37c`) | After |
|---|---|---|
| 🔒 Security specialist | **FAILURE** | SKIPPED |
| 🏗️ Architecture specialist | **FAILURE** | SKIPPED |
| ✅ Correctness specialist | **FAILURE** | SKIPPED |
| 📋 Verdict synthesizer | **FAILURE** | SKIPPED |
| Preflight | SUCCESS | SKIPPED |

Four permanently-red checks are gone. Re-enable with one repo variable: `CLAUDE_REVIEWS_ENABLED=true`.

## Red path — run [30724388135](https://github.com/seantokuzo/major-tom/actions/runs/30724388135) (`873c587`) → **failure**

A throwaway commit added `static let deliberatelyBroken: Int = "this is not an Int"` to `FeatureFlags.swift`, then was reverted in `82d0f31`.

```
Build (iOS)  FAILURE  00:00:04 -> 00:01:15
  FeatureFlags.swift:20:42: error: cannot convert value of type 'String'
                                   to specified type 'Int'
Label PR     success  00:01:19 -> 00:01:25   <-- started AFTER iOS failed
CI Success   FAILURE  00:01:18 -> 00:01:21
  "iOS build failed (result: failure)"
```

PR labels during that run: **`CI Pass` removed, `Build Failure` applied.** That is the whole point of #197 — the gate fails closed, on the label as well as on the check.

---

## What was NOT changed, and why

- **Action SHA pinning** — deferred to #203, not skipped out of laziness. Pinning the one new line while `actions/checkout@v4` ×5, `actions/setup-node@v4` ×4 and `actions/github-script@v7` ×10 keep floating is theater. #203 presents the policy choice and flags the actually-dangerous target: `anthropics/claude-code-action@v1`, a third-party action on a mutable major tag across 8 call sites, each holding `id-token: write` + `pull-requests: write` + `issues: write` + a secret.

## Pushback — one review claim was factually wrong

> "`claude.yml`, `claude-code-review.yml`, `claude-deep-review.yml` still fire on `pull_request: opened`"

Only **`claude-code-review.yml`** does (`.github/workflows/claude-code-review.yml:22-23`). `claude.yml:9-17` triggers on `issue_comment` / `pull_request_review_comment` / `pull_request_review` / `issues` / `workflow_dispatch` — never on PR open. `claude-deep-review.yml:13-14` triggers on `pull_request: [labeled]`, gated at `:32` to `github.event.label.name == 'claude-deep-review'`. The check rollup on `c66c37c` bears this out: every red check came from **"Claude Auto Review"** only.

The *conclusion* stood, so all three were gated anyway — a stray `@claude` mention or a stray label should also no-op rather than go red. Only the attribution was corrected.

One implementation note the finding didn't cover: the gate is applied to `preflight` **and** to each of the three specialists in `claude-code-review.yml`, not to `preflight` alone. Those three carry their own `if:`, and a job with an explicit `if:` is not reliably skipped by a skipped dependency. `claude-deep-review.yml`'s specialists have no `if:`, so gating its `preflight` skips that graph on its own.

`actionlint 1.7.12` on `ci.yml`: clean.
